### PR TITLE
Add nudge claude run command to wrap Claude Code CLI

### DIFF
--- a/docs/claude-run-plan.md
+++ b/docs/claude-run-plan.md
@@ -1,0 +1,193 @@
+# Implementation Plan: `nudge claude run`
+
+## Overview
+
+A subcommand that wraps the Claude Code CLI, allowing Nudge to control the interaction between the user and Claude. This enables features that aren't possible with hooks alone:
+
+- Running the agent in a loop (agentic mode)
+- Session resuming across instances
+- Session teleporting between users and machines
+- Rewindable sessions that couple conversation state with code state
+- Providing a working terminal frontend for users whose terminals don't work with Claude's built-in UI
+
+## Status
+
+**Phase 1 (MVP) is complete.** The basic subprocess wrapper works:
+
+```bash
+nudge claude run                           # Interactive prompt
+nudge claude run "your prompt here"        # With initial prompt
+nudge claude run -c                        # Continue most recent session
+nudge claude run -r <session_id>           # Resume specific session
+nudge claude run -v                        # Verbose (show tool I/O)
+nudge claude run --max-turns 50            # Limit agentic turns
+nudge claude run --model sonnet            # Specify model
+```
+
+## How Claude Code's JSON API Works
+
+### Command-Line Flags
+
+```bash
+claude -p \
+  --output-format stream-json \
+  --input-format stream-json \
+  --verbose
+```
+
+- `-p` / `--print`: Non-interactive mode (required for JSON I/O)
+- `--output-format stream-json`: Emit NDJSON on stdout
+- `--input-format stream-json`: Accept NDJSON messages on stdin (prompt sent via stdin, not as argument)
+- `--verbose`: Required with stream-json output
+- `--continue` / `-c`: Resume most recent conversation
+- `--resume <session_id>`: Resume specific session by ID
+
+### Output Message Types (NDJSON on stdout)
+
+```jsonl
+{"type":"system","subtype":"init","session_id":"...","cwd":"...","model":"...","tools":[...]}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"..."}],"stop_reason":null}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"...","content":"..."}]}}
+{"type":"result","subtype":"success","session_id":"...","duration_ms":1234,"total_cost_usd":0.05}
+```
+
+### Input Message Format (NDJSON on stdin)
+
+```json
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"your message"}]}}
+```
+
+## Architecture
+
+### Module Structure
+
+```
+src/cmd/claude/
+├── claude.rs       # Commands enum includes Run
+├── run.rs          # Main run command, CLI config, run loop
+├── run/
+│   ├── process.rs  # ClaudeProcess subprocess management
+│   ├── stream.rs   # NDJSON message types
+│   └── ui.rs       # Terminal UI
+├── hook.rs
+├── setup.rs
+└── docs.rs
+```
+
+### Key Types
+
+**`ClaudeProcess`** (`run/process.rs`): Spawns and manages the Claude subprocess.
+- `spawn(opts)` - Start Claude with stream-json flags, send initial prompt via stdin
+- `send_message(msg)` - Write JSON to stdin
+- `read_message()` - Read next NDJSON line from stdout
+
+**`OutputMessage`** (`run/stream.rs`): Enum for parsing Claude's output:
+- `System` - Init message with session_id, tools, model
+- `Assistant` - Text and tool_use content blocks
+- `User` - Tool results
+- `Result` - Turn completion with stats
+
+**`TerminalUI`** (`run/ui.rs`): Handles display and user input:
+- Displays assistant text, tool calls with summaries, results
+- Tool summaries show contextual info (file paths, commands, patterns)
+- Prompts user for input with slash command support
+
+## CLI Interface
+
+```bash
+nudge claude run [OPTIONS] [PROMPT]
+
+Arguments:
+  [PROMPT]  Initial prompt to send to Claude
+
+Options:
+  -c, --continue               Continue the most recent conversation
+  -r, --resume <RESUME>        Resume a specific session by ID
+      --max-turns <MAX_TURNS>  Maximum number of agentic turns
+      --model <MODEL>          Model to use
+  -v, --verbose                Show verbose output (tool inputs/outputs)
+      --cwd <CWD>              Working directory
+```
+
+### Slash Commands (in-session)
+
+- `/exit`, `/quit`, `/q` - Exit the conversation
+- `/help`, `/h`, `/?` - Show help
+- `/session` - Show current session ID
+
+## Future Phases
+
+### Phase 2: Rewindable Sessions
+
+**Goal**: Bundle conversation context with code state so you can rewind to any point in time.
+
+A session captures:
+1. **Starting point**: repo URL + commit hash (or local path + initial state)
+2. **Conversation log**: Claude's NDJSON stream (messages, tool calls, results)
+3. **Change log**: Diffs keyed to conversation turns
+
+This enables:
+- **Rewind**: Jump back to turn N, which also reverts code to that point
+- **Teleport**: Share a session bundle with another user who can replay/continue
+- **Fork**: Branch from any point to explore different approaches
+- **Non-destructive compaction**: `/compact` forks with a summary instead of nuking history
+
+#### Session Bundle Format
+
+```
+session-<id>/
+├── manifest.json      # Metadata: repo, commit, created_at, turn_count
+├── conversation.jsonl # Claude's stream (what we already capture)
+└── changes/
+    ├── turn-001.patch # Diff after turn 1
+    ├── turn-002.patch # Diff after turn 2 (cumulative or incremental TBD)
+    └── ...
+```
+
+#### Key Operations
+
+- `nudge session list` - List sessions with metadata
+- `nudge session export <id>` - Bundle session for sharing
+- `nudge session import <bundle>` - Import and set up session
+- `nudge session rewind <id> <turn>` - Rewind to specific turn
+- `nudge session fork <id> [turn]` - Fork from a point
+- `/compact` (in-session) - Fork current session with a summarized context (original preserved)
+
+#### Open Questions
+
+- Cumulative vs incremental patches? (cumulative = simpler to apply, incremental = smaller)
+- How to handle uncommitted changes at session start?
+- What about files outside the repo (e.g., config, env)?
+
+### Phase 3: Agentic Loop Control
+
+- Local turn counting independent of Claude's `--max-turns`
+- Loop detection and intervention
+- Configurable intervention points
+
+### Phase 4: Rule Integration
+
+When we see `tool_use` messages for Write/Edit:
+1. Parse the tool input using existing hook types
+2. Run Nudge rules against it
+3. If rules match, inject feedback via stdin message
+4. More control than hooks (can modify behavior, not just block)
+
+### Phase 5: Enhanced UI
+
+- Consider `ratatui` for TUI with scrolling
+- Syntax highlighting for code
+- Progress indicators during tool execution
+
+## Design Decisions
+
+1. **Stdin handling**: True multi-turn stdin with long-running process
+2. **Tool result visibility**: Show everything (controlled by `-v` flag)
+3. **Error handling**: Report with color_eyre context and exit
+4. **Session file format**: Custom bundle format (conversation.jsonl + patches + manifest)
+5. **Concurrent access**: Fork sessions to allow parallel exploration
+
+## Resources
+
+- [Claude Code CLI Reference](https://code.claude.com/docs/en/cli-reference)
+- [Headless Mode Documentation](https://code.claude.com/docs/en/headless)

--- a/packages/nudge/src/cmd/claude.rs
+++ b/packages/nudge/src/cmd/claude.rs
@@ -6,6 +6,7 @@ use tracing::instrument;
 
 pub mod docs;
 pub mod hook;
+pub mod run;
 pub mod setup;
 
 #[derive(Args, Clone, Debug)]
@@ -24,6 +25,9 @@ enum Commands {
 
     /// Show documentation for writing Nudge rules.
     Docs(docs::Config),
+
+    /// Run Claude Code with Nudge as the frontend.
+    Run(run::Config),
 }
 
 #[instrument]
@@ -32,5 +36,6 @@ pub fn main(config: Config) -> Result<()> {
         Commands::Hook(config) => hook::main(config),
         Commands::Setup(config) => setup::main(config),
         Commands::Docs(config) => docs::main(config),
+        Commands::Run(config) => run::main(config),
     }
 }

--- a/packages/nudge/src/cmd/claude/run.rs
+++ b/packages/nudge/src/cmd/claude/run.rs
@@ -1,0 +1,219 @@
+//! Run Claude Code with Nudge as the frontend.
+
+use std::path::PathBuf;
+
+use clap::Args;
+use color_eyre::eyre::{Context, Result};
+use tracing::{debug, instrument};
+
+mod process;
+mod stream;
+mod ui;
+
+use process::{ClaudeProcess, SpawnOptions};
+use stream::{InputMessage, OutputMessage};
+use ui::TerminalUI;
+
+/// Configuration for the run command.
+#[derive(Args, Clone, Debug)]
+pub struct Config {
+    /// Initial prompt to send to Claude.
+    pub prompt: Option<String>,
+
+    /// Continue the most recent conversation.
+    #[arg(short, long)]
+    pub r#continue: bool,
+
+    /// Resume a specific session by ID.
+    #[arg(short, long)]
+    pub resume: Option<String>,
+
+    /// Maximum number of agentic turns.
+    #[arg(long)]
+    pub max_turns: Option<u32>,
+
+    /// Model to use.
+    #[arg(long)]
+    pub model: Option<String>,
+
+    /// Show verbose output (tool inputs/outputs).
+    #[arg(short, long)]
+    pub verbose: bool,
+
+    /// Working directory (defaults to current directory).
+    #[arg(long)]
+    pub cwd: Option<PathBuf>,
+}
+
+impl From<&Config> for SpawnOptions {
+    fn from(config: &Config) -> Self {
+        Self {
+            prompt: config.prompt.clone(),
+            continue_session: config.r#continue,
+            resume: config.resume.clone(),
+            max_turns: config.max_turns,
+            model: config.model.clone(),
+            cwd: config.cwd.clone(),
+        }
+    }
+}
+
+/// Main entry point for the run command.
+#[instrument(skip_all)]
+pub fn main(config: Config) -> Result<()> {
+    let ui = TerminalUI::new(config.verbose);
+
+    // If no prompt provided, prompt the user first
+    let config = if config.prompt.is_none() && !config.r#continue && config.resume.is_none() {
+        let mut config = config;
+        ui.display_status("Enter your prompt (or /help for commands):");
+        match ui.prompt()? {
+            Some(input) if input.is_empty() => {
+                ui.display_error("No prompt provided");
+                return Ok(());
+            }
+            Some(input) if input.starts_with('/') => {
+                handle_command(&input, None, &ui)?;
+                return Ok(());
+            }
+            Some(input) => {
+                config.prompt = Some(input);
+                config
+            }
+            None => {
+                // EOF
+                return Ok(());
+            }
+        }
+    } else {
+        config
+    };
+
+    let opts = SpawnOptions::from(&config);
+    debug!(?opts, "Spawning Claude with options");
+
+    let mut process = ClaudeProcess::spawn(opts).wrap_err("Failed to start Claude")?;
+
+    run_loop(&mut process, &ui)
+}
+
+/// Main conversation loop.
+fn run_loop(process: &mut ClaudeProcess, ui: &TerminalUI) -> Result<()> {
+    loop {
+        // Read messages until we get a result or EOF
+        let should_prompt = read_until_result(process, ui)?;
+
+        if !should_prompt {
+            // Process ended
+            break;
+        }
+
+        // Prompt for next input
+        match ui.prompt()? {
+            None => {
+                // EOF
+                ui.display_status("Goodbye!");
+                break;
+            }
+            Some(input) if input.is_empty() => {
+                // Empty input, prompt again
+                continue;
+            }
+            Some(input) if input.starts_with('/') => {
+                // Command
+                match handle_command(&input, Some(process), ui)? {
+                    LoopAction::Continue => continue,
+                    LoopAction::Exit => break,
+                }
+            }
+            Some(input) => {
+                // Send user message
+                let msg = InputMessage::user(&input);
+                process
+                    .send_message(&msg)
+                    .wrap_err("Failed to send message to Claude")?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Read messages from Claude until we get a result message or EOF.
+///
+/// Returns `true` if we should prompt for more input, `false` if the conversation ended.
+fn read_until_result(process: &mut ClaudeProcess, ui: &TerminalUI) -> Result<bool> {
+    loop {
+        match process.read_message()? {
+            None => {
+                // EOF - process ended
+                return Ok(false);
+            }
+            Some(OutputMessage::System(sys)) => {
+                if sys.subtype == "init" {
+                    if let Some(ref session_id) = sys.session_id {
+                        ui.display_init(session_id);
+                    }
+                }
+            }
+            Some(OutputMessage::Assistant(asst)) => {
+                ui.display_content(&asst.message.content);
+            }
+            Some(OutputMessage::User(usr)) => {
+                // Tool results - display if verbose
+                ui.display_content(&usr.message.content);
+            }
+            Some(OutputMessage::Result(res)) => {
+                ui.display_result(&res);
+                if res.is_error {
+                    return Ok(false);
+                }
+                return Ok(true);
+            }
+        }
+    }
+}
+
+/// Action to take after handling a command.
+enum LoopAction {
+    Continue,
+    Exit,
+}
+
+/// Handle a slash command.
+fn handle_command(
+    input: &str,
+    process: Option<&ClaudeProcess>,
+    ui: &TerminalUI,
+) -> Result<LoopAction> {
+    let cmd = input.trim_start_matches('/').to_lowercase();
+    let cmd = cmd.split_whitespace().next().unwrap_or("");
+
+    match cmd {
+        "exit" | "quit" | "q" => {
+            ui.display_status("Goodbye!");
+            Ok(LoopAction::Exit)
+        }
+        "help" | "h" | "?" => {
+            ui.display_help();
+            Ok(LoopAction::Continue)
+        }
+        "session" => {
+            if let Some(process) = process {
+                if let Some(session_id) = process.session_id() {
+                    ui.display_status(&format!("Session ID: {}", session_id));
+                } else {
+                    ui.display_status("No session ID yet");
+                }
+            } else {
+                ui.display_status("No active session");
+            }
+            Ok(LoopAction::Continue)
+        }
+        _ => {
+            ui.display_error(&format!("Unknown command: /{}", cmd));
+            ui.display_help();
+            Ok(LoopAction::Continue)
+        }
+    }
+}

--- a/packages/nudge/src/cmd/claude/run/process.rs
+++ b/packages/nudge/src/cmd/claude/run/process.rs
@@ -1,0 +1,199 @@
+//! Subprocess management for Claude Code.
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+use color_eyre::eyre::{Context, Result};
+use tracing::{debug, trace};
+
+use super::stream::{InputMessage, OutputMessage};
+
+/// A running Claude Code process.
+pub struct ClaudeProcess {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    session_id: Option<String>,
+}
+
+/// Options for spawning a Claude process.
+#[derive(Debug, Default)]
+pub struct SpawnOptions {
+    /// Initial prompt to send
+    pub prompt: Option<String>,
+
+    /// Resume the most recent session
+    pub continue_session: bool,
+
+    /// Resume a specific session by ID
+    pub resume: Option<String>,
+
+    /// Maximum number of agentic turns
+    pub max_turns: Option<u32>,
+
+    /// Model to use
+    pub model: Option<String>,
+
+    /// Working directory
+    pub cwd: Option<std::path::PathBuf>,
+}
+
+impl ClaudeProcess {
+    /// Spawn a new Claude Code process.
+    ///
+    /// If `opts.prompt` is provided, it will be sent as the first message via stdin.
+    pub fn spawn(opts: SpawnOptions) -> Result<Self> {
+        let mut cmd = Command::new("claude");
+
+        // Required flags for JSON I/O
+        cmd.arg("-p"); // Non-interactive mode
+        cmd.args(["--output-format", "stream-json"]);
+        cmd.args(["--input-format", "stream-json"]);
+        cmd.arg("--verbose");
+
+        // Session management
+        if opts.continue_session {
+            cmd.arg("--continue");
+        }
+        if let Some(ref session_id) = opts.resume {
+            cmd.args(["--resume", session_id]);
+        }
+
+        // Optional flags
+        if let Some(max_turns) = opts.max_turns {
+            cmd.args(["--max-turns", &max_turns.to_string()]);
+        }
+        if let Some(ref model) = opts.model {
+            cmd.args(["--model", model]);
+        }
+
+        // Working directory
+        if let Some(ref cwd) = opts.cwd {
+            cmd.current_dir(cwd);
+        }
+
+        // Set up pipes
+        cmd.stdin(Stdio::piped());
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::inherit()); // Let stderr pass through for debugging
+
+        debug!(?cmd, "Spawning Claude process");
+
+        let mut child = cmd.spawn().wrap_err("Failed to spawn claude process")?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| color_eyre::eyre::eyre!("Failed to capture stdin"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| color_eyre::eyre::eyre!("Failed to capture stdout"))?;
+
+        let mut process = Self {
+            child,
+            stdin,
+            stdout: BufReader::new(stdout),
+            session_id: None,
+        };
+
+        // Send initial prompt via stdin if provided
+        if let Some(ref prompt) = opts.prompt {
+            let msg = super::stream::InputMessage::user(prompt);
+            process.send_message(&msg)?;
+        }
+
+        Ok(process)
+    }
+
+    /// Get the session ID if known.
+    pub fn session_id(&self) -> Option<&str> {
+        self.session_id.as_deref()
+    }
+
+    /// Set the session ID (called when we receive it from init message).
+    #[allow(dead_code)]
+    pub fn set_session_id(&mut self, session_id: String) {
+        self.session_id = Some(session_id);
+    }
+
+    /// Send a message to Claude via stdin.
+    pub fn send_message(&mut self, msg: &InputMessage) -> Result<()> {
+        let json = serde_json::to_string(msg).wrap_err("Failed to serialize input message")?;
+        trace!(%json, "Sending message to Claude");
+
+        writeln!(self.stdin, "{}", json).wrap_err("Failed to write to Claude stdin")?;
+        self.stdin.flush().wrap_err("Failed to flush Claude stdin")?;
+
+        Ok(())
+    }
+
+    /// Read the next message from Claude's stdout.
+    ///
+    /// Returns `None` if the process has closed stdout.
+    pub fn read_message(&mut self) -> Result<Option<OutputMessage>> {
+        let mut line = String::new();
+
+        match self.stdout.read_line(&mut line) {
+            Ok(0) => {
+                // EOF - process closed stdout
+                debug!("Claude process closed stdout");
+                return Ok(None);
+            }
+            Ok(_) => {}
+            Err(e) => {
+                return Err(e).wrap_err("Failed to read from Claude stdout");
+            }
+        }
+
+        let line = line.trim();
+        if line.is_empty() {
+            // Empty line, try again
+            return self.read_message();
+        }
+
+        trace!(%line, "Received message from Claude");
+
+        let msg: OutputMessage =
+            serde_json::from_str(line).wrap_err_with(|| format!("Failed to parse message: {}", line))?;
+
+        // Track session ID
+        if let OutputMessage::System(ref sys) = msg {
+            if let Some(ref session_id) = sys.session_id {
+                self.session_id = Some(session_id.clone());
+            }
+        }
+        if let OutputMessage::Result(ref res) = msg {
+            if let Some(ref session_id) = res.session_id {
+                self.session_id = Some(session_id.clone());
+            }
+        }
+
+        Ok(Some(msg))
+    }
+
+    /// Check if the process is still running.
+    pub fn is_running(&mut self) -> bool {
+        matches!(self.child.try_wait(), Ok(None))
+    }
+
+    /// Wait for the process to exit and return its exit status.
+    #[allow(dead_code)]
+    pub fn wait(&mut self) -> Result<std::process::ExitStatus> {
+        self.child.wait().wrap_err("Failed to wait for Claude process")
+    }
+
+    /// Kill the process.
+    pub fn kill(&mut self) -> Result<()> {
+        self.child.kill().wrap_err("Failed to kill Claude process")
+    }
+}
+
+impl Drop for ClaudeProcess {
+    fn drop(&mut self) {
+        // Try to kill the process if it's still running
+        if self.is_running() {
+            let _ = self.kill();
+        }
+    }
+}

--- a/packages/nudge/src/cmd/claude/run/stream.rs
+++ b/packages/nudge/src/cmd/claude/run/stream.rs
@@ -1,0 +1,224 @@
+//! NDJSON message types for Claude Code's stream-json format.
+
+use serde::{Deserialize, Serialize};
+
+/// Output message from Claude Code (stdout).
+///
+/// Each line of stdout is a complete JSON object of one of these types.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub enum OutputMessage {
+    /// System messages (init, etc.)
+    #[serde(rename = "system")]
+    System(SystemMessage),
+
+    /// Assistant messages (text, tool use)
+    #[serde(rename = "assistant")]
+    Assistant(AssistantMessage),
+
+    /// User messages (tool results)
+    #[serde(rename = "user")]
+    User(UserMessage),
+
+    /// Result message (end of conversation turn)
+    #[serde(rename = "result")]
+    Result(ResultMessage),
+}
+
+/// System message, typically sent at conversation start.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct SystemMessage {
+    /// Subtype of the system message (e.g., "init")
+    pub subtype: String,
+
+    /// Session ID for this conversation
+    pub session_id: Option<String>,
+
+    /// Current working directory
+    pub cwd: Option<String>,
+
+    /// Model being used
+    pub model: Option<String>,
+
+    /// Available tools (we don't parse this in detail)
+    #[serde(default)]
+    pub tools: Vec<String>,
+}
+
+/// Assistant message containing response content.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct AssistantMessage {
+    /// The message content (nested message object from Claude API)
+    pub message: ApiMessage,
+
+    /// Session ID
+    pub session_id: Option<String>,
+}
+
+/// User message, typically containing tool results.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct UserMessage {
+    /// The message content
+    pub message: ApiMessage,
+
+    /// Session ID
+    pub session_id: Option<String>,
+}
+
+/// A message from the Claude API (nested inside assistant/user messages).
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ApiMessage {
+    /// Role of the message sender
+    #[serde(default)]
+    pub role: Option<String>,
+
+    /// Content blocks
+    pub content: MessageContent,
+
+    /// Stop reason (if finished)
+    pub stop_reason: Option<String>,
+}
+
+/// Message content can be a string or array of content blocks.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum MessageContent {
+    /// Simple string content
+    Text(String),
+
+    /// Array of content blocks
+    Blocks(Vec<ContentBlock>),
+}
+
+impl MessageContent {
+    /// Iterate over content blocks, treating string content as a single text block.
+    pub fn blocks(&self) -> impl Iterator<Item = ContentBlock> + '_ {
+        match self {
+            MessageContent::Text(s) => {
+                vec![ContentBlock::Text { text: s.clone() }].into_iter()
+            }
+            MessageContent::Blocks(blocks) => blocks.clone().into_iter(),
+        }
+    }
+}
+
+/// A content block within a message.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "type")]
+pub enum ContentBlock {
+    /// Text content
+    #[serde(rename = "text")]
+    Text { text: String },
+
+    /// Tool use request
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+
+    /// Tool result
+    #[serde(rename = "tool_result")]
+    ToolResult {
+        tool_use_id: String,
+        content: ToolResultContent,
+    },
+}
+
+/// Tool result content can be a string or structured.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ToolResultContent {
+    /// Simple string result
+    Text(String),
+
+    /// Structured result (we just preserve as JSON)
+    Structured(serde_json::Value),
+}
+
+impl std::fmt::Display for ToolResultContent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ToolResultContent::Text(s) => write!(f, "{}", s),
+            ToolResultContent::Structured(v) => {
+                write!(f, "{}", serde_json::to_string_pretty(v).unwrap_or_default())
+            }
+        }
+    }
+}
+
+/// Result message indicating end of a conversation turn.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct ResultMessage {
+    /// Result subtype (e.g., "success", "error")
+    pub subtype: String,
+
+    /// Session ID
+    pub session_id: Option<String>,
+
+    /// Whether this is an error
+    #[serde(default)]
+    pub is_error: bool,
+
+    /// Total duration in milliseconds
+    pub duration_ms: Option<u64>,
+
+    /// API duration in milliseconds
+    pub duration_api_ms: Option<u64>,
+
+    /// Number of conversation turns
+    pub num_turns: Option<u32>,
+
+    /// Total cost in USD
+    pub total_cost_usd: Option<f64>,
+
+    /// Result text (for success)
+    pub result: Option<String>,
+}
+
+/// Input message to send to Claude Code (stdin).
+#[derive(Debug, Serialize)]
+pub struct InputMessage {
+    /// Message type (always "user" for input)
+    pub r#type: String,
+
+    /// The message content
+    pub message: InputMessageContent,
+}
+
+/// Content of an input message.
+#[derive(Debug, Serialize)]
+pub struct InputMessageContent {
+    /// Role (always "user")
+    pub role: String,
+
+    /// Content blocks
+    pub content: Vec<InputContentBlock>,
+}
+
+/// A content block for input messages.
+#[derive(Debug, Serialize)]
+#[serde(tag = "type")]
+pub enum InputContentBlock {
+    /// Text content
+    #[serde(rename = "text")]
+    Text { text: String },
+}
+
+impl InputMessage {
+    /// Create a new user text message.
+    pub fn user(text: impl Into<String>) -> Self {
+        Self {
+            r#type: "user".to_string(),
+            message: InputMessageContent {
+                role: "user".to_string(),
+                content: vec![InputContentBlock::Text { text: text.into() }],
+            },
+        }
+    }
+}

--- a/packages/nudge/src/cmd/claude/run/ui.rs
+++ b/packages/nudge/src/cmd/claude/run/ui.rs
@@ -1,0 +1,180 @@
+//! Terminal UI for displaying Claude's output and prompting the user.
+
+use std::io::{Write, stdin, stdout};
+
+use color_eyre::eyre::{Context, Result};
+use color_print::{cformat, cprintln};
+
+use nudge::claude::hook::{
+    PreToolUseEditInput, PreToolUseWebFetchInput, PreToolUseWriteInput,
+};
+
+use super::stream::{ContentBlock, MessageContent, ResultMessage, ToolResultContent};
+
+/// Terminal UI for Claude interactions.
+pub struct TerminalUI {
+    /// Whether to show verbose output (tool results, etc.)
+    verbose: bool,
+}
+
+impl TerminalUI {
+    /// Create a new terminal UI.
+    pub fn new(verbose: bool) -> Self {
+        Self { verbose }
+    }
+
+    /// Display assistant text output.
+    pub fn display_text(&self, text: &str) {
+        print!("{}", text);
+        let _ = stdout().flush();
+    }
+
+    /// Display a tool use request.
+    pub fn display_tool_use(&self, name: &str, input: &serde_json::Value) {
+        // Try to extract a useful summary based on tool type
+        let summary = self.tool_summary(name, input);
+        if let Some(summary) = summary {
+            cprintln!("\n<dim>[{}: {}]</dim>", name, summary);
+        } else {
+            cprintln!("\n<dim>[{}]</dim>", name);
+        }
+
+        if self.verbose {
+            if let Ok(pretty) = serde_json::to_string_pretty(input) {
+                cprintln!("<dim>{}</dim>", pretty);
+            }
+        }
+    }
+
+    /// Extract a short summary for known tool types.
+    fn tool_summary(&self, name: &str, input: &serde_json::Value) -> Option<String> {
+        match name {
+            "Read" => {
+                let path = input.get("file_path")?.as_str()?;
+                Some(path.to_string())
+            }
+            "Write" => {
+                let parsed: PreToolUseWriteInput = serde_json::from_value(input.clone()).ok()?;
+                Some(parsed.file_path.display().to_string())
+            }
+            "Edit" => {
+                let parsed: PreToolUseEditInput = serde_json::from_value(input.clone()).ok()?;
+                Some(parsed.file_path.display().to_string())
+            }
+            "Bash" => {
+                let cmd = input.get("command")?.as_str()?;
+                // Truncate long commands
+                let truncated = if cmd.len() > 60 {
+                    format!("{}...", &cmd[..57])
+                } else {
+                    cmd.to_string()
+                };
+                Some(format!("`{}`", truncated))
+            }
+            "Glob" => {
+                let pattern = input.get("pattern")?.as_str()?;
+                Some(pattern.to_string())
+            }
+            "Grep" => {
+                let pattern = input.get("pattern")?.as_str()?;
+                Some(format!("/{}/", pattern))
+            }
+            "WebFetch" => {
+                let parsed: PreToolUseWebFetchInput = serde_json::from_value(input.clone()).ok()?;
+                Some(parsed.url)
+            }
+            "WebSearch" => {
+                let query = input.get("query")?.as_str()?;
+                Some(format!("\"{}\"", query))
+            }
+            "Task" => {
+                let desc = input.get("description")?.as_str()?;
+                Some(desc.to_string())
+            }
+            _ => None,
+        }
+    }
+
+    /// Display a tool result.
+    pub fn display_tool_result(&self, tool_use_id: &str, content: &ToolResultContent) {
+        if self.verbose {
+            cprintln!("<dim>[Result {}]</dim>", tool_use_id);
+            cprintln!("<dim>{}</dim>", content);
+        }
+    }
+
+    /// Display message content blocks.
+    pub fn display_content(&self, content: &MessageContent) {
+        for block in content.blocks() {
+            match block {
+                ContentBlock::Text { text } => self.display_text(&text),
+                ContentBlock::ToolUse { id: _, name, input } => {
+                    self.display_tool_use(&name, &input);
+                }
+                ContentBlock::ToolResult {
+                    tool_use_id,
+                    content,
+                } => {
+                    self.display_tool_result(&tool_use_id, &content);
+                }
+            }
+        }
+    }
+
+    /// Display session initialization info.
+    pub fn display_init(&self, session_id: &str) {
+        cprintln!("<dim>Session: {}</dim>", session_id);
+    }
+
+    /// Display result/completion info.
+    pub fn display_result(&self, result: &ResultMessage) {
+        println!(); // Ensure we're on a new line
+        if result.is_error {
+            cprintln!("<red>Error during conversation</red>");
+        }
+        if self.verbose {
+            if let Some(duration) = result.duration_ms {
+                cprintln!("<dim>Duration: {}ms</dim>", duration);
+            }
+            if let Some(cost) = result.total_cost_usd {
+                cprintln!("<dim>Cost: ${:.4}</dim>", cost);
+            }
+            if let Some(turns) = result.num_turns {
+                cprintln!("<dim>Turns: {}</dim>", turns);
+            }
+        }
+    }
+
+    /// Display an error message.
+    pub fn display_error(&self, error: &str) {
+        cprintln!("<red>Error:</red> {}", error);
+    }
+
+    /// Display a status message.
+    pub fn display_status(&self, status: &str) {
+        cprintln!("<dim>{}</dim>", status);
+    }
+
+    /// Prompt the user for input.
+    ///
+    /// Returns the user's input, or `None` if EOF was reached.
+    pub fn prompt(&self) -> Result<Option<String>> {
+        print!("\n{}", cformat!("<cyan><bold>You:</bold></cyan> "));
+        stdout().flush().wrap_err("Failed to flush stdout")?;
+
+        let mut input = String::new();
+        match stdin().read_line(&mut input) {
+            Ok(0) => Ok(None), // EOF
+            Ok(_) => Ok(Some(input.trim().to_string())),
+            Err(e) => Err(e).wrap_err("Failed to read user input"),
+        }
+    }
+
+    /// Display help for available commands.
+    pub fn display_help(&self) {
+        cprintln!("<bold>Available commands:</bold>");
+        cprintln!("  <cyan>/exit</cyan>, <cyan>/quit</cyan>  - Exit the conversation");
+        cprintln!("  <cyan>/help</cyan>        - Show this help");
+        cprintln!("  <cyan>/session</cyan>     - Show current session ID");
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 (MVP) of a subprocess wrapper that allows Nudge to control interaction with Claude Code. Spawns Claude with stream-json I/O for programmatic control, displays assistant text with tool call summaries, and supports multi-turn conversations via stdin. Enables features not possible with hooks alone: agentic loop control, session resumption, and session teleporting between users.

## Implementation

- **ClaudeProcess**: Manages Claude subprocess with piped stdin/stdout
- **NDJSON streaming**: Parses system/assistant/user/result message types
- **Terminal UI**: Displays text, tool calls with contextual summaries, and results
- **CLI options**: Support for `-c` (continue), `-r` (resume session), `--max-turns`, `--model`, `-v` (verbose)
- **Slash commands**: `/exit`, `/help`, `/session` for in-session control

## Testing

Run with: `cargo run -p nudge -- claude run "your prompt"`