### PR TITLE
Use settings.local.json and project root CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ cargo test -p nudge test_name
 
 # Run the CLI
 cargo run -p nudge -- claude hook      # Respond to hook (reads JSON from stdin)
-cargo run -p nudge -- claude setup     # Install hooks into .claude/settings.json
+cargo run -p nudge -- claude setup     # Install hooks into .claude/settings.local.json
 cargo run -p nudge -- claude docs      # Print rule writing documentation
 cargo run -p nudge -- test             # Test a rule against sample input
 cargo run -p nudge -- validate         # Validate rule config files
@@ -45,7 +45,7 @@ cargo run -p nudge -- validate         # Validate rule config files
 
 ```
 nudge claude hook   - Receives hook JSON on stdin, evaluates rules, outputs response
-nudge claude setup  - Writes hook configuration to .claude/settings.json
+nudge claude setup  - Writes hook configuration to .claude/settings.local.json
 nudge claude docs   - Prints documentation for writing rules
 nudge test          - Test a specific rule against sample input
 nudge validate      - Validate and display parsed rule configs
@@ -55,7 +55,7 @@ nudge validate      - Validate and display parsed rule configs
 
 - `src/main.rs` - CLI entry point using clap
 - `src/cmd/claude/hook.rs` - Hook command: deserializes input, evaluates rules, emits response
-- `src/cmd/claude/setup.rs` - Setup command: configures hooks in settings.json
+- `src/cmd/claude/setup.rs` - Setup command: configures hooks in settings.local.json
 - `src/cmd/claude/docs.rs` - Docs command: prints rule writing guide
 - `src/cmd/test.rs` - Test command: test a rule against sample input
 - `src/cmd/validate.rs` - Validate command: parse and display rule configs

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Navigate to any project where you use Claude Code and run:
 nudge claude setup
 ```
 
-This adds Nudge to `.claude/settings.json`. You can verify with `/hooks` in Claude Code.
+This adds Nudge to `.claude/settings.local.json`. You can verify with `/hooks` in Claude Code.
 
 > [!NOTE]
 > Claude Code loads hooks on startup, so you'll need to restart open sessions (`claude -c` is an easy way to do this without breaking your flow). Future changes to rules are internal to Nudge and therefore do not need a Claude Code restart.

--- a/packages/nudge/src/claude/hook.rs
+++ b/packages/nudge/src/claude/hook.rs
@@ -382,7 +382,7 @@ impl From<&Config> for Config {
     }
 }
 
-/// Configures hook matching strategy in Claude Code's settings.json.
+/// Configures hook matching strategy in Claude Code's settings.local.json.
 #[derive(Debug, Serialize, Clone, Builder)]
 #[non_exhaustive]
 pub struct Matcher {


### PR DESCRIPTION
## Summary

- Write hooks to `.claude/settings.local.json` instead of `settings.json`, keeping user-committed settings separate from machine-local hooks
- Write `CLAUDE.md` to the project root (`./CLAUDE.md`) instead of inside `.claude/`, matching the standard location for project instructions

## Test plan

- [ ] Run `cargo test -p nudge` to verify all tests pass
- [ ] Run `nudge claude setup` in a test project and verify hooks are written to `.claude/settings.local.json`
- [ ] Verify CLAUDE.md prompt targets `./CLAUDE.md` instead of `.claude/CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)