### PR TITLE
Add Bash command matcher with project_state filtering

### DIFF
--- a/packages/nudge/src/cmd/test.rs
+++ b/packages/nudge/src/cmd/test.rs
@@ -106,6 +106,14 @@ fn evaluate_rule(rule: &Rule, hook: &Hook) -> (Vec<Match>, Source) {
                 let source = Source::from(&payload.tool_input.url);
                 (matches, source)
             }
+            PreToolUsePayload::Bash(payload) => {
+                let matches = rule
+                    .hooks_pretooluse_bash()
+                    .flat_map(|matcher| payload.evaluate(matcher))
+                    .collect_vec();
+                let source = Source::from(&payload.tool_input.command);
+                (matches, source)
+            }
             PreToolUsePayload::Other => (Vec::new(), Source::from("")),
         },
         Hook::UserPromptSubmit(payload) => {

--- a/packages/nudge/src/git.rs
+++ b/packages/nudge/src/git.rs
@@ -1,0 +1,50 @@
+//! Git state queries via shell commands.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Get the current git branch name.
+///
+/// Returns `None` if:
+/// - Not in a git repository
+/// - Git command fails
+/// - In detached HEAD state (no branch name)
+pub fn current_branch(cwd: &Path) -> Option<String> {
+    let cwd_str = cwd.to_str()?;
+
+    let output = Command::new("git")
+        .args(["-C", cwd_str, "branch", "--show-current"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    String::from_utf8(output.stdout)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    #[test]
+    fn test_current_branch_in_git_repo() {
+        // This test runs in the nudge repo, so we should get a branch name
+        let cwd = env::current_dir().expect("get cwd");
+        let branch = current_branch(&cwd);
+        // We should be on some branch (could be main, a feature branch, etc.)
+        assert!(branch.is_some(), "expected to be in a git repo with a branch");
+    }
+
+    #[test]
+    fn test_current_branch_not_git_repo() {
+        // /tmp is unlikely to be a git repo
+        let branch = current_branch(Path::new("/tmp"));
+        assert!(branch.is_none(), "expected None for non-git directory");
+    }
+}

--- a/packages/nudge/src/lib.rs
+++ b/packages/nudge/src/lib.rs
@@ -1,6 +1,7 @@
 //! Main library for Nudge, used by its CLI.
 
 pub mod claude;
+pub mod git;
 pub mod rules;
 pub mod snippet;
 pub mod template;

--- a/packages/nudge/tests/it/bash.rs
+++ b/packages/nudge/tests/it/bash.rs
@@ -1,0 +1,363 @@
+//! Integration tests for Bash tool matching with project_state.
+
+use std::io::Write as _;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use pretty_assertions::assert_eq as pretty_assert_eq;
+use tempfile::TempDir;
+
+/// Create a temporary directory with a .nudge.yaml config containing the given rules.
+fn setup_config(rules_yaml: &str) -> TempDir {
+    let dir = TempDir::new().expect("create temp dir");
+    let config_path = dir.path().join(".nudge.yaml");
+    std::fs::write(&config_path, rules_yaml).expect("write config");
+    dir
+}
+
+/// Create a temporary git repository with the given branch name.
+fn setup_git_repo(branch_name: &str, rules_yaml: &str) -> TempDir {
+    let dir = setup_config(rules_yaml);
+    let temp_path = dir.path();
+
+    // Initialize git repo
+    Command::new("git")
+        .args(["init"])
+        .current_dir(temp_path)
+        .output()
+        .expect("git init");
+
+    // Configure git user for commits (required for some git operations)
+    Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(temp_path)
+        .output()
+        .expect("git config email");
+
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(temp_path)
+        .output()
+        .expect("git config name");
+
+    // Create initial commit so we have a branch
+    std::fs::write(temp_path.join("README.md"), "# Test").expect("write readme");
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(temp_path)
+        .output()
+        .expect("git add");
+    Command::new("git")
+        .args(["commit", "-m", "Initial commit"])
+        .current_dir(temp_path)
+        .output()
+        .expect("git commit");
+
+    // Rename branch to desired name
+    Command::new("git")
+        .args(["branch", "-m", branch_name])
+        .current_dir(temp_path)
+        .output()
+        .expect("git branch rename");
+
+    dir
+}
+
+/// Get the path to the built nudge binary.
+fn get_binary_path() -> PathBuf {
+    let status = Command::new("cargo")
+        .args(["build", "--quiet", "-p", "nudge"])
+        .status()
+        .expect("failed to build nudge");
+    assert!(status.success(), "cargo build failed");
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir.parent().unwrap().parent().unwrap();
+    workspace_root.join("target/debug/nudge")
+}
+
+/// Run nudge claude hook with the given input JSON in the specified directory.
+fn run_hook_in_dir(dir: &TempDir, input: &str) -> (i32, String) {
+    let binary = get_binary_path();
+
+    let mut child = Command::new(&binary)
+        .args(["claude", "hook"])
+        .current_dir(dir.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn nudge");
+
+    {
+        let stdin = child.stdin.as_mut().expect("failed to get stdin");
+        stdin
+            .write_all(input.as_bytes())
+            .expect("failed to write to stdin");
+    }
+
+    let output = child.wait_with_output().expect("failed to wait for nudge");
+
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    let combined = if !stdout.trim().is_empty() {
+        stdout.trim().to_string()
+    } else {
+        stderr.trim().to_string()
+    };
+
+    (exit_code, combined)
+}
+
+/// Build a PreToolUse hook JSON payload for Bash tool.
+fn bash_hook(command: &str, cwd: &str) -> String {
+    serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "test",
+        "transcript_path": "/tmp/test",
+        "permission_mode": "default",
+        "cwd": cwd,
+        "tool_name": "Bash",
+        "tool_use_id": "123",
+        "tool_input": {
+            "command": command,
+            "description": "Test command"
+        }
+    })
+    .to_string()
+}
+
+#[test]
+fn test_bash_command_match() {
+    let config = r#"
+version: 1
+rules:
+  - name: block-rm-rf
+    description: Block dangerous rm commands
+    message: "Dangerous rm command detected"
+    on:
+      - hook: PreToolUse
+        tool: Bash
+        command:
+          - kind: Regex
+            pattern: "rm\\s+-rf"
+"#;
+
+    let dir = setup_config(config);
+
+    // Should match: rm -rf command
+    let input = bash_hook("rm -rf /some/path", dir.path().to_str().unwrap());
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected interrupt for rm -rf command, got: {output}"
+    );
+}
+
+#[test]
+fn test_bash_command_no_match() {
+    let config = r#"
+version: 1
+rules:
+  - name: block-rm-rf
+    description: Block dangerous rm commands
+    message: "Dangerous rm command detected"
+    on:
+      - hook: PreToolUse
+        tool: Bash
+        command:
+          - kind: Regex
+            pattern: "rm\\s+-rf"
+"#;
+
+    let dir = setup_config(config);
+
+    // Should not match: safe rm command
+    let input = bash_hook("rm file.txt", dir.path().to_str().unwrap());
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.is_empty(),
+        "expected passthrough for safe rm, got: {output}"
+    );
+
+    // Should not match: unrelated command
+    let input = bash_hook("ls -la", dir.path().to_str().unwrap());
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.is_empty(),
+        "expected passthrough for ls, got: {output}"
+    );
+}
+
+#[test]
+fn test_bash_project_state_git_branch_match() {
+    let config = r#"
+version: 1
+rules:
+  - name: block-main-push
+    description: Block git push on main
+    message: "git push is not allowed on main"
+    on:
+      - hook: PreToolUse
+        tool: Bash
+        command:
+          - kind: Regex
+            pattern: "git\\s+push"
+        project_state:
+          - kind: Git
+            branch:
+              - kind: Regex
+                pattern: "^main$"
+"#;
+
+    // Create git repo on main branch
+    let dir = setup_git_repo("main", config);
+
+    // Should match: git push on main branch
+    let input = bash_hook("git push origin main", dir.path().to_str().unwrap());
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected interrupt for git push on main, got: {output}"
+    );
+    assert!(
+        output.contains("git push is not allowed"),
+        "output should contain rule message: {output}"
+    );
+}
+
+#[test]
+fn test_bash_project_state_git_branch_no_match() {
+    let config = r#"
+version: 1
+rules:
+  - name: block-main-push
+    description: Block git push on main
+    message: "git push is not allowed on main"
+    on:
+      - hook: PreToolUse
+        tool: Bash
+        command:
+          - kind: Regex
+            pattern: "git\\s+push"
+        project_state:
+          - kind: Git
+            branch:
+              - kind: Regex
+                pattern: "^main$"
+"#;
+
+    // Create git repo on feature branch
+    let dir = setup_git_repo("feature-branch", config);
+
+    // Should NOT match: git push on feature branch (not main)
+    let input = bash_hook("git push origin feature-branch", dir.path().to_str().unwrap());
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.is_empty(),
+        "expected passthrough for git push on feature branch, got: {output}"
+    );
+}
+
+#[test]
+fn test_bash_project_state_non_git_dir() {
+    let config = r#"
+version: 1
+rules:
+  - name: block-main-push
+    description: Block git push on main
+    message: "git push is not allowed on main"
+    on:
+      - hook: PreToolUse
+        tool: Bash
+        command:
+          - kind: Regex
+            pattern: "git\\s+push"
+        project_state:
+          - kind: Git
+            branch:
+              - kind: Regex
+                pattern: "^main$"
+"#;
+
+    // Create a non-git directory (just use setup_config without git init)
+    let dir = setup_config(config);
+
+    // Should NOT match: not a git repo, so project_state fails (with warning)
+    let input = bash_hook("git push origin main", dir.path().to_str().unwrap());
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.is_empty(),
+        "expected passthrough for non-git directory, got: {output}"
+    );
+}
+
+#[test]
+fn test_bash_without_project_state() {
+    let config = r#"
+version: 1
+rules:
+  - name: block-all-push
+    description: Block all git push commands
+    message: "git push is blocked everywhere"
+    on:
+      - hook: PreToolUse
+        tool: Bash
+        command:
+          - kind: Regex
+            pattern: "git\\s+push"
+"#;
+
+    let dir = setup_config(config);
+
+    // Should match: git push without project_state requirement
+    let input = bash_hook("git push origin main", dir.path().to_str().unwrap());
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected interrupt for git push, got: {output}"
+    );
+}
+
+#[test]
+fn test_bash_multiple_branch_patterns() {
+    let config = r#"
+version: 1
+rules:
+  - name: block-main-push
+    description: Block git push on main or master
+    message: "git push is not allowed on main or master"
+    on:
+      - hook: PreToolUse
+        tool: Bash
+        command:
+          - kind: Regex
+            pattern: "git\\s+push"
+        project_state:
+          - kind: Git
+            branch:
+              - kind: Regex
+                pattern: "^(main|master)$"
+"#;
+
+    // Create git repo on main branch
+    let dir = setup_git_repo("main", config);
+
+    // Should match: git push on main branch
+    let input = bash_hook("git push", dir.path().to_str().unwrap());
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected interrupt for git push on main, got: {output}"
+    );
+}

--- a/packages/nudge/tests/it/main.rs
+++ b/packages/nudge/tests/it/main.rs
@@ -6,6 +6,7 @@
 //! - Rules produce correct responses (interrupt vs continue vs passthrough)
 
 mod basic;
+mod bash;
 mod cli;
 mod edit_tool;
 mod external;
@@ -100,6 +101,29 @@ pub fn webfetch_hook(url: &str, prompt: &str) -> String {
         "tool_input": {
             "url": url,
             "prompt": prompt
+        }
+    })
+    .to_string()
+}
+
+/// Build a PreToolUse hook JSON payload for Bash tool.
+pub fn bash_hook(command: &str) -> String {
+    bash_hook_with_cwd(command, "/tmp")
+}
+
+/// Build a PreToolUse hook JSON payload for Bash tool with custom cwd.
+pub fn bash_hook_with_cwd(command: &str, cwd: &str) -> String {
+    serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "test",
+        "transcript_path": "/tmp/test",
+        "permission_mode": "default",
+        "cwd": cwd,
+        "tool_name": "Bash",
+        "tool_use_id": "123",
+        "tool_input": {
+            "command": command,
+            "description": "Test command"
         }
     })
     .to_string()


### PR DESCRIPTION
Add support for matching Bash tool invocations with optional project_state conditions. This enables rules like "block git push when on main branch".

Key features:
- Bash command matching with regex patterns
- Project state filtering (currently supports git branch matching)
- Shell-based git state queries with proper error handling
- Comprehensive test coverage (7 integration tests + 5 unit tests)

All 75 tests pass (37 unit + 37 integration + 1 doctest).