### PR TITLE
Use hurry for build caching in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,7 +64,8 @@ jobs:
             - name: Install Rust
               run: rustup show
             - uses: actions/checkout@v4
-            - uses: Swatinem/rust-cache@v2
-              with:
-                  shared-key: build
-            - run: cargo build --all-targets --verbose
+            - name: Install hurry
+              run: curl -sSfL https://hurry.build/install.sh | bash
+            - run: hurry cargo build --all-targets --verbose
+              env:
+                  HURRY_API_TOKEN: ${{ secrets.HURRY_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace `rust-cache` with hurry's distributed build cache for the build job
- Install hurry via the official install script and use `HURRY_API_TOKEN` secret

## Test plan
- [x] Verify CI build job passes with hurry caching

🤖 Generated with [Claude Code](https://claude.com/claude-code)