### PR TITLE
Support Claude and Codex hook adapters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,98 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## The Spirit of Nudge
+
+Nudge is a **collaborative partner**, not a rule enforcer. It helps you remember coding conventions so you can focus on the user's actual problem. Internalize these points:
+
+1. **Nudge is on your side.** When it sends a message, that's a colleague tapping your shoulder—not a reprimand.
+2. **Direct ≠ hostile.** Messages are blunt because that's what cuts through when you're focused. Trust the feedback.
+3. **Don't route around it.** If you're tempted to work around a Nudge message, pause. Either follow the rule, or flag that the rule needs fixing.
+
+For the full philosophy (why Nudge exists, the "collaborative memory layer" framing, the rally copilot analogy), see [README.md](README.md).
+
+### Working on Nudge Itself
+
+Nudge is dogfooded here. Your experience using it is direct feedback:
+
+- **Rule feels unclear?** That's signal to improve the wording. Mention it.
+- **Rule feels wrong?** Let's fix the rule, not route around it.
+
+## Build and Test Commands
+
+```bash
+# Build
+cargo build -p nudge
+
+# Run all tests
+cargo test -p nudge
+
+# Run a specific test
+cargo test -p nudge test_name
+
+# Run the CLI
+cargo run -p nudge -- Codex hook      # Respond to hook (reads JSON from stdin)
+cargo run -p nudge -- Codex setup     # Install hooks into .Codex/settings.local.json
+cargo run -p nudge -- Codex docs      # Print rule writing documentation
+cargo run -p nudge -- test             # Test a rule against sample input
+cargo run -p nudge -- validate         # Validate rule config files
+cargo run -p nudge -- check            # Check project files against rules (for CI)
+```
+
+## Architecture
+
+### CLI Structure
+
+```
+nudge Codex hook   - Receives hook JSON on stdin, evaluates rules, outputs response
+nudge Codex setup  - Writes hook configuration to .Codex/settings.local.json
+nudge Codex docs   - Prints documentation for writing rules
+nudge test          - Test a specific rule against sample input
+nudge validate      - Validate and display parsed rule configs
+nudge check         - Check project files against rules (CI/linter mode)
+```
+
+### Module Layout
+
+- `src/main.rs` - CLI entry point using clap
+- `src/cmd/Codex/hook.rs` - Hook command: deserializes input, evaluates rules, emits response
+- `src/cmd/Codex/setup.rs` - Setup command: configures hooks in settings.local.json
+- `src/cmd/Codex/docs.rs` - Docs command: prints rule writing guide
+- `src/cmd/test.rs` - Test command: test a rule against sample input
+- `src/cmd/validate.rs` - Validate command: parse and display rule configs
+- `src/cmd/check.rs` - Check command: validate project files against rules for CI
+- `src/rules.rs` - Rule loading from config files
+- `src/rules/schema.rs` - Rule schema types and matchers (serde types that double as evaluators)
+- `src/Codex/hook.rs` - Hook payload and response types
+- `src/snippet.rs` - Code snippet rendering for rule violations (uses `annotate-snippets`)
+
+### How Nudge Communicates
+
+When Nudge has something to share, it responds in one of three ways:
+
+- **Passthrough**: Nothing to note—carry on!
+- **Continue**: For UserPromptSubmit hooks, Nudge injects context as plain text
+- **Interrupt**: For PreToolUse hooks, Nudge blocks the operation and explains what to fix
+
+The response type is determined by the hook type:
+- `PreToolUse` rules always **interrupt** (block the Write/Edit operation)
+- `UserPromptSubmit` rules always **continue** (inject guidance into the conversation)
+
+## Keeping Documentation in Sync
+
+Nudge has three documentation sources that must stay aligned. When updating one, consider whether the others need updates too.
+
+| Document | Audience | Purpose | Focus |
+|----------|----------|---------|-------|
+| **AGENTS.md** | You, developing Nudge | How Nudge works under the hood | Architecture, internals, testing patterns |
+| **README.md** | Humans evaluating or contributing | Why Nudge exists and what it believes | Philosophy, motivation, the collaborative framing |
+| **`nudge Codex docs`** | You or humans writing rules elsewhere | How to write rules (reference card) | Rule syntax, examples |
+
+**AGENTS.md** (this file) is for *developing* Nudge—understanding the module layout, how to add features, how tests work.
+
+**README.md** is for *understanding* Nudge—the philosophy that Nudge is a collaborative partner, why directness matters, how to write effective rules. This is the front door; it needs to convey the spirit.
+
+**`nudge Codex docs`** (`src/cmd/Codex/docs.rs`) is for *using* Nudge—a self-contained reference that future Codex instances or humans can consult when writing rules. It should be scannable, copy-pasteable, and not assume any prior context.
+
+When you change something fundamental (like changing the rule format or refining the collaborative framing), update all three.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@ This file provides guidance to Codex (Codex.ai/code) when working with code in t
 
 Nudge is a **collaborative partner**, not a rule enforcer. It helps you remember coding conventions so you can focus on the user's actual problem. Internalize these points:
 
-1. **Nudge is on your side.** When it sends a message, that's a colleague tapping your shoulder—not a reprimand.
-2. **Direct ≠ hostile.** Messages are blunt because that's what cuts through when you're focused. Trust the feedback.
+1. **Nudge is on your side.** When it sends a message, that's a colleague tapping your shoulder, not a reprimand.
+2. **Direct does not mean hostile.** Messages are blunt because that's what cuts through when you're focused. Trust the feedback.
 3. **Don't route around it.** If you're tempted to work around a Nudge message, pause. Either follow the rule, or flag that the rule needs fixing.
 
 For the full philosophy (why Nudge exists, the "collaborative memory layer" framing, the rally copilot analogy), see [README.md](README.md).
@@ -32,9 +32,12 @@ cargo test -p nudge
 cargo test -p nudge test_name
 
 # Run the CLI
-cargo run -p nudge -- Codex hook      # Respond to hook (reads JSON from stdin)
-cargo run -p nudge -- Codex setup     # Install hooks into .Codex/settings.local.json
-cargo run -p nudge -- Codex docs      # Print rule writing documentation
+cargo run -p nudge -- claude hook      # Respond to Claude hook (reads JSON from stdin)
+cargo run -p nudge -- claude setup     # Install hooks into .claude/settings.local.json
+cargo run -p nudge -- claude docs      # Print rule writing documentation
+cargo run -p nudge -- codex hook       # Respond to Codex hook (reads JSON from stdin)
+cargo run -p nudge -- codex setup      # Install hooks into .codex/hooks.json
+cargo run -p nudge -- codex docs       # Print rule writing documentation
 cargo run -p nudge -- test             # Test a rule against sample input
 cargo run -p nudge -- validate         # Validate rule config files
 cargo run -p nudge -- check            # Check project files against rules (for CI)
@@ -45,9 +48,12 @@ cargo run -p nudge -- check            # Check project files against rules (for 
 ### CLI Structure
 
 ```
-nudge Codex hook   - Receives hook JSON on stdin, evaluates rules, outputs response
-nudge Codex setup  - Writes hook configuration to .Codex/settings.local.json
-nudge Codex docs   - Prints documentation for writing rules
+nudge claude hook   - Receives hook JSON on stdin, evaluates rules, outputs response
+nudge claude setup  - Writes hook configuration to .claude/settings.local.json
+nudge claude docs   - Prints documentation for writing rules
+nudge codex hook    - Receives hook JSON on stdin, evaluates rules, outputs response
+nudge codex setup   - Writes hook configuration to .codex/hooks.json
+nudge codex docs    - Prints documentation for writing rules
 nudge test          - Test a specific rule against sample input
 nudge validate      - Validate and display parsed rule configs
 nudge check         - Check project files against rules (CI/linter mode)
@@ -56,28 +62,37 @@ nudge check         - Check project files against rules (CI/linter mode)
 ### Module Layout
 
 - `src/main.rs` - CLI entry point using clap
-- `src/cmd/Codex/hook.rs` - Hook command: deserializes input, evaluates rules, emits response
-- `src/cmd/Codex/setup.rs` - Setup command: configures hooks in settings.local.json
-- `src/cmd/Codex/docs.rs` - Docs command: prints rule writing guide
+- `src/agent.rs` - Provider adapters for Claude Code and Codex CLI
+- `src/hook.rs` - Normalized hook event model
+- `src/hook/evaluate.rs` - Provider-neutral rule evaluation
+- `src/hook/response.rs` - Provider-specific response rendering
+- `src/hook/apply_patch.rs` - Codex apply_patch normalization
+- `src/cmd/claude/hook.rs` - Hook command: deserializes input, evaluates rules, emits response
+- `src/cmd/claude/setup.rs` - Setup command: configures hooks in settings.local.json
+- `src/cmd/claude/docs.rs` - Docs command: prints rule writing guide
+- `src/cmd/codex/hook.rs` - Hook command: deserializes input, evaluates rules, emits response
+- `src/cmd/codex/setup.rs` - Setup command: configures hooks in hooks.json
+- `src/cmd/codex/docs.rs` - Docs command: prints rule writing guide
 - `src/cmd/test.rs` - Test command: test a rule against sample input
 - `src/cmd/validate.rs` - Validate command: parse and display rule configs
 - `src/cmd/check.rs` - Check command: validate project files against rules for CI
 - `src/rules.rs` - Rule loading from config files
-- `src/rules/schema.rs` - Rule schema types and matchers (serde types that double as evaluators)
-- `src/Codex/hook.rs` - Hook payload and response types
+- `src/rules/schema.rs` - Rule schema types and matchers
 - `src/snippet.rs` - Code snippet rendering for rule violations (uses `annotate-snippets`)
 
 ### How Nudge Communicates
 
 When Nudge has something to share, it responds in one of three ways:
 
-- **Passthrough**: Nothing to note—carry on!
+- **Passthrough**: Nothing to note. Carry on!
 - **Continue**: For UserPromptSubmit hooks, Nudge injects context as plain text
 - **Interrupt**: For PreToolUse hooks, Nudge blocks the operation and explains what to fix
 
 The response type is determined by the hook type:
-- `PreToolUse` rules always **interrupt** (block the Write/Edit operation)
+- `PreToolUse` rules always **interrupt** (block provider-supported Write/Edit/WebFetch/Bash operations)
 - `UserPromptSubmit` rules always **continue** (inject guidance into the conversation)
+- `PermissionRequest` is parsed but always **passes through** until Nudge has a permission-specific rule surface
+- `Delete` is normalized but not yet matchable from YAML rules
 
 ## Keeping Documentation in Sync
 
@@ -87,12 +102,12 @@ Nudge has three documentation sources that must stay aligned. When updating one,
 |----------|----------|---------|-------|
 | **AGENTS.md** | You, developing Nudge | How Nudge works under the hood | Architecture, internals, testing patterns |
 | **README.md** | Humans evaluating or contributing | Why Nudge exists and what it believes | Philosophy, motivation, the collaborative framing |
-| **`nudge Codex docs`** | You or humans writing rules elsewhere | How to write rules (reference card) | Rule syntax, examples |
+| **`nudge claude docs` / `nudge codex docs`** | You or humans writing rules elsewhere | How to write rules (reference card) | Rule syntax, examples |
 
-**AGENTS.md** (this file) is for *developing* Nudge—understanding the module layout, how to add features, how tests work.
+**AGENTS.md** (this file) is for *developing* Nudge - understanding the module layout, how to add features, how tests work.
 
-**README.md** is for *understanding* Nudge—the philosophy that Nudge is a collaborative partner, why directness matters, how to write effective rules. This is the front door; it needs to convey the spirit.
+**README.md** is for *understanding* Nudge - the philosophy that Nudge is a collaborative partner, why directness matters, how to write effective rules. This is the front door; it needs to convey the spirit.
 
-**`nudge Codex docs`** (`src/cmd/Codex/docs.rs`) is for *using* Nudge—a self-contained reference that future Codex instances or humans can consult when writing rules. It should be scannable, copy-pasteable, and not assume any prior context.
+**`nudge claude docs` / `nudge codex docs`** (`src/cmd/claude/docs.rs`, `src/cmd/codex/docs.rs`) is for *using* Nudge - a self-contained reference that future agents or humans can consult when writing rules. It should be scannable, copy-pasteable, and not assume any prior context.
 
 When you change something fundamental (like changing the rule format or refining the collaborative framing), update all three.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Nudge is a **collaborative partner**, not a rule enforcer. It helps you remember coding conventions so you can focus on the user's actual problem. Internalize these points:
 
-1. **Nudge is on your side.** When it sends a message, that's a colleague tapping your shoulder—not a reprimand.
-2. **Direct ≠ hostile.** Messages are blunt because that's what cuts through when you're focused. Trust the feedback.
+1. **Nudge is on your side.** When it sends a message, that's a colleague tapping your shoulder, not a reprimand.
+2. **Direct does not mean hostile.** Messages are blunt because that's what cuts through when you're focused. Trust the feedback.
 3. **Don't route around it.** If you're tempted to work around a Nudge message, pause. Either follow the rule, or flag that the rule needs fixing.
 
 For the full philosophy (why Nudge exists, the "collaborative memory layer" framing, the rally copilot analogy), see [README.md](README.md).
@@ -35,6 +35,9 @@ cargo test -p nudge test_name
 cargo run -p nudge -- claude hook      # Respond to hook (reads JSON from stdin)
 cargo run -p nudge -- claude setup     # Install hooks into .claude/settings.local.json
 cargo run -p nudge -- claude docs      # Print rule writing documentation
+cargo run -p nudge -- codex hook       # Respond to Codex hook (reads JSON from stdin)
+cargo run -p nudge -- codex setup      # Install hooks into .codex/hooks.json
+cargo run -p nudge -- codex docs       # Print rule writing documentation
 cargo run -p nudge -- test             # Test a rule against sample input
 cargo run -p nudge -- validate         # Validate rule config files
 cargo run -p nudge -- check            # Check project files against rules (for CI)
@@ -48,6 +51,9 @@ cargo run -p nudge -- check            # Check project files against rules (for 
 nudge claude hook   - Receives hook JSON on stdin, evaluates rules, outputs response
 nudge claude setup  - Writes hook configuration to .claude/settings.local.json
 nudge claude docs   - Prints documentation for writing rules
+nudge codex hook    - Receives hook JSON on stdin, evaluates rules, outputs response
+nudge codex setup   - Writes hook configuration to .codex/hooks.json
+nudge codex docs    - Prints documentation for writing rules
 nudge test          - Test a specific rule against sample input
 nudge validate      - Validate and display parsed rule configs
 nudge check         - Check project files against rules (CI/linter mode)
@@ -56,28 +62,37 @@ nudge check         - Check project files against rules (CI/linter mode)
 ### Module Layout
 
 - `src/main.rs` - CLI entry point using clap
+- `src/agent.rs` - Provider adapters for Claude Code and Codex CLI
+- `src/hook.rs` - Normalized hook event model
+- `src/hook/evaluate.rs` - Provider-neutral rule evaluation
+- `src/hook/response.rs` - Provider-specific response rendering
+- `src/hook/apply_patch.rs` - Codex apply_patch normalization
 - `src/cmd/claude/hook.rs` - Hook command: deserializes input, evaluates rules, emits response
 - `src/cmd/claude/setup.rs` - Setup command: configures hooks in settings.local.json
 - `src/cmd/claude/docs.rs` - Docs command: prints rule writing guide
+- `src/cmd/codex/hook.rs` - Hook command: deserializes input, evaluates rules, emits response
+- `src/cmd/codex/setup.rs` - Setup command: configures hooks in hooks.json
+- `src/cmd/codex/docs.rs` - Docs command: prints rule writing guide
 - `src/cmd/test.rs` - Test command: test a rule against sample input
 - `src/cmd/validate.rs` - Validate command: parse and display rule configs
 - `src/cmd/check.rs` - Check command: validate project files against rules for CI
 - `src/rules.rs` - Rule loading from config files
-- `src/rules/schema.rs` - Rule schema types and matchers (serde types that double as evaluators)
-- `src/claude/hook.rs` - Hook payload and response types
+- `src/rules/schema.rs` - Rule schema types and matchers
 - `src/snippet.rs` - Code snippet rendering for rule violations (uses `annotate-snippets`)
 
 ### How Nudge Communicates
 
 When Nudge has something to share, it responds in one of three ways:
 
-- **Passthrough**: Nothing to note—carry on!
+- **Passthrough**: Nothing to note. Carry on!
 - **Continue**: For UserPromptSubmit hooks, Nudge injects context as plain text
 - **Interrupt**: For PreToolUse hooks, Nudge blocks the operation and explains what to fix
 
 The response type is determined by the hook type:
-- `PreToolUse` rules always **interrupt** (block the Write/Edit operation)
+- `PreToolUse` rules always **interrupt** (block provider-supported Write/Edit/WebFetch/Bash operations)
 - `UserPromptSubmit` rules always **continue** (inject guidance into the conversation)
+- `PermissionRequest` is parsed but always **passes through** until Nudge has a permission-specific rule surface
+- `Delete` is normalized but not yet matchable from YAML rules
 
 ## Keeping Documentation in Sync
 
@@ -87,12 +102,12 @@ Nudge has three documentation sources that must stay aligned. When updating one,
 |----------|----------|---------|-------|
 | **CLAUDE.md** | You, developing Nudge | How Nudge works under the hood | Architecture, internals, testing patterns |
 | **README.md** | Humans evaluating or contributing | Why Nudge exists and what it believes | Philosophy, motivation, the collaborative framing |
-| **`nudge claude docs`** | You or humans writing rules elsewhere | How to write rules (reference card) | Rule syntax, examples |
+| **`nudge claude docs` / `nudge codex docs`** | You or humans writing rules elsewhere | How to write rules (reference card) | Rule syntax, examples |
 
-**CLAUDE.md** (this file) is for *developing* Nudge—understanding the module layout, how to add features, how tests work.
+**CLAUDE.md** (this file) is for *developing* Nudge - understanding the module layout, how to add features, how tests work.
 
-**README.md** is for *understanding* Nudge—the philosophy that Nudge is a collaborative partner, why directness matters, how to write effective rules. This is the front door; it needs to convey the spirit.
+**README.md** is for *understanding* Nudge - the philosophy that Nudge is a collaborative partner, why directness matters, how to write effective rules. This is the front door; it needs to convey the spirit.
 
-**`nudge claude docs`** (`src/cmd/claude/docs.rs`) is for *using* Nudge—a self-contained reference that future Claude instances or humans can consult when writing rules. It should be scannable, copy-pasteable, and not assume any prior context.
+**`nudge claude docs` / `nudge codex docs`** (`src/cmd/claude/docs.rs`, `src/cmd/codex/docs.rs`) is for *using* Nudge - a self-contained reference that future agents or humans can consult when writing rules. It should be scannable, copy-pasteable, and not assume any prior context.
 
 When you change something fundamental (like changing the rule format or refining the collaborative framing), update all three.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nudge
 
-Nudge is a **collaborative memory layer** for Claude Code. It remembers the coding conventions, patterns, and preferences that matter to you- so Claude can focus on solving your actual problem instead of tracking a mental checklist of stylistic details.
+Nudge is a **collaborative memory layer** for agent hooks. It remembers the coding conventions, patterns, and preferences that matter to you so Claude Code or Codex CLI can focus on solving your actual problem instead of tracking a mental checklist of stylistic details.
 
 Think of Nudge as a helpful tap on the shoulder: *"Hey, remember this codebase uses turbofish syntax"* rather than a guard checking badges at the door.
 
@@ -8,23 +8,28 @@ Think of Nudge as a helpful tap on the shoulder: *"Hey, remember this codebase u
 
 ## The Problem Nudge Solves
 
-Human engineers are (rightfully!) particular about code style. But asking Claude to keep dozens of project-specific preferences in working memory competes with focusing on what you actually want to accomplish.
+Human engineers are (rightfully!) particular about code style. But asking an agent to keep dozens of project-specific preferences in working memory competes with focusing on what you actually want to accomplish.
 
-Nudge offloads those details. You encode your preferences once, and Nudge catches the slips- freeing both you and Claude to think at the level of *"implement this feature"* rather than *"implement this feature, and remember the 47 things I care about."*
+Nudge offloads those details. You encode your preferences once, and Nudge catches the slips, freeing both you and the agent to think at the level of *"implement this feature"* rather than *"implement this feature, and remember the 47 things I care about."*
 
 ## How It Works
 
-Nudge uses Claude Code's [hooks system](https://docs.anthropic.com/en/docs/claude-code/hooks) to watch what it does. When something matches a rule you've defined:
+Nudge uses agent hook systems to watch supported operations:
+
+- [Claude Code hooks](https://docs.anthropic.com/en/docs/claude-code/hooks)
+- [Codex CLI hooks](https://developers.openai.com/codex/hooks)
+
+When something matches a rule you've defined:
 
 - **Interrupt** (PreToolUse rules): Nudge catches the issue *before* it's written and explains what to fix
-- **Continue** (UserPromptSubmit rules): Nudge injects context into the conversation to guide Claude
+- **Continue** (UserPromptSubmit rules): Nudge injects context into the conversation to guide the agent
 - **Passthrough**: No rules matched, everything proceeds normally
 
 ## Example Rules
 
 These are the rules Nudge uses on its own codebase (yes, we dogfood):
 
-| Preference           | What Nudge reminds Claude about                            |
+| Preference           | What Nudge reminds agents about                            |
 |----------------------|-------------------------------------------------------------|
 | No inline imports    | Move `use` statements to the top of the file                |
 | LHS type annotations | Prefer turbofish (`::<T>`) over `let x: T = ...`            |
@@ -38,7 +43,7 @@ Other Attune codebases of course have other rules.
 
 Nudge is a collaborative partner, but **trusted partners can be blunt**.
 
-When Claude is deep in implementation, gentle suggestions get lost in the noise. A soft *"you might want to consider..."* will likely be ignored. A direct *"Stop. Move this import to the top of the file."* gets attention.
+When an agent is deep in implementation, gentle suggestions get lost in the noise. A soft *"you might want to consider..."* will likely be ignored. A direct *"Stop. Move this import to the top of the file."* gets attention.
 
 This isn't about being harsh, it's about being effective. Think of a rally copilot: they say "HARD LEFT NOW" not because they're angry, but because that's what cuts through when the driver is focused. The trust is what *allows* the directness.
 
@@ -46,13 +51,13 @@ This isn't about being harsh, it's about being effective. Think of a rally copil
 
 - **Be specific**: "Move this import to the top of the file" not "Consider reorganizing imports"
 - **Be direct**: "Stop. Fix this first." not "You might want to think about..."
-- **Explain why** (briefly): "Use turbofish—LHS annotations clutter the variable name"
+- **Explain why** (briefly): "Use turbofish; LHS annotations clutter the variable name"
 - **Give the fix**: Don't just say what's wrong; say what to do instead
-- **Use suggestions**: Capture groups let you generate context-aware fixes (see `nudge claude docs`)
-- **End with "then retry"**: Tell Claude to retry the operation after fixing
+- **Use suggestions**: Capture groups let you generate context-aware fixes (see `nudge claude docs` or `nudge codex docs`)
+- **End with "then retry"**: Tell the agent to retry the operation after fixing
 - **Write for one match**: Your message appears at each match location in a code snippet
 
-Nudge displays violations like Rust compiler errors—your message appears directly at the matched code:
+Nudge displays violations like Rust compiler errors. Your message appears directly at the matched code:
 
 ```
 error: rule violation
@@ -64,17 +69,17 @@ error: rule violation
   |
 ```
 
-The pattern: **what's wrong** → **how to fix** → **retry**.
+The pattern: **what's wrong** -> **how to fix** -> **retry**.
 
-For the full rule syntax and copy-pasteable examples, run `nudge claude docs`.
+For the full rule syntax and copy-pasteable examples, run `nudge claude docs` or `nudge codex docs`.
 
 ### Rule Writing Is Iterative
 
-If Claude ignores a rule, **the fix is usually to make the message more direct**, not to give up on the rule.
+If an agent ignores a rule, **the fix is usually to make the message more direct**, not to give up on the rule.
 
-Attune dogfoods Nudge on its own codebase and on other codebases we manage. When we notice Claude routing around a rule or missing the point, we tune the message until it lands. Treat ignored rules as feedback on clarity, not evidence that rules don't work.
+Attune dogfoods Nudge on its own codebase and on other codebases we manage. When we notice an agent routing around a rule or missing the point, we tune the message until it lands. Treat ignored rules as feedback on clarity, not evidence that rules don't work.
 
-The collaborative spirit lives in *why* Nudge exists (to help Claude focus on your real problem), not in tiptoeing around feedback.
+The collaborative spirit lives in *why* Nudge exists (to help the agent focus on your real problem), not in tiptoeing around feedback.
 
 ## Setup
 
@@ -102,30 +107,31 @@ cargo install --path packages/nudge
 
 ### 2. Install Hooks in Your Project
 
-Navigate to any project where you use Claude Code and run:
+Navigate to any project where you use Claude Code or Codex CLI and run the setup for the agent you use:
 
 ```bash
 nudge claude setup
+nudge codex setup
 ```
 
-This adds Nudge to `.claude/settings.local.json`. You can verify with `/hooks` in Claude Code.
+Claude setup adds Nudge to `.claude/settings.local.json`. Codex setup adds Nudge to `.codex/hooks.json`. You can verify with `/hooks` in the relevant agent.
 
 > [!NOTE]
-> Claude Code loads hooks on startup, so you'll need to restart open sessions (`claude -c` is an easy way to do this without breaking your flow). Future changes to rules are internal to Nudge and therefore do not need a Claude Code restart.
+> Hook configuration is loaded when agent sessions start, so restart open Claude Code or Codex sessions after setup. Future changes to rules are internal to Nudge and therefore do not need an agent restart.
 
-### 3. Use Claude Code Normally
+### 3. Use Your Agent Normally
 
-Nudge runs automatically as you use Claude Code. No changes to your workflow required.
+Nudge runs automatically as you use Claude Code or Codex CLI. No changes to your workflow required.
 
 ## Seeing It Work
 
 ### In Practice
 
-Write some rules for things that you want to be enforced, and then just use Claude Code normally. You should see Nudge interject when the rules are violated and help Claude stay on track.
+Write some rules for things that you want to be enforced, and then just use your agent normally. You should see Nudge interject when the rules are violated and help the agent stay on track.
 
 ### Debug Mode
 
-Run Claude Code with debug logging to see hook execution:
+Run your agent with debug logging to see hook execution. For Claude Code:
 
 ```bash
 claude --debug
@@ -135,7 +141,7 @@ You'll see Nudge's hook being called and its response in the logs.
 
 ### CI / Linting Mode
 
-Use `nudge check` to validate your entire project against rules—useful for CI pipelines or local linting:
+Use `nudge check` to validate your entire project against rules, useful for CI pipelines or local linting:
 
 ```bash
 # Check entire project
@@ -152,7 +158,7 @@ nudge check || exit 1
 Example output when violations are found:
 
 ```
-✗ Found 3 issues in 2 files
+x Found 3 issues in 2 files
 
 ./src/main.rs:42 [no-unwrap]
   Use `.expect("descriptive error message")` instead of `.unwrap()`, then retry.
@@ -169,7 +175,7 @@ Checked 25 files against 6 rules
 When all checks pass:
 
 ```
-✓ Checked 25 files against 6 rules
+Checked 25 files against 6 rules
   - .nudge.yaml: 6 rules
 ```
 
@@ -198,6 +204,17 @@ echo '{
     "content": "fn main() {\n    use std::io;\n}"
   }
 }' | nudge claude hook
+
+# Codex sends apply_patch for file writes and edits; Nudge normalizes those
+# into Write/Edit/Delete before evaluating rules.
+echo '{
+  "hook_event_name": "PreToolUse",
+  "cwd": "/tmp",
+  "tool_name": "apply_patch",
+  "tool_input": {
+    "command": "*** Begin Patch\n*** Add File: test.rs\n+fn main() {\n+    use std::io;\n+}\n*** End Patch\n"
+  }
+}' | nudge codex hook
 
 # Exit 0 with JSON output = Interrupt (rule matched, operation blocked)
 # Exit 0 with plain text = Continue (UserPromptSubmit context injected)

--- a/docs/rfc/0002-claude-and-codex-hooks.md
+++ b/docs/rfc/0002-claude-and-codex-hooks.md
@@ -1,0 +1,641 @@
+# RFC 0002: Claude Code and Codex Hook Support
+
+## Summary
+
+Update Nudge from a Claude Code-specific hook adapter into a small agent-hook
+platform that supports both Claude Code and Codex CLI.
+
+The clean architecture is:
+
+1. Parse each agent's hook wire format at the CLI boundary.
+2. Normalize supported events into Nudge's own event model.
+3. Evaluate existing Nudge rules against the normalized event.
+4. Render an agent-specific hook response at the boundary.
+
+This preserves the rule language users already write while making the hook
+integration explicit, testable, and extensible.
+
+## Research Snapshot
+
+Research date: 2026-05-27.
+
+Primary sources:
+
+- Codex hooks guide: <https://developers.openai.com/codex/hooks>
+- Codex config reference: <https://developers.openai.com/codex/config-reference>
+- Claude Code hooks reference: <https://code.claude.com/docs/en/hooks>
+
+### Codex Hooks
+
+Codex hooks are enabled by default and can be disabled with:
+
+```toml
+[features]
+hooks = false
+```
+
+Codex discovers hook configuration in `hooks.json` files or inline `[hooks]`
+tables next to active config layers. The practical project-local locations are:
+
+- `.codex/hooks.json`
+- `.codex/config.toml`
+
+Codex also supports user-level equivalents under `~/.codex`. Project-local
+hooks only load when the project `.codex/` layer is trusted. Non-managed command
+hooks must be reviewed and trusted with `/hooks` before they run.
+
+The config shape mirrors Claude's three-level model:
+
+- Event name, such as `PreToolUse` or `UserPromptSubmit`
+- Matcher group
+- One or more hook handlers
+
+Command hooks receive one JSON object on stdin. The events Nudge needs first are:
+
+- `PreToolUse`
+- `UserPromptSubmit`
+
+For `PreToolUse`, Codex currently intercepts Bash, `apply_patch`, and MCP tool
+calls. It does not currently intercept all shell paths under unified exec, and
+it does not intercept WebSearch or other non-shell, non-MCP tools.
+
+Codex `PreToolUse` input for Bash and `apply_patch` uses:
+
+- `hook_event_name: "PreToolUse"`
+- `tool_name: "Bash"` or `"apply_patch"`
+- `tool_input.command`
+
+For `apply_patch`, matcher aliases can include `Edit` or `Write`, but the hook
+input still reports `tool_name: "apply_patch"`.
+
+Codex `UserPromptSubmit` input includes:
+
+- `hook_event_name: "UserPromptSubmit"`
+- `prompt`
+
+Codex `PreToolUse` denial should be returned through the hook-specific shape:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "Destructive command blocked by hook."
+  }
+}
+```
+
+Important compatibility detail: Codex documents `continue`, `stopReason`, and
+`suppressOutput` as unsupported for `PreToolUse`. Returning those fields on
+`PreToolUse` makes the hook run fail and Codex continues the tool call. Nudge's
+current Claude response envelope includes those fields, so Codex needs a
+separate response renderer or a reduced common renderer that omits unsupported
+fields.
+
+For `UserPromptSubmit`, plain stdout is added as extra developer context. JSON
+with `hookSpecificOutput.additionalContext` is also supported.
+
+### Claude Code Hooks
+
+Claude Code discovers hooks in:
+
+- `~/.claude/settings.json`
+- `.claude/settings.json`
+- `.claude/settings.local.json`
+- managed policy settings
+- plugin `hooks/hooks.json`
+- skill or agent frontmatter while active
+
+Claude uses the same broad three-level shape:
+
+- Event name
+- Matcher group
+- Hook handler
+
+Claude supports more hook handler types than Codex today: `command`, `http`,
+`mcp_tool`, `prompt`, and `agent`. Nudge should continue installing only command
+hooks.
+
+Claude's matcher behavior differs from Codex:
+
+- `"*"`, `""`, or missing means match all.
+- Simple strings with `|` are exact alternatives.
+- Values containing other characters are JavaScript regular expressions.
+- Tool events match on `tool_name`.
+
+Claude supports the Nudge-relevant tool names directly:
+
+- `Write`
+- `Edit`
+- `WebFetch`
+- `Bash`
+
+Claude `PreToolUse` denial supports the same hook-specific output Nudge already
+uses:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "Database writes are not allowed"
+  }
+}
+```
+
+Claude also accepts extra common fields, but Nudge does not need them for
+blocking a tool call.
+
+For `UserPromptSubmit`, plain stdout is added to Claude's context.
+
+## Current Nudge Shape
+
+Today the public CLI is Claude-shaped:
+
+- `nudge claude hook`
+- `nudge claude setup`
+- `nudge claude docs`
+- `nudge claude run`
+
+The Rust model is also Claude-shaped:
+
+- `packages/nudge/src/claude/hook.rs`
+- `packages/nudge/src/cmd/claude/hook.rs`
+- `packages/nudge/src/cmd/claude/setup.rs`
+
+The rule engine itself is mostly generic. Rules already name lifecycle concepts
+instead of Claude-specific APIs:
+
+- `PreToolUse`
+- `UserPromptSubmit`
+- `Write`
+- `Edit`
+- `WebFetch`
+- `Bash`
+
+That is the right user-facing vocabulary. The problem is that internal payload
+types and response serialization are coupled to Claude's wire format.
+
+## Goals
+
+- Support Claude Code and Codex CLI with one rule language.
+- Keep `PreToolUse` and `UserPromptSubmit` as the first supported events.
+- Preserve existing rule files without requiring users to fork rules per agent.
+- Correctly block Codex `PreToolUse` calls by avoiding unsupported response
+  fields.
+- Make Codex `apply_patch` useful for existing `Write` and `Edit` file-content
+  rules.
+- Model file deletion as a first-class normalized tool event.
+- Keep setup idempotent and avoid clobbering unrelated user settings.
+- Update README, command docs, and repository agent instructions together.
+
+## Non-Goals
+
+- Support every Claude hook event in this update.
+- Support every Codex hook event in this update.
+- Add natural-language or model-judged rules.
+- Implement HTTP, MCP-tool, prompt, or agent hook handlers.
+- Claim Codex can enforce WebSearch/WebFetch rules when current Codex hooks do
+  not intercept that path.
+
+## Design
+
+### CLI Surface
+
+Add a Codex namespace alongside the existing Claude namespace:
+
+```bash
+nudge claude hook
+nudge claude setup
+nudge claude docs
+
+nudge codex hook
+nudge codex setup
+nudge codex docs
+```
+
+Keep `nudge claude run` as Claude-only. There is no Codex equivalent in this
+update.
+
+Add a future-friendly top-level setup convenience after the core support lands:
+
+```bash
+nudge setup --agent claude
+nudge setup --agent codex
+nudge setup --agent all
+```
+
+That convenience should call the same setup implementations as the provider
+namespaces. It is optional for this RFC because the important compatibility
+contract is the installed hook command.
+
+### Internal Modules
+
+Replace the Claude-specific hook domain model with an agent-neutral one:
+
+```text
+packages/nudge/src/agent.rs
+packages/nudge/src/agent/claude.rs
+packages/nudge/src/agent/codex.rs
+packages/nudge/src/hook.rs
+packages/nudge/src/hook/evaluate.rs
+packages/nudge/src/hook/response.rs
+packages/nudge/src/hook/apply_patch.rs
+```
+
+Suggested responsibilities:
+
+- `agent/claude.rs`: parse Claude hook JSON, emit Claude setup JSON.
+- `agent/codex.rs`: parse Codex hook JSON, emit Codex setup JSON.
+- `hook.rs`: normalized Nudge event types.
+- `hook/evaluate.rs`: rule evaluation over normalized events.
+- `hook/response.rs`: abstract Nudge outcomes plus provider-specific rendering.
+- `hook/apply_patch.rs`: parse Codex `apply_patch` commands into file changes.
+
+The existing `packages/nudge/src/claude/hook.rs` should be split rather than
+grown. Leaving it as the center would make Codex support feel bolted on.
+
+### Normalized Event Model
+
+Define a normalized event enum:
+
+```rust
+pub enum NudgeHook {
+    PreToolUse(PreToolUse),
+    UserPromptSubmit(UserPromptSubmit),
+    Other,
+}
+```
+
+Define `PreToolUse` around what rules need:
+
+```rust
+pub struct PreToolUse {
+    pub context: HookContext,
+    pub tool: ToolUse,
+}
+
+pub enum ToolUse {
+    Write(WriteInput),
+    Edit(EditInput),
+    Delete(DeleteInput),
+    WebFetch(WebFetchInput),
+    Bash(BashInput),
+    Other { tool_name: String, input: serde_json::Value },
+}
+```
+
+`HookContext` should include only shared or useful metadata:
+
+```rust
+pub struct HookContext {
+    pub agent: AgentKind,
+    pub session_id: Option<String>,
+    pub turn_id: Option<String>,
+    pub transcript_path: Option<PathBuf>,
+    pub cwd: PathBuf,
+    pub permission_mode: Option<String>,
+    pub model: Option<String>,
+}
+```
+
+Use `Option` for fields that differ across providers. Parse at the boundary and
+avoid sprinkling provider checks through rule evaluation.
+
+### Provider Mapping
+
+Claude maps directly:
+
+| Claude input | Normalized event |
+| --- | --- |
+| `PreToolUse` + `tool_name: "Write"` | `ToolUse::Write` |
+| `PreToolUse` + `tool_name: "Edit"` | `ToolUse::Edit` |
+| `PreToolUse` + `tool_name: "WebFetch"` | `ToolUse::WebFetch` |
+| `PreToolUse` + `tool_name: "Bash"` | `ToolUse::Bash` |
+| `UserPromptSubmit` | `NudgeHook::UserPromptSubmit` |
+
+Codex maps as follows:
+
+| Codex input | Normalized event |
+| --- | --- |
+| `PreToolUse` + `tool_name: "Bash"` | `ToolUse::Bash` from `tool_input.command` |
+| `PreToolUse` + `tool_name: "apply_patch"` add file | `ToolUse::Write` per added file |
+| `PreToolUse` + `tool_name: "apply_patch"` update file | `ToolUse::Edit` per updated file |
+| `PreToolUse` + `tool_name: "apply_patch"` delete file | `ToolUse::Delete` per deleted file |
+| `PreToolUse` + MCP tool | `Other` until rules support MCP-specific matching |
+| `UserPromptSubmit` | `NudgeHook::UserPromptSubmit` |
+
+Codex `apply_patch` can contain multiple file changes. A single raw hook may
+normalize to multiple Nudge `PreToolUse` events. Evaluate all of them and emit
+one response that aggregates all matches.
+
+### Codex `apply_patch` Handling
+
+Codex file edits generally arrive as `apply_patch`, so this is required for
+existing file-content rules to work.
+
+Implement a small parser for the patch format used by the `apply_patch` tool:
+
+- `*** Begin Patch`
+- `*** Add File: <path>`
+- `*** Update File: <path>`
+- `*** Delete File: <path>`
+- optional `*** Move to: <path>`
+- `*** End Patch`
+
+For added files:
+
+- Collect added lines.
+- Normalize into `WriteInput { file_path, content }`.
+
+For updated files:
+
+- Read the current file from `cwd`.
+- Apply hunks in memory.
+- Normalize into `EditInput { file_path, old_string, new_string }`, where
+  `new_string` is the full post-patch file content.
+
+For moved files:
+
+- Use the destination path for file glob matching.
+
+For deleted files:
+
+- Normalize into `DeleteInput { file_path }`.
+- This should be a first-class `ToolUse::Delete` event even before the YAML rule
+  language grows delete-specific matchers. A deleted file is not an "other" tool
+  use; it is a concrete file operation that future rules and audit output should
+  be able to name precisely.
+
+If patch parsing fails:
+
+- Do not block the tool call.
+- Emit a tracing warning.
+- In debug mode, tell the user Nudge could not inspect that patch.
+
+Fail-open is appropriate here because Nudge is a collaborative reminder layer.
+Blocking every unparseable patch would make it feel hostile.
+
+### Rule Evaluation
+
+Move rule evaluation out of `cmd/claude/hook.rs` into a provider-neutral
+function:
+
+```rust
+pub fn evaluate_hook(hook: &NudgeHook, rules: &[Rule]) -> Evaluation;
+```
+
+`Evaluation` should collect:
+
+- matched annotations
+- source text for snippet rendering
+- matched rule names
+- desired Nudge outcome
+
+The existing behavior remains:
+
+- `PreToolUse` matches produce a blocking denial.
+- `UserPromptSubmit` matches produce context on stdout.
+- No matches produce no output and exit 0.
+
+### Response Rendering
+
+Define an abstract outcome:
+
+```rust
+pub enum HookOutcome {
+    Passthrough,
+    DenyPreToolUse { message: String },
+    AddContext { context: String },
+}
+```
+
+Render it per agent:
+
+Claude `DenyPreToolUse`:
+
+```json
+{
+  "systemMessage": "Nudge blocked operation due to rule violation.",
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "<message>"
+  }
+}
+```
+
+Codex `DenyPreToolUse`:
+
+```json
+{
+  "systemMessage": "Nudge blocked operation due to rule violation.",
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "<message>"
+  }
+}
+```
+
+Do not include `continue`, `stopReason`, or `suppressOutput` on `PreToolUse`.
+This is the key wire-format fix for Codex.
+
+For `UserPromptSubmit`, prefer plain stdout for both agents. It is simple and
+documented by both hook systems as model-visible context.
+
+### Setup
+
+Claude setup should continue writing `.claude/settings.local.json`, but it
+should only install events Nudge actually handles:
+
+- `PreToolUse`
+- `UserPromptSubmit`
+
+The current setup also installs `PostToolUse` and `Stop`, but the hook command
+passes those through. Remove them. This is a behavior change, but it reduces
+unnecessary hook executions and makes setup honest.
+
+Claude `PreToolUse` matcher should be narrower than `"*"`:
+
+```json
+{
+  "matcher": "Write|Edit|WebFetch|Bash",
+  "hooks": [
+    {
+      "type": "command",
+      "command": "<nudge> claude hook",
+      "timeout": 5
+    }
+  ]
+}
+```
+
+Codex setup should write `.codex/hooks.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|apply_patch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "<nudge> codex hook",
+            "timeout": 5,
+            "statusMessage": "Checking Nudge rules"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "<nudge> codex hook",
+            "timeout": 5,
+            "statusMessage": "Checking Nudge rules"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Use `hooks.json` rather than inline `[hooks]` in `.codex/config.toml` because
+Nudge already has safe JSON merge behavior and Codex warns when a single layer
+contains both representations. If `.codex/config.toml` already contains inline
+hooks, setup should warn and skip automatic merge unless we add a TOML-preserving
+editor.
+
+Codex setup should print these next steps:
+
+1. Restart Codex sessions so hooks are loaded.
+2. Run `/hooks`.
+3. Review and trust the new Nudge hooks.
+4. If hooks do not appear, check that the project `.codex/` layer is trusted and
+   `[features].hooks` has not been disabled.
+
+### Documentation
+
+Update these together:
+
+- `README.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+- `nudge claude docs`
+- new `nudge codex docs`
+
+README should describe Nudge as supporting "agent hooks" and then name the
+current integrations:
+
+- Claude Code
+- Codex CLI
+
+The rule writing guide should state provider support per tool:
+
+| Rule target | Claude Code | Codex |
+| --- | --- | --- |
+| `PreToolUse Write` | yes | yes, through `apply_patch` add-file parsing |
+| `PreToolUse Edit` | yes | yes, through `apply_patch` update parsing |
+| `PreToolUse Delete` | no current direct rule target | yes, through `apply_patch` delete-file parsing |
+| `PreToolUse WebFetch` | yes | no, current Codex hooks do not intercept WebSearch |
+| `PreToolUse Bash` | yes | partial, current Codex hook coverage is documented as incomplete for some unified exec paths |
+| `UserPromptSubmit` | yes | yes |
+
+### Validation and Warnings
+
+`nudge validate` should warn when a project appears to target Codex and contains
+rules that cannot fire there, especially `WebFetch`.
+
+The warning should be informational, not a failure:
+
+```text
+warning: rule "prefer-local-docs" uses PreToolUse WebFetch, which Claude Code
+supports but Codex hooks do not currently intercept.
+```
+
+### Tests
+
+Add provider-neutral unit tests:
+
+- Claude `Write` payload normalizes to `ToolUse::Write`.
+- Claude `Edit` payload normalizes to `ToolUse::Edit`.
+- Claude `Bash` payload normalizes to `ToolUse::Bash`.
+- Claude `UserPromptSubmit` normalizes to prompt text.
+- Codex `Bash` payload normalizes to `ToolUse::Bash`.
+- Codex `UserPromptSubmit` normalizes to prompt text.
+- Codex `apply_patch` add-file normalizes to `ToolUse::Write`.
+- Codex `apply_patch` update-file normalizes to `ToolUse::Edit`.
+- Codex `apply_patch` delete-file normalizes to `ToolUse::Delete`.
+- Codex multi-file patch aggregates all matches into one denial.
+- Codex unsupported MCP tool passes through.
+
+Add response renderer tests:
+
+- Claude denial JSON contains `permissionDecision: "deny"`.
+- Codex denial JSON contains `permissionDecision: "deny"`.
+- Codex denial JSON does not contain `continue`, `stopReason`, or
+  `suppressOutput`.
+- UserPromptSubmit context renders as plain text for both agents.
+
+Add setup tests:
+
+- `nudge claude setup` is idempotent.
+- `nudge codex setup` creates `.codex/hooks.json`.
+- `nudge codex setup` is idempotent.
+- Existing unrelated hook config is preserved.
+- Existing inline Codex hooks in `.codex/config.toml` produce a warning rather
+  than an unsafe merge.
+
+Add integration tests:
+
+- Existing Claude integration tests still pass via `nudge claude hook`.
+- Equivalent Codex tests pass via `nudge codex hook`.
+- A Codex `apply_patch` payload that writes Rust with an inline import is
+  blocked by the existing `no-inline-imports` rule.
+
+## Migration Plan
+
+1. Introduce normalized hook types and move evaluation into provider-neutral
+   code.
+2. Rewire `nudge claude hook` through the normalized path with no intended
+   behavior change except the reduced PreToolUse JSON envelope.
+3. Add `nudge codex hook` and Codex response rendering.
+4. Add Codex `apply_patch` parsing and multi-change aggregation.
+5. Add `nudge codex setup`.
+6. Narrow Claude setup to the supported events and tools.
+7. Update docs and repository instructions.
+8. Run:
+
+```bash
+cargo fmt --all
+cargo test -p nudge
+cargo run -p nudge -- claude docs
+cargo run -p nudge -- codex docs
+```
+
+## Breaking Changes
+
+- `nudge claude setup` should stop installing `PostToolUse` and `Stop` because
+  Nudge does not currently handle those events.
+- PreToolUse response JSON should omit common fields that Nudge does not need.
+  Claude should still honor the denial, and Codex requires this cleaner shape.
+- Documentation should stop describing Nudge as Claude-only.
+
+## Open Questions
+
+- Should the rule language gain an explicit `tool: ApplyPatch` target, or should
+  Codex `apply_patch` remain an implementation detail behind `Write` and `Edit`?
+  Recommendation: keep it hidden until users need patch-specific rules.
+- Should the rule language gain explicit `tool: Delete` matchers in this update?
+  Recommendation: normalize deletion now, then add YAML matchers when we have a
+  concrete deletion policy to express.
+- Should setup support a committed `.codex/hooks.json` option in addition to
+  local setup? Recommendation: default to project-local `.codex/hooks.json`
+  because Codex requires hook trust review anyway, then revisit after real use.
+- Should `nudge check` understand Codex patch files? Recommendation: no. `check`
+  validates repository files, not hook payloads.

--- a/docs/rfc/0002-claude-and-codex-hooks.md
+++ b/docs/rfc/0002-claude-and-codex-hooks.md
@@ -50,7 +50,8 @@ The config shape mirrors Claude's three-level model:
 - Matcher group
 - One or more hook handlers
 
-Command hooks receive one JSON object on stdin. The events Nudge needs first are:
+Command hooks receive one JSON object on stdin. The events Nudge should install
+and evaluate first are:
 
 - `PreToolUse`
 - `UserPromptSubmit`
@@ -58,6 +59,11 @@ Command hooks receive one JSON object on stdin. The events Nudge needs first are
 For `PreToolUse`, Codex currently intercepts Bash, `apply_patch`, and MCP tool
 calls. It does not currently intercept all shell paths under unified exec, and
 it does not intercept WebSearch or other non-shell, non-MCP tools.
+
+Codex also supports `PermissionRequest` for approval prompts. Nudge should
+parse that event into its normalized model in this update, but it should not
+install `PermissionRequest` hooks or evaluate rules against approval prompts
+until Nudge has a permission-specific rule surface.
 
 Codex `PreToolUse` input for Bash and `apply_patch` uses:
 
@@ -130,6 +136,9 @@ Claude supports the Nudge-relevant tool names directly:
 - `WebFetch`
 - `Bash`
 
+Claude also exposes MCP tools in hook events. Nudge should preserve those as
+`Other`, matching the existing behavior for unsupported tool names.
+
 Claude `PreToolUse` denial supports the same hook-specific output Nudge already
 uses:
 
@@ -179,20 +188,26 @@ types and response serialization are coupled to Claude's wire format.
 ## Goals
 
 - Support Claude Code and Codex CLI with one rule language.
-- Keep `PreToolUse` and `UserPromptSubmit` as the first supported events.
+- Keep `PreToolUse` and `UserPromptSubmit` as the first rule-evaluated events.
 - Preserve existing rule files without requiring users to fork rules per agent.
 - Correctly block Codex `PreToolUse` calls by avoiding unsupported response
   fields.
 - Make Codex `apply_patch` useful for existing `Write` and `Edit` file-content
   rules.
 - Model file deletion as a first-class normalized tool event.
+- Parse `PermissionRequest` into a normalized event for both agents, without
+  making it rule-matchable in this update.
 - Keep setup idempotent and avoid clobbering unrelated user settings.
+- Keep setup local to each agent's standard local hook configuration.
 - Update README, command docs, and repository agent instructions together.
 
 ## Non-Goals
 
 - Support every Claude hook event in this update.
 - Support every Codex hook event in this update.
+- Match rules against `PermissionRequest` or make approval decisions from
+  Nudge rules.
+- Add YAML rule matching for file deletion.
 - Add natural-language or model-judged rules.
 - Implement HTTP, MCP-tool, prompt, or agent hook handlers.
 - Claim Codex can enforce WebSearch/WebFetch rules when current Codex hooks do
@@ -216,18 +231,6 @@ nudge codex docs
 
 Keep `nudge claude run` as Claude-only. There is no Codex equivalent in this
 update.
-
-Add a future-friendly top-level setup convenience after the core support lands:
-
-```bash
-nudge setup --agent claude
-nudge setup --agent codex
-nudge setup --agent all
-```
-
-That convenience should call the same setup implementations as the provider
-namespaces. It is optional for this RFC because the important compatibility
-contract is the installed hook command.
 
 ### Internal Modules
 
@@ -262,6 +265,7 @@ Define a normalized event enum:
 ```rust
 pub enum NudgeHook {
     PreToolUse(PreToolUse),
+    PermissionRequest(PermissionRequest),
     UserPromptSubmit(UserPromptSubmit),
     Other,
 }
@@ -275,6 +279,11 @@ pub struct PreToolUse {
     pub tool: ToolUse,
 }
 
+pub struct PermissionRequest {
+    pub context: HookContext,
+    pub tool: ToolUse,
+}
+
 pub enum ToolUse {
     Write(WriteInput),
     Edit(EditInput),
@@ -284,6 +293,12 @@ pub enum ToolUse {
     Other { tool_name: String, input: serde_json::Value },
 }
 ```
+
+`PermissionRequest` exists so the CLI boundary can parse current agent hook
+payloads without treating them as unknown JSON. Rule evaluation must return
+passthrough for `PermissionRequest` in this RFC. Nudge should not approve,
+deny, rewrite, or add context to approval prompts until the rule language has a
+clear permission-specific policy surface.
 
 `HookContext` should include only shared or useful metadata:
 
@@ -312,6 +327,8 @@ Claude maps directly:
 | `PreToolUse` + `tool_name: "Edit"` | `ToolUse::Edit` |
 | `PreToolUse` + `tool_name: "WebFetch"` | `ToolUse::WebFetch` |
 | `PreToolUse` + `tool_name: "Bash"` | `ToolUse::Bash` |
+| `PreToolUse` + MCP tool | `ToolUse::Other` |
+| `PermissionRequest` | `NudgeHook::PermissionRequest`, parsed but unmatchable |
 | `UserPromptSubmit` | `NudgeHook::UserPromptSubmit` |
 
 Codex maps as follows:
@@ -322,7 +339,8 @@ Codex maps as follows:
 | `PreToolUse` + `tool_name: "apply_patch"` add file | `ToolUse::Write` per added file |
 | `PreToolUse` + `tool_name: "apply_patch"` update file | `ToolUse::Edit` per updated file |
 | `PreToolUse` + `tool_name: "apply_patch"` delete file | `ToolUse::Delete` per deleted file |
-| `PreToolUse` + MCP tool | `Other` until rules support MCP-specific matching |
+| `PreToolUse` + MCP tool | `ToolUse::Other` |
+| `PermissionRequest` | `NudgeHook::PermissionRequest`, parsed but unmatchable |
 | `UserPromptSubmit` | `NudgeHook::UserPromptSubmit` |
 
 Codex `apply_patch` can contain multiple file changes. A single raw hook may
@@ -362,10 +380,10 @@ For moved files:
 For deleted files:
 
 - Normalize into `DeleteInput { file_path }`.
-- This should be a first-class `ToolUse::Delete` event even before the YAML rule
-  language grows delete-specific matchers. A deleted file is not an "other" tool
-  use; it is a concrete file operation that future rules and audit output should
-  be able to name precisely.
+- This is a first-class `ToolUse::Delete` event, but it is not matchable from
+  YAML in this update. A deleted file is not an "other" tool use; it is a
+  concrete file operation that future rules and audit output can name
+  precisely.
 
 If patch parsing fails:
 
@@ -396,7 +414,12 @@ The existing behavior remains:
 
 - `PreToolUse` matches produce a blocking denial.
 - `UserPromptSubmit` matches produce context on stdout.
+- `PermissionRequest` always passes through in this update.
 - No matches produce no output and exit 0.
+
+`ToolUse::Delete` is also unmatchable in this update. It should be preserved in
+the normalized model and test coverage, but rule evaluation should not expose a
+YAML matcher for it until Nudge has a concrete deletion policy to express.
 
 ### Response Rendering
 
@@ -443,6 +466,9 @@ This is the key wire-format fix for Codex.
 
 For `UserPromptSubmit`, prefer plain stdout for both agents. It is simple and
 documented by both hook systems as model-visible context.
+
+For `PermissionRequest`, render `Passthrough` only. The hook command should
+exit 0 with no output for that event.
 
 ### Setup
 
@@ -505,11 +531,12 @@ Codex setup should write `.codex/hooks.json`:
 }
 ```
 
-Use `hooks.json` rather than inline `[hooks]` in `.codex/config.toml` because
-Nudge already has safe JSON merge behavior and Codex warns when a single layer
-contains both representations. If `.codex/config.toml` already contains inline
-hooks, setup should warn and skip automatic merge unless we add a TOML-preserving
-editor.
+Use local `.codex/hooks.json` rather than inline `[hooks]` in
+`.codex/config.toml` because Nudge already has safe JSON merge behavior and
+Codex warns when a single layer contains both representations. Do not add a
+committed/shared Codex setup mode in this update. If `.codex/config.toml`
+already contains inline hooks, setup should warn and skip automatic merge
+because TOML-preserving inline hook editing is out of scope.
 
 Codex setup should print these next steps:
 
@@ -535,16 +562,21 @@ current integrations:
 - Claude Code
 - Codex CLI
 
-The rule writing guide should state provider support per tool:
+The rule writing guide should state provider support per surface:
 
-| Rule target | Claude Code | Codex |
+| Surface | Claude Code | Codex |
 | --- | --- | --- |
 | `PreToolUse Write` | yes | yes, through `apply_patch` add-file parsing |
 | `PreToolUse Edit` | yes | yes, through `apply_patch` update parsing |
-| `PreToolUse Delete` | no current direct rule target | yes, through `apply_patch` delete-file parsing |
+| `PreToolUse Delete` | normalized only, no YAML matcher yet | normalized only, through `apply_patch` delete-file parsing, no YAML matcher yet |
 | `PreToolUse WebFetch` | yes | no, current Codex hooks do not intercept WebSearch |
 | `PreToolUse Bash` | yes | partial, current Codex hook coverage is documented as incomplete for some unified exec paths |
+| `PermissionRequest` | parsed only, no YAML matcher yet | parsed only, no YAML matcher yet |
 | `UserPromptSubmit` | yes | yes |
+
+Do not document `apply_patch` as a user-facing rule target. It is a significant
+mental model departure from Nudge's rule vocabulary, so the Codex adapter should
+translate it into `Write`, `Edit`, and `Delete` before rules see it.
 
 ### Validation and Warnings
 
@@ -558,6 +590,10 @@ warning: rule "prefer-local-docs" uses PreToolUse WebFetch, which Claude Code
 supports but Codex hooks do not currently intercept.
 ```
 
+`nudge check` only validates repository files today. Keep Codex patch payload
+evaluation out of `check`; hook payload behavior belongs in hook command tests
+and `nudge test`.
+
 ### Tests
 
 Add provider-neutral unit tests:
@@ -565,14 +601,19 @@ Add provider-neutral unit tests:
 - Claude `Write` payload normalizes to `ToolUse::Write`.
 - Claude `Edit` payload normalizes to `ToolUse::Edit`.
 - Claude `Bash` payload normalizes to `ToolUse::Bash`.
+- Claude `PermissionRequest` normalizes to `NudgeHook::PermissionRequest` and
+  passes through.
 - Claude `UserPromptSubmit` normalizes to prompt text.
 - Codex `Bash` payload normalizes to `ToolUse::Bash`.
+- Codex `PermissionRequest` normalizes to `NudgeHook::PermissionRequest` and
+  passes through.
 - Codex `UserPromptSubmit` normalizes to prompt text.
 - Codex `apply_patch` add-file normalizes to `ToolUse::Write`.
 - Codex `apply_patch` update-file normalizes to `ToolUse::Edit`.
 - Codex `apply_patch` delete-file normalizes to `ToolUse::Delete`.
 - Codex multi-file patch aggregates all matches into one denial.
 - Codex unsupported MCP tool passes through.
+- `ToolUse::Delete` does not match any YAML rule in this update.
 
 Add response renderer tests:
 
@@ -580,6 +621,7 @@ Add response renderer tests:
 - Codex denial JSON contains `permissionDecision: "deny"`.
 - Codex denial JSON does not contain `continue`, `stopReason`, or
   `suppressOutput`.
+- PermissionRequest renders no output for both agents.
 - UserPromptSubmit context renders as plain text for both agents.
 
 Add setup tests:
@@ -606,10 +648,11 @@ Add integration tests:
    behavior change except the reduced PreToolUse JSON envelope.
 3. Add `nudge codex hook` and Codex response rendering.
 4. Add Codex `apply_patch` parsing and multi-change aggregation.
-5. Add `nudge codex setup`.
-6. Narrow Claude setup to the supported events and tools.
-7. Update docs and repository instructions.
-8. Run:
+5. Add parsed-but-unmatchable `PermissionRequest` support for both agents.
+6. Add `nudge codex setup`.
+7. Narrow Claude setup to the supported events and tools.
+8. Update docs and repository instructions.
+9. Run:
 
 ```bash
 cargo fmt --all
@@ -622,20 +665,8 @@ cargo run -p nudge -- codex docs
 
 - `nudge claude setup` should stop installing `PostToolUse` and `Stop` because
   Nudge does not currently handle those events.
+- `nudge codex setup` should only write local `.codex/hooks.json`; it should not
+  add a committed/shared setup mode.
 - PreToolUse response JSON should omit common fields that Nudge does not need.
   Claude should still honor the denial, and Codex requires this cleaner shape.
 - Documentation should stop describing Nudge as Claude-only.
-
-## Open Questions
-
-- Should the rule language gain an explicit `tool: ApplyPatch` target, or should
-  Codex `apply_patch` remain an implementation detail behind `Write` and `Edit`?
-  Recommendation: keep it hidden until users need patch-specific rules.
-- Should the rule language gain explicit `tool: Delete` matchers in this update?
-  Recommendation: normalize deletion now, then add YAML matchers when we have a
-  concrete deletion policy to express.
-- Should setup support a committed `.codex/hooks.json` option in addition to
-  local setup? Recommendation: default to project-local `.codex/hooks.json`
-  because Codex requires hook trust review anyway, then revisit after real use.
-- Should `nudge check` understand Codex patch files? Recommendation: no. `check`
-  validates repository files, not hook payloads.

--- a/packages/nudge/src/agent.rs
+++ b/packages/nudge/src/agent.rs
@@ -1,0 +1,16 @@
+//! Agent-specific hook adapters.
+
+use serde::{Deserialize, Serialize};
+
+pub mod claude;
+pub mod codex;
+
+/// The agent that emitted a hook event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+pub enum AgentKind {
+    /// Claude Code.
+    Claude,
+
+    /// Codex CLI.
+    Codex,
+}

--- a/packages/nudge/src/agent/claude.rs
+++ b/packages/nudge/src/agent/claude.rs
@@ -1,0 +1,194 @@
+//! Claude Code hook adapter.
+
+use std::{env, path::PathBuf};
+
+use color_eyre::eyre::{Context, OptionExt, Result};
+use serde_json::Value;
+
+use crate::{
+    agent::AgentKind,
+    hook::{
+        BashInput, DeleteInput, EditInput, HookContext, NudgeHook, PermissionRequest, PreToolUse,
+        ToolUse, UserPromptSubmit, WebFetchInput, WriteInput,
+    },
+};
+
+/// Parse a Claude Code hook payload into normalized Nudge hooks.
+pub fn parse_hook(raw: Value) -> Result<Vec<NudgeHook>> {
+    let event = raw
+        .get("hook_event_name")
+        .and_then(Value::as_str)
+        .ok_or_eyre("missing hook_event_name")?;
+    let context = context(&raw, AgentKind::Claude)?;
+
+    match event {
+        "PreToolUse" => Ok(vec![NudgeHook::PreToolUse(PreToolUse {
+            tool: tool_use(&raw)?,
+            context,
+        })]),
+        "PermissionRequest" => Ok(vec![NudgeHook::PermissionRequest(PermissionRequest {
+            tool: tool_use(&raw)?,
+            context,
+        })]),
+        "UserPromptSubmit" => Ok(vec![NudgeHook::UserPromptSubmit(UserPromptSubmit {
+            prompt: string_field(&raw, "prompt")?.to_string(),
+            context,
+        })]),
+        _ => Ok(vec![NudgeHook::Other]),
+    }
+}
+
+fn context(raw: &Value, agent: AgentKind) -> Result<HookContext> {
+    let cwd = raw
+        .get("cwd")
+        .and_then(Value::as_str)
+        .map(PathBuf::from)
+        .map(Ok)
+        .unwrap_or_else(env::current_dir)
+        .context("get hook cwd")?;
+
+    Ok(HookContext {
+        agent,
+        session_id: optional_string(raw, "session_id"),
+        turn_id: optional_string(raw, "turn_id"),
+        transcript_path: optional_string(raw, "transcript_path").map(PathBuf::from),
+        cwd,
+        permission_mode: optional_string(raw, "permission_mode"),
+        model: optional_string(raw, "model"),
+    })
+}
+
+fn tool_use(raw: &Value) -> Result<ToolUse> {
+    let tool_name = string_field(raw, "tool_name")?;
+    let input = raw.get("tool_input").cloned().unwrap_or(Value::Null);
+
+    match tool_name {
+        "Write" => Ok(ToolUse::Write(WriteInput {
+            file_path: path_field(&input, "file_path")?,
+            content: string_field(&input, "content")?.to_string(),
+        })),
+        "Edit" => Ok(ToolUse::Edit(EditInput {
+            file_path: path_field(&input, "file_path")?,
+            old_string: string_field(&input, "old_string")
+                .unwrap_or_default()
+                .to_string(),
+            new_string: string_field(&input, "new_string")?.to_string(),
+        })),
+        "Delete" => Ok(ToolUse::Delete(DeleteInput {
+            file_path: path_field(&input, "file_path")?,
+        })),
+        "WebFetch" => Ok(ToolUse::WebFetch(WebFetchInput {
+            url: string_field(&input, "url")?.to_string(),
+            prompt: optional_string(&input, "prompt"),
+        })),
+        "Bash" => Ok(ToolUse::Bash(BashInput {
+            command: string_field(&input, "command")?.to_string(),
+            description: optional_string(&input, "description"),
+        })),
+        other => Ok(ToolUse::Other {
+            tool_name: other.to_string(),
+            input,
+        }),
+    }
+}
+
+fn string_field<'a>(value: &'a Value, field: &str) -> Result<&'a str> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| color_eyre::eyre::eyre!("missing string field {field}"))
+}
+
+fn optional_string(value: &Value, field: &str) -> Option<String> {
+    value.get(field).and_then(Value::as_str).map(str::to_string)
+}
+
+fn path_field(value: &Value, field: &str) -> Result<PathBuf> {
+    string_field(value, field).map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::hook::{NudgeHook, ToolUse};
+
+    use super::parse_hook;
+
+    #[test]
+    fn write_payload_normalizes_to_write() {
+        let hooks = parse_hook(json!({
+            "hook_event_name": "PreToolUse",
+            "session_id": "test",
+            "transcript_path": "/tmp/test",
+            "permission_mode": "default",
+            "cwd": "/tmp",
+            "tool_name": "Write",
+            "tool_input": { "file_path": "src.rs", "content": "fn main() {}" }
+        }))
+        .expect("parse hook");
+
+        assert!(
+            matches!(hooks.as_slice(), [NudgeHook::PreToolUse(payload)] if matches!(payload.tool, ToolUse::Write(_)))
+        );
+    }
+
+    #[test]
+    fn edit_payload_normalizes_to_edit() {
+        let hooks = parse_hook(json!({
+            "hook_event_name": "PreToolUse",
+            "cwd": "/tmp",
+            "tool_name": "Edit",
+            "tool_input": { "file_path": "src.rs", "old_string": "a", "new_string": "b" }
+        }))
+        .expect("parse hook");
+
+        assert!(
+            matches!(hooks.as_slice(), [NudgeHook::PreToolUse(payload)] if matches!(payload.tool, ToolUse::Edit(_)))
+        );
+    }
+
+    #[test]
+    fn bash_payload_normalizes_to_bash() {
+        let hooks = parse_hook(json!({
+            "hook_event_name": "PreToolUse",
+            "cwd": "/tmp",
+            "tool_name": "Bash",
+            "tool_input": { "command": "cargo test" }
+        }))
+        .expect("parse hook");
+
+        assert!(
+            matches!(hooks.as_slice(), [NudgeHook::PreToolUse(payload)] if matches!(payload.tool, ToolUse::Bash(_)))
+        );
+    }
+
+    #[test]
+    fn user_prompt_submit_normalizes_to_prompt_text() {
+        let hooks = parse_hook(json!({
+            "hook_event_name": "UserPromptSubmit",
+            "cwd": "/tmp",
+            "prompt": "hello"
+        }))
+        .expect("parse hook");
+
+        assert!(
+            matches!(hooks.as_slice(), [NudgeHook::UserPromptSubmit(payload)] if payload.prompt == "hello")
+        );
+    }
+
+    #[test]
+    fn mcp_tool_normalizes_to_other() {
+        let hooks = parse_hook(json!({
+            "hook_event_name": "PreToolUse",
+            "cwd": "/tmp",
+            "tool_name": "mcp__server__tool",
+            "tool_input": { "x": 1 }
+        }))
+        .expect("parse hook");
+
+        assert!(
+            matches!(hooks.as_slice(), [NudgeHook::PreToolUse(payload)] if matches!(payload.tool, ToolUse::Other { .. }))
+        );
+    }
+}

--- a/packages/nudge/src/agent/codex.rs
+++ b/packages/nudge/src/agent/codex.rs
@@ -1,0 +1,244 @@
+//! Codex CLI hook adapter.
+
+use std::{env, path::PathBuf};
+
+use color_eyre::eyre::{Context, OptionExt, Result};
+use serde_json::Value;
+
+use crate::{
+    agent::AgentKind,
+    hook::{
+        BashInput, HookContext, NudgeHook, PermissionRequest, PreToolUse, ToolUse,
+        UserPromptSubmit, apply_patch,
+    },
+};
+
+/// Parse a Codex hook payload into normalized Nudge hooks.
+pub fn parse_hook(raw: Value) -> Result<Vec<NudgeHook>> {
+    let event = raw
+        .get("hook_event_name")
+        .and_then(Value::as_str)
+        .ok_or_eyre("missing hook_event_name")?;
+    let context = context(&raw, AgentKind::Codex)?;
+
+    match event {
+        "PreToolUse" => Ok(pretooluse(raw, context)),
+        "PermissionRequest" => Ok(vec![NudgeHook::PermissionRequest(PermissionRequest {
+            tool: tool_use(&raw),
+            context,
+        })]),
+        "UserPromptSubmit" => Ok(vec![NudgeHook::UserPromptSubmit(UserPromptSubmit {
+            prompt: string_field(&raw, "prompt")?.to_string(),
+            context,
+        })]),
+        _ => Ok(vec![NudgeHook::Other]),
+    }
+}
+
+fn pretooluse(raw: Value, context: HookContext) -> Vec<NudgeHook> {
+    let tool = tool_use(&raw);
+    match tool {
+        ToolUse::Other { tool_name, input } if tool_name == "apply_patch" => {
+            let command = input
+                .get("command")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            match apply_patch::parse(command, &context.cwd) {
+                Ok(tools) => tools
+                    .into_iter()
+                    .map(|tool| {
+                        NudgeHook::PreToolUse(PreToolUse {
+                            context: context.clone(),
+                            tool,
+                        })
+                    })
+                    .collect(),
+                Err(error) => {
+                    tracing::warn!(?error, "failed to parse Codex apply_patch input");
+                    vec![NudgeHook::Other]
+                }
+            }
+        }
+        tool => vec![NudgeHook::PreToolUse(PreToolUse { context, tool })],
+    }
+}
+
+fn context(raw: &Value, agent: AgentKind) -> Result<HookContext> {
+    let cwd = raw
+        .get("cwd")
+        .and_then(Value::as_str)
+        .map(PathBuf::from)
+        .map(Ok)
+        .unwrap_or_else(env::current_dir)
+        .context("get hook cwd")?;
+
+    Ok(HookContext {
+        agent,
+        session_id: optional_string(raw, "session_id"),
+        turn_id: optional_string(raw, "turn_id"),
+        transcript_path: optional_string(raw, "transcript_path").map(PathBuf::from),
+        cwd,
+        permission_mode: optional_string(raw, "permission_mode"),
+        model: optional_string(raw, "model"),
+    })
+}
+
+fn tool_use(raw: &Value) -> ToolUse {
+    let tool_name = raw
+        .get("tool_name")
+        .and_then(Value::as_str)
+        .unwrap_or("Other");
+    let input = raw.get("tool_input").cloned().unwrap_or(Value::Null);
+
+    match tool_name {
+        "Bash" => ToolUse::Bash(BashInput {
+            command: input
+                .get("command")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            description: optional_string(&input, "description"),
+        }),
+        other => ToolUse::Other {
+            tool_name: other.to_string(),
+            input,
+        },
+    }
+}
+
+fn string_field<'a>(value: &'a Value, field: &str) -> Result<&'a str> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| color_eyre::eyre::eyre!("missing string field {field}"))
+}
+
+fn optional_string(value: &Value, field: &str) -> Option<String> {
+    value.get(field).and_then(Value::as_str).map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    use crate::hook::{NudgeHook, ToolUse};
+
+    use super::parse_hook;
+
+    #[test]
+    fn bash_payload_normalizes_to_bash() {
+        let hooks = parse_hook(json!({
+            "hook_event_name": "PreToolUse",
+            "cwd": "/tmp",
+            "tool_name": "Bash",
+            "tool_input": { "command": "cargo test" }
+        }))
+        .expect("parse hook");
+
+        assert!(
+            matches!(hooks.as_slice(), [NudgeHook::PreToolUse(payload)] if matches!(payload.tool, ToolUse::Bash(_)))
+        );
+    }
+
+    #[test]
+    fn permission_request_normalizes() {
+        let hooks = parse_hook(json!({
+            "hook_event_name": "PermissionRequest",
+            "cwd": "/tmp",
+            "tool_name": "Bash",
+            "tool_input": { "command": "cargo test" }
+        }))
+        .expect("parse hook");
+
+        assert!(matches!(
+            hooks.as_slice(),
+            [NudgeHook::PermissionRequest(_)]
+        ));
+    }
+
+    #[test]
+    fn user_prompt_submit_normalizes_to_prompt_text() {
+        let hooks = parse_hook(json!({
+            "hook_event_name": "UserPromptSubmit",
+            "cwd": "/tmp",
+            "prompt": "hello"
+        }))
+        .expect("parse hook");
+
+        assert!(
+            matches!(hooks.as_slice(), [NudgeHook::UserPromptSubmit(payload)] if payload.prompt == "hello")
+        );
+    }
+
+    #[test]
+    fn apply_patch_add_file_normalizes_to_write() {
+        let hooks = parse_hook(json!({
+            "hook_event_name": "PreToolUse",
+            "cwd": "/tmp",
+            "tool_name": "apply_patch",
+            "tool_input": {
+                "command": "*** Begin Patch\n*** Add File: test.rs\n+fn main() {}\n*** End Patch\n"
+            }
+        }))
+        .expect("parse hook");
+
+        assert!(
+            matches!(hooks.as_slice(), [NudgeHook::PreToolUse(payload)] if matches!(payload.tool, ToolUse::Write(_)))
+        );
+    }
+
+    #[test]
+    fn apply_patch_update_file_normalizes_to_edit() {
+        let temp = TempDir::new().expect("temp dir");
+        fs::write(temp.path().join("test.rs"), "fn main() {\n    old();\n}\n").expect("write file");
+
+        let hooks = parse_hook(json!({
+            "hook_event_name": "PreToolUse",
+            "cwd": temp.path(),
+            "tool_name": "apply_patch",
+            "tool_input": {
+                "command": "*** Begin Patch\n*** Update File: test.rs\n@@\n fn main() {\n-    old();\n+    new();\n }\n*** End Patch\n"
+            }
+        }))
+        .expect("parse hook");
+
+        assert!(
+            matches!(hooks.as_slice(), [NudgeHook::PreToolUse(payload)] if matches!(payload.tool, ToolUse::Edit(_)))
+        );
+    }
+
+    #[test]
+    fn apply_patch_delete_file_normalizes_to_delete() {
+        let hooks = parse_hook(json!({
+            "hook_event_name": "PreToolUse",
+            "cwd": "/tmp",
+            "tool_name": "apply_patch",
+            "tool_input": {
+                "command": "*** Begin Patch\n*** Delete File: test.rs\n*** End Patch\n"
+            }
+        }))
+        .expect("parse hook");
+
+        assert!(
+            matches!(hooks.as_slice(), [NudgeHook::PreToolUse(payload)] if matches!(payload.tool, ToolUse::Delete(_)))
+        );
+    }
+
+    #[test]
+    fn unsupported_mcp_tool_passes_through_as_other() {
+        let hooks = parse_hook(json!({
+            "hook_event_name": "PreToolUse",
+            "cwd": "/tmp",
+            "tool_name": "mcp__server__tool",
+            "tool_input": { "x": 1 }
+        }))
+        .expect("parse hook");
+
+        assert!(
+            matches!(hooks.as_slice(), [NudgeHook::PreToolUse(payload)] if matches!(payload.tool, ToolUse::Other { .. }))
+        );
+    }
+}

--- a/packages/nudge/src/claude/hook.rs
+++ b/packages/nudge/src/claude/hook.rs
@@ -279,9 +279,8 @@ pub struct PreToolUseInterruptResponse {
     user_message: String,
 }
 
-/// Claude Code expects a two-level structured response, but that's annoying to
-/// work with for our use case, so we just translate it inside this `Serialize`
-/// implementation.
+/// Claude Code and Codex both accept this two-level structured response for
+/// denying `PreToolUse`. Keep the envelope minimal so it is safe for Codex too.
 impl Serialize for PreToolUseInterruptResponse {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -312,24 +311,6 @@ impl<S: Into<String>> From<S> for UserPromptSubmitResponse {
 #[derive(Debug, Serialize, Clone, Builder)]
 #[serde(rename_all = "camelCase")]
 struct HookResponseEnvelope<T> {
-    /// Whether Claude Code should continue after hook execution.
-    ///
-    /// This should nearly always be `true` so that Claude Code can respond to
-    /// the hook event- for example, don't use this to reject a `PreToolUse`
-    /// hook unless you want Claude Code to immediately abort the operation and
-    /// do nothing else until the user prompts again.
-    #[serde(rename = "continue")]
-    #[builder(default = true)]
-    should_continue: bool,
-
-    /// The message shown to the user when `should_continue` is false.
-    #[builder(into, default = "Nudge blocked operation due to rule violation")]
-    stop_reason: String,
-
-    /// Whether to hide the output of the hook from the user.
-    #[builder(default = false)]
-    suppress_output: bool,
-
     /// Message to display to the user when this response is emitted.
     #[builder(into)]
     system_message: String,

--- a/packages/nudge/src/cmd.rs
+++ b/packages/nudge/src/cmd.rs
@@ -2,6 +2,7 @@
 
 pub mod check;
 pub mod claude;
+pub mod codex;
 pub mod syntaxtree;
 pub mod test;
 pub mod validate;

--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -17,11 +17,11 @@ const DOCS: &str = cstr!("\
 
 <bold>What is Nudge?</bold>
 
-  Nudge is a <cyan>collaborative partner</cyan> for Claude Code. It watches Write, Edit,
-  WebFetch, and Bash operations and reminds you about coding conventions—so you can
-  focus on the user's actual problem instead of tracking dozens of stylistic details.
+  Nudge is a <cyan>collaborative partner</cyan> for agent hooks. It supports Claude Code
+  and Codex CLI, and reminds you about coding conventions when provider hooks expose
+  Write, Edit, WebFetch, Bash, or prompt-submission surfaces.
 
-  <green>Nudge is on your side.</green> When it sends a message, it's not a reprimand—it's
+  <green>Nudge is on your side.</green> When it sends a message, it's not a reprimand. It's
   a colleague tapping you on the shoulder. The messages are direct (sometimes
   blunt) because that's what cuts through when you're focused.
 
@@ -49,7 +49,7 @@ const DOCS: &str = cstr!("\
 
       <yellow>on:</yellow>                           <dim># List of matchers (any match triggers the rule)</dim>
         <yellow>- hook: PreToolUse</yellow>          <dim># PreToolUse or UserPromptSubmit</dim>
-          <yellow>tool: Write</yellow>               <dim># Write, Edit, or WebFetch (PreToolUse only)</dim>
+          <yellow>tool: Write</yellow>               <dim># Write, Edit, WebFetch, or Bash (PreToolUse only)</dim>
           <yellow>file: \"**/*.rs\"</yellow>           <dim># Glob pattern for file path</dim>
           <yellow>content:</yellow>                   <dim># Patterns to match (Write tool)</dim>
             <yellow>- kind: Regex</yellow>
@@ -66,8 +66,9 @@ const DOCS: &str = cstr!("\
 
 <bold>Hook Types</bold>
 
-  <green>PreToolUse</green>        Triggers before Write/Edit/WebFetch/Bash operations. Always
-                    <cyan>interrupts</cyan> (blocks the operation until the issue is fixed).
+  <green>PreToolUse</green>        Triggers before provider-supported Write/Edit/WebFetch/Bash
+                    operations. Always <cyan>interrupts</cyan> (blocks the operation until
+                    the issue is fixed).
 
   <green>UserPromptSubmit</green>  Triggers when user submits a prompt. Always <cyan>continues</cyan>
                     (injects context into the conversation).
@@ -86,6 +87,24 @@ const DOCS: &str = cstr!("\
   <green>Bash</green>       Match shell commands being executed
              Use <cyan>command:</cyan> to specify patterns to match
              Use <cyan>project_state:</cyan> to add conditional filters (e.g., git branch)
+
+  <green>Delete</green>     Normalized internally for file deletion, but not yet matchable
+             in YAML rules.
+
+<bold>Provider Support</bold>
+
+  <white>Surface</white>                      <white>Claude Code</white>     <white>Codex CLI</white>
+  <green>PreToolUse Write</green>             yes             yes, through apply_patch add-file parsing
+  <green>PreToolUse Edit</green>              yes             yes, through apply_patch update parsing
+  <green>PreToolUse Delete</green>            normalized      normalized through apply_patch delete-file parsing
+  <green>PreToolUse WebFetch</green>          yes             no, current Codex hooks do not intercept WebSearch
+  <green>PreToolUse Bash</green>              yes             partial, Codex hook coverage is incomplete for some shell paths
+  <green>PermissionRequest</green>            parsed only     parsed only
+  <green>UserPromptSubmit</green>             yes             yes
+
+  <dim>Delete and PermissionRequest are parsed so Nudge can name them precisely, but</dim>
+  <dim>they do not have YAML matchers yet. Codex apply_patch is an adapter detail:</dim>
+  <dim>write rules in terms of Write, Edit, and future Delete policy instead.</dim>
 
 <bold>Regex Inline Flags</bold>
 
@@ -128,7 +147,7 @@ const DOCS: &str = cstr!("\
 <bold>How Messages Are Displayed</bold>
 
   When a rule matches, Nudge displays a <cyan>code snippet</cyan> with your message shown
-  at each match location—similar to Rust compiler errors:
+  at each match location, similar to Rust compiler errors:
 
     <dim>error: rule violation</dim>
       <dim>|</dim>
@@ -144,7 +163,7 @@ const DOCS: &str = cstr!("\
 
   Nudge messages must be <cyan>direct</cyan> to be effective. Gentle suggestions get ignored.
 
-  <white>Pattern:</white> what's wrong → how to fix → retry
+  <white>Pattern:</white> what's wrong -> how to fix -> retry
 
   <red>Bad</red> <dim>(vague, easy to ignore):</dim>
     <dim>\"Consider reorganizing your imports.\"</dim>
@@ -153,11 +172,11 @@ const DOCS: &str = cstr!("\
     <dim>\"Move this import to the top of the file, then retry.\"</dim>
 
   <white>Guidelines:</white>
-    • <cyan>Be specific:</cyan> \"Move this import to top\" not \"Consider reorganizing\"
-    • <cyan>Be direct:</cyan> \"Stop. Fix this first.\" not \"You might want to...\"
-    • <cyan>Give the fix:</cyan> Don't just say what's wrong—say what to do instead
-    • <cyan>End with \"then retry\":</cyan> Tell Claude to retry after fixing
-    • <cyan>Write for one match:</cyan> The message appears at each match location
+    - <cyan>Be specific:</cyan> \"Move this import to top\" not \"Consider reorganizing\"
+    - <cyan>Be direct:</cyan> \"Stop. Fix this first.\" not \"You might want to...\"
+    - <cyan>Give the fix:</cyan> Don't just say what's wrong. Say what to do instead
+    - <cyan>End with \"then retry\":</cyan> Tell the agent to retry after fixing
+    - <cyan>Write for one match:</cyan> The message appears at each match location
 
 <bold>Syntax Tree Matching (Tree-sitter)</bold>
 
@@ -194,7 +213,7 @@ const DOCS: &str = cstr!("\
     <green>SyntaxTree</green>  Structural patterns (e.g., \"use inside function body\")
 
   <dim>Note: If code fails to parse (incomplete or invalid syntax), the matcher</dim>
-  <dim>passes silently. This is intentional—code being written is often incomplete.</dim>
+  <dim>passes silently. This is intentional because code being written is often incomplete.</dim>
 
 <bold>External Program Matching</bold>
 
@@ -342,7 +361,7 @@ const DOCS: &str = cstr!("\
 
   <cyan>Redirect docs.rs to local source (WebFetch)</cyan>
 
-    <dim># When Claude tries to fetch from docs.rs, redirect to local cargo registry.</dim>
+    <dim># When Claude Code tries to fetch from docs.rs, redirect to local cargo registry.</dim>
     <dim># Uses capture groups to extract the crate name from the URL.</dim>
 
     <yellow>- name: prefer-local-docs</yellow>
@@ -400,6 +419,6 @@ const DOCS: &str = cstr!("\
 
 <bold>Rule Writing is Iterative</bold>
 
-  If Claude ignores a rule, the fix is usually to make the message more direct,
+  If an agent ignores a rule, the fix is usually to make the message more direct,
   not to give up on the rule. Treat ignored rules as feedback on clarity.
 ");

--- a/packages/nudge/src/cmd/claude/setup.rs
+++ b/packages/nudge/src/cmd/claude/setup.rs
@@ -55,18 +55,16 @@ pub fn main(config: Config) -> Result<()> {
 
     let nudge_command = format!("{nudge_path} claude hook");
     let nudge_hook = hook::Config::builder()
-        .command(nudge_command)
+        .command(&nudge_command)
         .timeout(5)
         .build();
-    let nudge_matcher_wildcard = hook::Matcher::builder()
-        .matcher("*")
+    let nudge_pretooluse_matcher = hook::Matcher::builder()
+        .matcher("Write|Edit|WebFetch|Bash")
         .hooks([&nudge_hook])
         .build();
     let nudge_matcher = hook::Matcher::builder().hooks([nudge_hook]).build();
     let desired_hooks = [
-        ("PreToolUse", nudge_matcher_wildcard.clone()),
-        ("PostToolUse", nudge_matcher_wildcard),
-        ("Stop", nudge_matcher.clone()),
+        ("PreToolUse", nudge_pretooluse_matcher),
         ("UserPromptSubmit", nudge_matcher),
     ];
     tracing::debug!(?desired_hooks, "generate desired hooks");
@@ -108,6 +106,8 @@ pub fn main(config: Config) -> Result<()> {
             matchers.push(matcher);
         }
     }
+    remove_managed_event_hook(hooks, "PostToolUse", &nudge_command);
+    remove_managed_event_hook(hooks, "Stop", &nudge_command);
 
     let settings_json = serde_json::to_string_pretty(&settings).context("serialize settings")?;
     fs::write(&settings_file, settings_json).context("write settings file")?;
@@ -128,6 +128,36 @@ pub fn main(config: Config) -> Result<()> {
     println!("2. Use claude --debug to see hook execution logs");
 
     Ok(())
+}
+
+fn remove_managed_event_hook(
+    hooks: &mut serde_json::Map<String, Value>,
+    event: &str,
+    command: &str,
+) {
+    let Some(entry) = hooks.get_mut(event) else {
+        return;
+    };
+    let Value::Array(matchers) = entry else {
+        return;
+    };
+
+    matchers.retain(|matcher| !matcher_uses_command(matcher, command));
+    if matchers.is_empty() {
+        hooks.remove(event);
+    }
+}
+
+fn matcher_uses_command(matcher: &Value, command: &str) -> bool {
+    matcher
+        .get("hooks")
+        .and_then(Value::as_array)
+        .is_some_and(|hooks| {
+            hooks.iter().any(|hook| {
+                hook.get("type").and_then(Value::as_str) == Some("command")
+                    && hook.get("command").and_then(Value::as_str) == Some(command)
+            })
+        })
 }
 
 /// Offer to add a Nudge section to CLAUDE.md in the project root.

--- a/packages/nudge/src/cmd/codex.rs
+++ b/packages/nudge/src/cmd/codex.rs
@@ -1,0 +1,36 @@
+//! Integration with Codex CLI.
+
+use clap::{Args, Subcommand};
+use color_eyre::Result;
+use tracing::instrument;
+
+pub mod docs;
+pub mod hook;
+pub mod setup;
+
+#[derive(Args, Clone, Debug)]
+pub struct Config {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand, Clone, Debug)]
+enum Commands {
+    /// Responds to Codex hooks.
+    Hook(hook::Config),
+
+    /// Set up Nudge hooks in .codex/hooks.json.
+    Setup(setup::Config),
+
+    /// Show documentation for writing Nudge rules.
+    Docs(docs::Config),
+}
+
+#[instrument]
+pub fn main(config: Config) -> Result<()> {
+    match config.command {
+        Commands::Hook(config) => hook::main(config),
+        Commands::Setup(config) => setup::main(config),
+        Commands::Docs(config) => docs::main(config),
+    }
+}

--- a/packages/nudge/src/cmd/codex/docs.rs
+++ b/packages/nudge/src/cmd/codex/docs.rs
@@ -1,0 +1,13 @@
+//! Documentation for writing Nudge rules with Codex.
+
+use clap::Args;
+use color_eyre::Result;
+
+use crate::cmd::claude::docs;
+
+#[derive(Args, Clone, Debug)]
+pub struct Config {}
+
+pub fn main(_config: Config) -> Result<()> {
+    docs::main(docs::Config {})
+}

--- a/packages/nudge/src/cmd/codex/hook.rs
+++ b/packages/nudge/src/cmd/codex/hook.rs
@@ -1,11 +1,11 @@
-//! Responds to Claude Code hooks.
+//! Responds to Codex hooks.
 
 use std::io;
 
 use clap::Args;
 use color_eyre::{Result, eyre::Context};
 use nudge::{
-    agent::{AgentKind, claude},
+    agent::{AgentKind, codex},
     hook::{evaluate::evaluate_hooks, response},
     rules,
 };
@@ -18,8 +18,8 @@ pub struct Config {}
 pub fn main(_config: Config) -> Result<()> {
     let stdin = io::stdin();
     let raw = serde_json::from_reader(stdin).context("read hook event")?;
-    let hooks = claude::parse_hook(raw).context("parse Claude hook event")?;
+    let hooks = codex::parse_hook(raw).context("parse Codex hook event")?;
 
     let rules = rules::load_all().context("load rules")?;
-    response::emit(AgentKind::Claude, evaluate_hooks(&hooks, &rules))
+    response::emit(AgentKind::Codex, evaluate_hooks(&hooks, &rules))
 }

--- a/packages/nudge/src/cmd/codex/setup.rs
+++ b/packages/nudge/src/cmd/codex/setup.rs
@@ -1,6 +1,10 @@
 //! Set up Nudge hooks for Codex CLI.
 
-use std::{env, fs, path::PathBuf};
+use std::{
+    env, fs,
+    io::ErrorKind,
+    path::{Path, PathBuf},
+};
 
 use clap::Args;
 use color_eyre::eyre::{Context, OptionExt, Result, bail};
@@ -104,10 +108,10 @@ pub fn main(config: Config) -> Result<()> {
     Ok(())
 }
 
-fn inline_config_has_hooks(path: &std::path::Path) -> Result<bool> {
+fn inline_config_has_hooks(path: &Path) -> Result<bool> {
     let content = match fs::read_to_string(path) {
         Ok(content) => content,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
         Err(error) => return Err(error).context("read .codex/config.toml"),
     };
 
@@ -119,12 +123,16 @@ fn inline_config_has_hooks(path: &std::path::Path) -> Result<bool> {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
+    use tempfile::NamedTempFile;
+
     use super::inline_config_has_hooks;
 
     #[test]
     fn detects_inline_hooks_table() {
-        let temp = tempfile::NamedTempFile::new().expect("temp file");
-        std::fs::write(temp.path(), "[hooks]\n").expect("write file");
+        let temp = NamedTempFile::new().expect("temp file");
+        fs::write(temp.path(), "[hooks]\n").expect("write file");
         assert!(inline_config_has_hooks(temp.path()).expect("detect hooks"));
     }
 }

--- a/packages/nudge/src/cmd/codex/setup.rs
+++ b/packages/nudge/src/cmd/codex/setup.rs
@@ -1,0 +1,130 @@
+//! Set up Nudge hooks for Codex CLI.
+
+use std::{env, fs, path::PathBuf};
+
+use clap::Args;
+use color_eyre::eyre::{Context, OptionExt, Result, bail};
+use serde_json::{Value, json};
+use tracing::instrument;
+
+#[derive(Args, Clone, Debug)]
+pub struct Config {
+    /// Path to the .codex directory.
+    #[arg(long, default_value = ".codex")]
+    codex_dir: PathBuf,
+}
+
+#[instrument]
+pub fn main(config: Config) -> Result<()> {
+    fs::create_dir_all(&config.codex_dir).context("create .codex directory")?;
+
+    let dotcodex = config
+        .codex_dir
+        .canonicalize()
+        .with_context(|| format!("canonicalize codex dir: {:?}", config.codex_dir))?;
+
+    let inline_config = dotcodex.join("config.toml");
+    if inline_config_has_hooks(&inline_config)? {
+        eprintln!(
+            "warning: {} already contains inline Codex hooks. Nudge setup skipped because safe TOML hook merging is out of scope. Move hooks to .codex/hooks.json or merge Nudge manually.",
+            inline_config.display()
+        );
+        return Ok(());
+    }
+
+    let hooks_file = dotcodex.join("hooks.json");
+    let nudge_path = env::current_exe()
+        .context("get current executable path")?
+        .to_str()
+        .ok_or_eyre("convert current executable path to string")?
+        .to_string();
+    let nudge_command = format!("{nudge_path} codex hook");
+
+    let nudge_hook = json!({
+        "type": "command",
+        "command": nudge_command,
+        "timeout": 5,
+        "statusMessage": "Checking Nudge rules"
+    });
+    let desired_hooks = [
+        (
+            "PreToolUse",
+            json!({
+                "matcher": "Bash|apply_patch",
+                "hooks": [nudge_hook.clone()]
+            }),
+        ),
+        (
+            "UserPromptSubmit",
+            json!({
+                "hooks": [nudge_hook]
+            }),
+        ),
+    ];
+
+    let mut config = if hooks_file.exists() {
+        let content = fs::read_to_string(&hooks_file).context("read existing hooks.json")?;
+        serde_json::from_str::<Value>(&content).context("parse existing hooks.json")?
+    } else {
+        json!({})
+    };
+
+    let Value::Object(root) = &mut config else {
+        bail!("expected hooks.json to be an object, got: {config:?}");
+    };
+    let hooks = root.entry("hooks").or_insert_with(|| json!({}));
+    let Value::Object(hooks) = hooks else {
+        bail!("expected hooks to be an object, got: {hooks:?}");
+    };
+
+    for (event, matcher) in desired_hooks {
+        let entry = hooks.entry(event).or_insert_with(|| json!([]));
+        let Value::Array(matchers) = entry else {
+            bail!("expected hook matchers to be an array, got: {entry:?}");
+        };
+
+        if !matchers.contains(&matcher) {
+            matchers.push(matcher);
+        }
+    }
+
+    let hooks_json = serde_json::to_string_pretty(&config).context("serialize hooks.json")?;
+    fs::write(&hooks_file, hooks_json).context("write hooks.json")?;
+
+    println!("✓ Wrote hooks configuration to {}", hooks_file.display());
+    println!();
+    println!("Next steps:");
+    println!("1. Restart Codex sessions so hooks are loaded.");
+    println!("2. Run /hooks.");
+    println!("3. Review and trust the new Nudge hooks.");
+    println!(
+        "4. If hooks do not appear, check that the project .codex/ layer is trusted and [features].hooks has not been disabled."
+    );
+
+    Ok(())
+}
+
+fn inline_config_has_hooks(path: &std::path::Path) -> Result<bool> {
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error).context("read .codex/config.toml"),
+    };
+
+    Ok(content.lines().any(|line| {
+        let line = line.trim();
+        line == "[hooks]" || line.starts_with("[hooks.")
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::inline_config_has_hooks;
+
+    #[test]
+    fn detects_inline_hooks_table() {
+        let temp = tempfile::NamedTempFile::new().expect("temp file");
+        std::fs::write(temp.path(), "[hooks]\n").expect("write file");
+        assert!(inline_config_has_hooks(temp.path()).expect("detect hooks"));
+    }
+}

--- a/packages/nudge/src/cmd/test.rs
+++ b/packages/nudge/src/cmd/test.rs
@@ -5,13 +5,12 @@ use std::path::PathBuf;
 
 use clap::Args;
 use color_eyre::eyre::{Context, Result, bail, eyre};
-use itertools::Itertools;
 use serde_json::json;
 
 use nudge::{
-    claude::hook::{Hook, PreToolUsePayload},
-    rules::{self, Rule},
-    snippet::{Match, Source},
+    agent::claude,
+    hook::{NudgeHook, evaluate::evaluate_hooks, response::HookOutcome},
+    rules,
 };
 
 #[derive(Args, Clone, Debug)]
@@ -20,7 +19,7 @@ pub struct Config {
     #[arg(long)]
     pub rule: String,
 
-    /// Tool name (for PreToolUse rules): Write, Edit, or WebFetch.
+    /// Tool name (for PreToolUse rules): Write, Edit, WebFetch, or Bash.
     #[arg(long)]
     pub tool: Option<String>,
 
@@ -52,85 +51,35 @@ pub fn main(config: Config) -> Result<()> {
         .find(|r| r.name == config.rule)
         .ok_or_else(|| eyre!("Rule '{}' not found", config.rule))?;
 
-    let hook = build_hook(&config)?;
+    let hooks = build_hooks(&config)?;
 
     println!("Rule: {}", config.rule);
     println!();
 
-    let (matched, source) = evaluate_rule(&rule, &hook);
-
-    if matched.is_empty() {
-        println!("Result: Passthrough");
-        println!("The rule did not match the provided input.");
-    } else {
-        let hook_type = match &hook {
-            Hook::PreToolUse(_) => "Interrupt",
-            Hook::UserPromptSubmit(_) => "Continue",
-            Hook::Other => "Passthrough",
-        };
-        println!("Result: {hook_type}");
-        println!();
-        println!("Matched content:");
-        let annotations = rule.annotate_matches(matched).collect_vec();
-        let snippet = source.annotate(annotations);
-        println!("{snippet}");
+    match evaluate_hooks(&hooks, &[rule]) {
+        HookOutcome::Passthrough => {
+            println!("Result: Passthrough");
+            println!("The rule did not match the provided input.");
+        }
+        HookOutcome::DenyPreToolUse { message } => {
+            println!("Result: Interrupt");
+            println!();
+            println!("Matched content:");
+            println!("{message}");
+        }
+        HookOutcome::AddContext { context } => {
+            println!("Result: Continue");
+            println!();
+            println!("Matched content:");
+            println!("{context}");
+        }
     }
 
     Ok(())
 }
 
-/// Evaluate a single rule against a hook, returning matches and the source.
-fn evaluate_rule(rule: &Rule, hook: &Hook) -> (Vec<Match>, Source) {
-    match hook {
-        Hook::PreToolUse(payload) => match payload {
-            PreToolUsePayload::Write(payload) => {
-                let matches = rule
-                    .hooks_pretooluse_write()
-                    .flat_map(|matcher| payload.evaluate(matcher))
-                    .collect_vec();
-                let source = Source::from(&payload.tool_input.content);
-                (matches, source)
-            }
-            PreToolUsePayload::Edit(payload) => {
-                let matches = rule
-                    .hooks_pretooluse_edit()
-                    .flat_map(|matcher| payload.evaluate(matcher))
-                    .collect_vec();
-                let source = Source::from(&payload.tool_input.new_string);
-                (matches, source)
-            }
-            PreToolUsePayload::WebFetch(payload) => {
-                let matches = rule
-                    .hooks_pretooluse_webfetch()
-                    .flat_map(|matcher| payload.evaluate(matcher))
-                    .collect_vec();
-                let source = Source::from(&payload.tool_input.url);
-                (matches, source)
-            }
-            PreToolUsePayload::Bash(payload) => {
-                let matches = rule
-                    .hooks_pretooluse_bash()
-                    .flat_map(|matcher| payload.evaluate(matcher))
-                    .collect_vec();
-                let source = Source::from(&payload.tool_input.command);
-                (matches, source)
-            }
-            PreToolUsePayload::Other => (Vec::new(), Source::from("")),
-        },
-        Hook::UserPromptSubmit(payload) => {
-            let matches = rule
-                .hooks_userpromptsubmit()
-                .flat_map(|matcher| payload.evaluate(matcher))
-                .collect_vec();
-            let source = Source::from(&payload.prompt);
-            (matches, source)
-        }
-        Hook::Other => (Vec::new(), Source::from("")),
-    }
-}
-
 /// Build a Hook from the CLI arguments.
-fn build_hook(config: &Config) -> Result<Hook> {
+fn build_hooks(config: &Config) -> Result<Vec<NudgeHook>> {
     // Determine what kind of hook to build based on arguments
     if config.prompt.is_some() {
         return build_user_prompt_hook(config);
@@ -150,7 +99,7 @@ fn build_hook(config: &Config) -> Result<Hook> {
     );
 }
 
-fn build_user_prompt_hook(config: &Config) -> Result<Hook> {
+fn build_user_prompt_hook(config: &Config) -> Result<Vec<NudgeHook>> {
     let prompt = config
         .prompt
         .as_ref()
@@ -165,10 +114,10 @@ fn build_user_prompt_hook(config: &Config) -> Result<Hook> {
         "prompt": prompt
     });
 
-    serde_json::from_value(payload).context("failed to build UserPromptSubmit hook")
+    claude::parse_hook(payload).context("failed to build UserPromptSubmit hook")
 }
 
-fn build_tool_use_hook(config: &Config) -> Result<Hook> {
+fn build_tool_use_hook(config: &Config) -> Result<Vec<NudgeHook>> {
     let tool = config.tool.as_deref().unwrap_or("Write");
     let file_path = config
         .file
@@ -204,8 +153,12 @@ fn build_tool_use_hook(config: &Config) -> Result<Hook> {
                 "prompt": content
             })
         }
+        "Bash" => json!({
+            "command": content,
+            "description": "Test command"
+        }),
         other => bail!(
-            "Unknown tool '{}'. Supported tools: Write, Edit, WebFetch",
+            "Unknown tool '{}'. Supported tools: Write, Edit, WebFetch, Bash",
             other
         ),
     };
@@ -221,5 +174,5 @@ fn build_tool_use_hook(config: &Config) -> Result<Hook> {
         "tool_input": tool_input
     });
 
-    serde_json::from_value(payload).context("failed to build PreToolUse hook")
+    claude::parse_hook(payload).context("failed to build PreToolUse hook")
 }

--- a/packages/nudge/src/cmd/validate.rs
+++ b/packages/nudge/src/cmd/validate.rs
@@ -27,6 +27,7 @@ fn validate_all() -> Result<()> {
         let yaml = serde_yaml::to_string(&rules).context("serialize rules")?;
         println!("Config file: {path:?}");
         println!("{yaml}");
+        print_codex_warnings(&rules);
         println!("------");
         println!();
     }
@@ -39,5 +40,21 @@ fn validate_file(path: &Path) -> Result<()> {
     let rules = rules::load_from(path).context("parse rules file")?;
     let yaml = serde_yaml::to_string(&rules).context("serialize rules")?;
     println!("{yaml}");
+    print_codex_warnings(&rules);
     Ok(())
+}
+
+fn print_codex_warnings(loaded_rules: &[rules::Rule]) {
+    if !Path::new(".codex").exists() {
+        return;
+    }
+
+    for rule in loaded_rules {
+        if rule.hooks_pretooluse_webfetch().next().is_some() {
+            eprintln!(
+                "warning: rule \"{}\" uses PreToolUse WebFetch, which Claude Code supports but Codex hooks do not currently intercept.",
+                rule.name
+            );
+        }
+    }
 }

--- a/packages/nudge/src/hook.rs
+++ b/packages/nudge/src/hook.rs
@@ -1,0 +1,160 @@
+//! Normalized hook event model and evaluation.
+
+use std::path::PathBuf;
+
+use serde_json::Value;
+
+use crate::agent::AgentKind;
+
+pub mod apply_patch;
+pub mod evaluate;
+pub mod response;
+
+/// A Nudge hook event after provider-specific payloads have been normalized.
+#[derive(Debug, Clone, PartialEq)]
+pub enum NudgeHook {
+    /// A tool is about to be used.
+    PreToolUse(PreToolUse),
+
+    /// The agent is requesting permission for a tool.
+    PermissionRequest(PermissionRequest),
+
+    /// The user submitted a prompt.
+    UserPromptSubmit(UserPromptSubmit),
+
+    /// A hook event Nudge does not currently handle.
+    Other,
+}
+
+/// Shared context that is useful across agent hook providers.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HookContext {
+    /// The provider that emitted the hook.
+    pub agent: AgentKind,
+
+    /// Provider session id, when available.
+    pub session_id: Option<String>,
+
+    /// Provider turn id, when available.
+    pub turn_id: Option<String>,
+
+    /// Transcript path, when available.
+    pub transcript_path: Option<PathBuf>,
+
+    /// Current working directory for the hook invocation.
+    pub cwd: PathBuf,
+
+    /// Provider permission mode, when available.
+    pub permission_mode: Option<String>,
+
+    /// Model name, when available.
+    pub model: Option<String>,
+}
+
+/// Normalized `PreToolUse` event.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PreToolUse {
+    /// Shared hook context.
+    pub context: HookContext,
+
+    /// Normalized tool input.
+    pub tool: ToolUse,
+}
+
+/// Normalized parsed-but-unmatchable permission request.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PermissionRequest {
+    /// Shared hook context.
+    pub context: HookContext,
+
+    /// Normalized requested tool input.
+    pub tool: ToolUse,
+}
+
+/// Normalized `UserPromptSubmit` event.
+#[derive(Debug, Clone, PartialEq)]
+pub struct UserPromptSubmit {
+    /// Shared hook context.
+    pub context: HookContext,
+
+    /// User prompt text.
+    pub prompt: String,
+}
+
+/// Normalized tool use.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ToolUse {
+    /// Write file content.
+    Write(WriteInput),
+
+    /// Edit file content.
+    Edit(EditInput),
+
+    /// Delete a file.
+    Delete(DeleteInput),
+
+    /// Fetch a URL.
+    WebFetch(WebFetchInput),
+
+    /// Run a shell command.
+    Bash(BashInput),
+
+    /// Any unsupported tool.
+    Other {
+        /// Provider tool name.
+        tool_name: String,
+
+        /// Raw provider input.
+        input: Value,
+    },
+}
+
+/// Normalized write input.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WriteInput {
+    /// Path being written.
+    pub file_path: PathBuf,
+
+    /// Full content being written.
+    pub content: String,
+}
+
+/// Normalized edit input.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EditInput {
+    /// Path being edited.
+    pub file_path: PathBuf,
+
+    /// Replaced content or matched pre-patch content.
+    pub old_string: String,
+
+    /// Full post-edit content.
+    pub new_string: String,
+}
+
+/// Normalized delete input.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeleteInput {
+    /// Path being deleted.
+    pub file_path: PathBuf,
+}
+
+/// Normalized web fetch input.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WebFetchInput {
+    /// URL being fetched.
+    pub url: String,
+
+    /// Provider prompt, when present.
+    pub prompt: Option<String>,
+}
+
+/// Normalized bash input.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BashInput {
+    /// Command being executed.
+    pub command: String,
+
+    /// Human-readable description, when present.
+    pub description: Option<String>,
+}

--- a/packages/nudge/src/hook/apply_patch.rs
+++ b/packages/nudge/src/hook/apply_patch.rs
@@ -1,6 +1,9 @@
 //! Parser for Codex `apply_patch` tool input.
 
-use std::{fs, path::Path};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use color_eyre::eyre::{Result, bail};
 
@@ -64,7 +67,7 @@ pub fn parse(command: &str, cwd: &Path) -> Result<Vec<ToolUse>> {
 }
 
 struct ParsedUpdate {
-    move_to: Option<std::path::PathBuf>,
+    move_to: Option<PathBuf>,
     old_string: String,
     hunks: Vec<Hunk>,
 }
@@ -191,6 +194,7 @@ fn is_file_header(line: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::path::{Path, PathBuf};
 
     use tempfile::TempDir;
 
@@ -200,12 +204,12 @@ mod tests {
     fn add_file_normalizes_to_write() {
         let parsed = apply_patch::parse(
             "*** Begin Patch\n*** Add File: src/main.rs\n+fn main() {}\n*** End Patch\n",
-            std::path::Path::new("/tmp"),
+            Path::new("/tmp"),
         )
         .expect("parse patch");
 
         assert!(
-            matches!(parsed.as_slice(), [ToolUse::Write(input)] if input.file_path == std::path::PathBuf::from("src/main.rs") && input.content == "fn main() {}\n")
+            matches!(parsed.as_slice(), [ToolUse::Write(input)] if input.file_path == PathBuf::from("src/main.rs") && input.content == "fn main() {}\n")
         );
     }
 
@@ -221,7 +225,7 @@ mod tests {
         .expect("parse patch");
 
         assert!(
-            matches!(parsed.as_slice(), [ToolUse::Edit(input)] if input.file_path == std::path::PathBuf::from("src.rs") && input.new_string == "fn main() {\n    new();\n}\n")
+            matches!(parsed.as_slice(), [ToolUse::Edit(input)] if input.file_path == PathBuf::from("src.rs") && input.new_string == "fn main() {\n    new();\n}\n")
         );
     }
 
@@ -229,12 +233,12 @@ mod tests {
     fn delete_file_normalizes_to_delete() {
         let parsed = apply_patch::parse(
             "*** Begin Patch\n*** Delete File: old.rs\n*** End Patch\n",
-            std::path::Path::new("/tmp"),
+            Path::new("/tmp"),
         )
         .expect("parse patch");
 
         assert!(
-            matches!(parsed.as_slice(), [ToolUse::Delete(input)] if input.file_path == std::path::PathBuf::from("old.rs"))
+            matches!(parsed.as_slice(), [ToolUse::Delete(input)] if input.file_path == PathBuf::from("old.rs"))
         );
     }
 }

--- a/packages/nudge/src/hook/apply_patch.rs
+++ b/packages/nudge/src/hook/apply_patch.rs
@@ -1,0 +1,240 @@
+//! Parser for Codex `apply_patch` tool input.
+
+use std::{fs, path::Path};
+
+use color_eyre::eyre::{Result, bail};
+
+use crate::hook::{DeleteInput, EditInput, ToolUse, WriteInput};
+
+/// Parse an `apply_patch` command into normalized file tool uses.
+pub fn parse(command: &str, cwd: &Path) -> Result<Vec<ToolUse>> {
+    let lines = command.lines().collect::<Vec<_>>();
+    if lines.first() != Some(&"*** Begin Patch") {
+        bail!("missing apply_patch begin marker");
+    }
+
+    if !lines.iter().any(|line| *line == "*** End Patch") {
+        bail!("missing apply_patch end marker");
+    }
+
+    let mut changes = Vec::new();
+    let mut index = 1;
+    while index < lines.len() {
+        let line = lines[index];
+        if line == "*** End Patch" {
+            break;
+        }
+
+        if let Some(path) = line.strip_prefix("*** Add File: ") {
+            let (content, next) = parse_add_file(&lines, index + 1);
+            changes.push(ToolUse::Write(WriteInput {
+                file_path: path.into(),
+                content,
+            }));
+            index = next;
+            continue;
+        }
+
+        if let Some(path) = line.strip_prefix("*** Delete File: ") {
+            changes.push(ToolUse::Delete(DeleteInput {
+                file_path: path.into(),
+            }));
+            index += 1;
+            continue;
+        }
+
+        if let Some(path) = line.strip_prefix("*** Update File: ") {
+            let (update, next) = parse_update_file(&lines, index + 1);
+            let current_path = cwd.join(path);
+            let current = fs::read_to_string(&current_path)?;
+            let new_string = apply_hunks(current, &update.hunks)?;
+            changes.push(ToolUse::Edit(EditInput {
+                file_path: update.move_to.unwrap_or_else(|| path.into()),
+                old_string: update.old_string,
+                new_string,
+            }));
+            index = next;
+            continue;
+        }
+
+        bail!("unexpected apply_patch line: {line}");
+    }
+
+    Ok(changes)
+}
+
+struct ParsedUpdate {
+    move_to: Option<std::path::PathBuf>,
+    old_string: String,
+    hunks: Vec<Hunk>,
+}
+
+#[derive(Debug)]
+struct Hunk {
+    old: String,
+    new: String,
+}
+
+fn parse_add_file(lines: &[&str], mut index: usize) -> (String, usize) {
+    let mut added = Vec::new();
+    while index < lines.len() && !is_section_header(lines[index]) {
+        if let Some(line) = lines[index].strip_prefix('+') {
+            added.push(line.to_string());
+        }
+        index += 1;
+    }
+
+    (join_patch_lines(&added), index)
+}
+
+fn parse_update_file(lines: &[&str], mut index: usize) -> (ParsedUpdate, usize) {
+    let mut move_to = None;
+    let mut hunks = Vec::new();
+    let mut old_lines = Vec::new();
+    let mut new_lines = Vec::new();
+
+    while index < lines.len() && !is_file_header(lines[index]) && lines[index] != "*** End Patch" {
+        let line = lines[index];
+        if let Some(path) = line.strip_prefix("*** Move to: ") {
+            move_to = Some(path.into());
+            index += 1;
+            continue;
+        }
+
+        if line.starts_with("@@") {
+            push_hunk(&mut hunks, &mut old_lines, &mut new_lines);
+            index += 1;
+            continue;
+        }
+
+        if let Some(content) = line.strip_prefix(' ') {
+            old_lines.push(content.to_string());
+            new_lines.push(content.to_string());
+        } else if let Some(content) = line.strip_prefix('-') {
+            old_lines.push(content.to_string());
+        } else if let Some(content) = line.strip_prefix('+') {
+            new_lines.push(content.to_string());
+        }
+
+        index += 1;
+    }
+
+    push_hunk(&mut hunks, &mut old_lines, &mut new_lines);
+    let old_string = hunks
+        .iter()
+        .map(|hunk| hunk.old.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    (
+        ParsedUpdate {
+            move_to,
+            old_string,
+            hunks,
+        },
+        index,
+    )
+}
+
+fn push_hunk(hunks: &mut Vec<Hunk>, old_lines: &mut Vec<String>, new_lines: &mut Vec<String>) {
+    if old_lines.is_empty() && new_lines.is_empty() {
+        return;
+    }
+
+    hunks.push(Hunk {
+        old: join_patch_lines(old_lines),
+        new: join_patch_lines(new_lines),
+    });
+    old_lines.clear();
+    new_lines.clear();
+}
+
+fn apply_hunks(mut current: String, hunks: &[Hunk]) -> Result<String> {
+    for hunk in hunks {
+        if let Some(index) = current.find(&hunk.old) {
+            current.replace_range(index..index + hunk.old.len(), &hunk.new);
+            continue;
+        }
+
+        let old_without_final_newline = hunk.old.trim_end_matches('\n');
+        if !old_without_final_newline.is_empty()
+            && let Some(index) = current.find(old_without_final_newline)
+        {
+            current.replace_range(index..index + old_without_final_newline.len(), &hunk.new);
+            continue;
+        }
+
+        bail!("apply_patch update hunk did not match current file");
+    }
+
+    Ok(current)
+}
+
+fn join_patch_lines(lines: &[String]) -> String {
+    if lines.is_empty() {
+        String::new()
+    } else {
+        format!("{}\n", lines.join("\n"))
+    }
+}
+
+fn is_section_header(line: &str) -> bool {
+    is_file_header(line) || line == "*** End Patch"
+}
+
+fn is_file_header(line: &str) -> bool {
+    line.starts_with("*** Add File: ")
+        || line.starts_with("*** Update File: ")
+        || line.starts_with("*** Delete File: ")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use crate::hook::{ToolUse, apply_patch};
+
+    #[test]
+    fn add_file_normalizes_to_write() {
+        let parsed = apply_patch::parse(
+            "*** Begin Patch\n*** Add File: src/main.rs\n+fn main() {}\n*** End Patch\n",
+            std::path::Path::new("/tmp"),
+        )
+        .expect("parse patch");
+
+        assert!(
+            matches!(parsed.as_slice(), [ToolUse::Write(input)] if input.file_path == std::path::PathBuf::from("src/main.rs") && input.content == "fn main() {}\n")
+        );
+    }
+
+    #[test]
+    fn update_file_normalizes_to_edit_with_full_new_content() {
+        let temp = TempDir::new().expect("temp dir");
+        fs::write(temp.path().join("src.rs"), "fn main() {\n    old();\n}\n").expect("write file");
+
+        let parsed = apply_patch::parse(
+            "*** Begin Patch\n*** Update File: src.rs\n@@\n fn main() {\n-    old();\n+    new();\n }\n*** End Patch\n",
+            temp.path(),
+        )
+        .expect("parse patch");
+
+        assert!(
+            matches!(parsed.as_slice(), [ToolUse::Edit(input)] if input.file_path == std::path::PathBuf::from("src.rs") && input.new_string == "fn main() {\n    new();\n}\n")
+        );
+    }
+
+    #[test]
+    fn delete_file_normalizes_to_delete() {
+        let parsed = apply_patch::parse(
+            "*** Begin Patch\n*** Delete File: old.rs\n*** End Patch\n",
+            std::path::Path::new("/tmp"),
+        )
+        .expect("parse patch");
+
+        assert!(
+            matches!(parsed.as_slice(), [ToolUse::Delete(input)] if input.file_path == std::path::PathBuf::from("old.rs"))
+        );
+    }
+}

--- a/packages/nudge/src/hook/apply_patch.rs
+++ b/packages/nudge/src/hook/apply_patch.rs
@@ -16,7 +16,7 @@ pub fn parse(command: &str, cwd: &Path) -> Result<Vec<ToolUse>> {
         bail!("missing apply_patch begin marker");
     }
 
-    if !lines.iter().any(|line| *line == "*** End Patch") {
+    if !lines.contains(&"*** End Patch") {
         bail!("missing apply_patch end marker");
     }
 
@@ -194,7 +194,7 @@ fn is_file_header(line: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use std::fs;
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
 
     use tempfile::TempDir;
 
@@ -209,7 +209,7 @@ mod tests {
         .expect("parse patch");
 
         assert!(
-            matches!(parsed.as_slice(), [ToolUse::Write(input)] if input.file_path == PathBuf::from("src/main.rs") && input.content == "fn main() {}\n")
+            matches!(parsed.as_slice(), [ToolUse::Write(input)] if input.file_path == Path::new("src/main.rs") && input.content == "fn main() {}\n")
         );
     }
 
@@ -225,7 +225,7 @@ mod tests {
         .expect("parse patch");
 
         assert!(
-            matches!(parsed.as_slice(), [ToolUse::Edit(input)] if input.file_path == PathBuf::from("src.rs") && input.new_string == "fn main() {\n    new();\n}\n")
+            matches!(parsed.as_slice(), [ToolUse::Edit(input)] if input.file_path == Path::new("src.rs") && input.new_string == "fn main() {\n    new();\n}\n")
         );
     }
 
@@ -238,7 +238,7 @@ mod tests {
         .expect("parse patch");
 
         assert!(
-            matches!(parsed.as_slice(), [ToolUse::Delete(input)] if input.file_path == PathBuf::from("old.rs"))
+            matches!(parsed.as_slice(), [ToolUse::Delete(input)] if input.file_path == Path::new("old.rs"))
         );
     }
 }

--- a/packages/nudge/src/hook/evaluate.rs
+++ b/packages/nudge/src/hook/evaluate.rs
@@ -1,0 +1,297 @@
+//! Rule evaluation for normalized hook events.
+
+use indoc::formatdoc;
+use itertools::Itertools;
+
+use crate::{
+    hook::{
+        BashInput, EditInput, NudgeHook, PreToolUse, ToolUse, UserPromptSubmit, WebFetchInput,
+        WriteInput, response::HookOutcome,
+    },
+    rules::{
+        ContentMatcher, PreToolUseBashMatcher, PreToolUseEditMatcher, PreToolUseWebFetchMatcher,
+        PreToolUseWriteMatcher, Rule, UrlMatcher, UserPromptSubmitMatcher,
+    },
+    snippet::{Annotation, Match, Source},
+};
+
+/// Evaluate a normalized hook batch against loaded rules.
+///
+/// A raw provider hook can normalize into multiple Nudge events. This happens
+/// for Codex `apply_patch`, where one tool call can touch several files.
+pub fn evaluate_hooks(hooks: &[NudgeHook], rules: &[Rule]) -> HookOutcome {
+    let mut pretooluse_matches = Vec::new();
+    let mut user_prompt_matches = Vec::new();
+
+    for hook in hooks {
+        match hook {
+            NudgeHook::PreToolUse(payload) => {
+                pretooluse_matches.extend(evaluate_pretooluse(payload, rules));
+            }
+            NudgeHook::UserPromptSubmit(payload) => {
+                user_prompt_matches.extend(evaluate_userpromptsubmit(payload, rules));
+            }
+            NudgeHook::PermissionRequest(_) | NudgeHook::Other => {}
+        }
+    }
+
+    if !pretooluse_matches.is_empty() {
+        let matches = pretooluse_matches.join("\n\n");
+        return HookOutcome::DenyPreToolUse {
+            message: formatdoc! {"
+                Nudge blocked operation due to rule violation.
+                Fix all issues immediately and try again:
+
+                {matches}
+            "},
+        };
+    }
+
+    if !user_prompt_matches.is_empty() {
+        return HookOutcome::AddContext {
+            context: user_prompt_matches.join("\n\n"),
+        };
+    }
+
+    HookOutcome::Passthrough
+}
+
+fn evaluate_pretooluse(payload: &PreToolUse, rules: &[Rule]) -> Vec<String> {
+    let annotations = rules
+        .iter()
+        .flat_map(|rule| match &payload.tool {
+            ToolUse::Write(input) => annotate_write(rule, input),
+            ToolUse::Edit(input) => annotate_edit(rule, input),
+            ToolUse::WebFetch(input) => annotate_webfetch(rule, input),
+            ToolUse::Bash(input) => annotate_bash(rule, payload, input),
+            ToolUse::Delete(_) | ToolUse::Other { .. } => Vec::new(),
+        })
+        .collect_vec();
+
+    if annotations.is_empty() {
+        return Vec::new();
+    }
+
+    vec![source_for_tool(&payload.tool).annotate(annotations)]
+}
+
+fn evaluate_userpromptsubmit(payload: &UserPromptSubmit, rules: &[Rule]) -> Vec<String> {
+    let annotations = rules
+        .iter()
+        .flat_map(|rule| {
+            rule.hooks_userpromptsubmit()
+                .flat_map(|matcher| evaluate_user_prompt(payload, matcher))
+                .pipe_matches(rule)
+        })
+        .collect_vec();
+
+    if annotations.is_empty() {
+        return Vec::new();
+    }
+
+    vec![Source::from(&payload.prompt).annotate(annotations)]
+}
+
+trait PipeMatches: Iterator<Item = Match> + Sized {
+    fn pipe_matches(self, rule: &Rule) -> Vec<Annotation> {
+        rule.annotate_matches(self).collect_vec()
+    }
+}
+
+impl<T> PipeMatches for T where T: Iterator<Item = Match> {}
+
+fn annotate_write(rule: &Rule, input: &WriteInput) -> Vec<Annotation> {
+    rule.hooks_pretooluse_write()
+        .flat_map(|matcher| evaluate_write(input, matcher))
+        .pipe_matches(rule)
+}
+
+fn annotate_edit(rule: &Rule, input: &EditInput) -> Vec<Annotation> {
+    rule.hooks_pretooluse_edit()
+        .flat_map(|matcher| evaluate_edit(input, matcher))
+        .pipe_matches(rule)
+}
+
+fn annotate_webfetch(rule: &Rule, input: &WebFetchInput) -> Vec<Annotation> {
+    rule.hooks_pretooluse_webfetch()
+        .flat_map(|matcher| evaluate_webfetch(input, matcher))
+        .pipe_matches(rule)
+}
+
+fn annotate_bash(rule: &Rule, payload: &PreToolUse, input: &BashInput) -> Vec<Annotation> {
+    rule.hooks_pretooluse_bash()
+        .flat_map(|matcher| evaluate_bash(payload, input, matcher))
+        .pipe_matches(rule)
+}
+
+fn evaluate_write(input: &WriteInput, matcher: &PreToolUseWriteMatcher) -> Vec<Match> {
+    if matcher.file.is_match_path(&input.file_path) {
+        evaluate_all_matched(&input.content, &matcher.content)
+    } else {
+        Vec::new()
+    }
+}
+
+fn evaluate_edit(input: &EditInput, matcher: &PreToolUseEditMatcher) -> Vec<Match> {
+    if matcher.file.is_match_path(&input.file_path) {
+        evaluate_all_matched(&input.new_string, &matcher.new_content)
+    } else {
+        Vec::new()
+    }
+}
+
+fn evaluate_webfetch(input: &WebFetchInput, matcher: &PreToolUseWebFetchMatcher) -> Vec<Match> {
+    evaluate_all_url_matched(&input.url, &matcher.url)
+}
+
+fn evaluate_bash(
+    payload: &PreToolUse,
+    input: &BashInput,
+    matcher: &PreToolUseBashMatcher,
+) -> Vec<Match> {
+    for state_matcher in &matcher.project_state {
+        if !state_matcher.is_match(&payload.context.cwd) {
+            return Vec::new();
+        }
+    }
+
+    evaluate_all_matched(&input.command, &matcher.command)
+}
+
+fn evaluate_user_prompt(input: &UserPromptSubmit, matcher: &UserPromptSubmitMatcher) -> Vec<Match> {
+    evaluate_all_matched(&input.prompt, &matcher.prompt)
+}
+
+fn source_for_tool(tool: &ToolUse) -> Source {
+    match tool {
+        ToolUse::Write(input) => Source::from(&input.content),
+        ToolUse::Edit(input) => Source::from(&input.new_string),
+        ToolUse::Delete(_) | ToolUse::Other { .. } => Source::from(""),
+        ToolUse::WebFetch(input) => Source::from(&input.url),
+        ToolUse::Bash(input) => Source::from(&input.command),
+    }
+}
+
+/// Evaluate all content matchers and return matches only if every matcher
+/// matched.
+fn evaluate_all_matched(content: &str, matchers: &[ContentMatcher]) -> Vec<Match> {
+    let mut matches = Vec::new();
+    for matcher in matchers {
+        let matcher_matches = matcher.matches_with_context(content);
+        if matcher_matches.is_empty() {
+            return Vec::new();
+        }
+        matches.extend(matcher_matches);
+    }
+    matches
+}
+
+/// Evaluate all URL matchers and return matches only if every matcher matched.
+fn evaluate_all_url_matched(url: &str, matchers: &[UrlMatcher]) -> Vec<Match> {
+    let mut matches = Vec::new();
+    for matcher in matchers {
+        let matcher_matches = matcher.matches_with_context(url);
+        if matcher_matches.is_empty() {
+            return Vec::new();
+        }
+        matches.extend(matcher_matches);
+    }
+    matches
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::{
+        agent::{claude, codex},
+        hook::{NudgeHook, ToolUse, evaluate::evaluate_hooks, response::HookOutcome},
+        rules::RuleConfig,
+    };
+
+    fn rules(yaml: &str) -> Vec<crate::rules::Rule> {
+        serde_yaml::from_str::<RuleConfig>(yaml)
+            .expect("rules parse")
+            .rules
+    }
+
+    #[test]
+    fn permission_request_passes_through() {
+        let hook = claude::parse_hook(json!({
+            "hook_event_name": "PermissionRequest",
+            "session_id": "test",
+            "transcript_path": "/tmp/test",
+            "permission_mode": "default",
+            "cwd": "/tmp",
+            "tool_name": "Bash",
+            "tool_input": { "command": "rm -rf target" }
+        }))
+        .expect("parse hook");
+
+        assert!(matches!(hook.as_slice(), [NudgeHook::PermissionRequest(_)]));
+
+        let rules = rules(
+            r#"
+version: 1
+rules:
+  - name: block-rm
+    message: "No rm"
+    description: test
+    on:
+      - hook: PreToolUse
+        tool: Bash
+        command:
+          - kind: Regex
+            pattern: "rm"
+"#,
+        );
+
+        assert_eq!(evaluate_hooks(&hook, &rules), HookOutcome::Passthrough);
+    }
+
+    #[test]
+    fn delete_is_normalized_but_unmatchable() {
+        let hook = codex::parse_hook(json!({
+            "hook_event_name": "PreToolUse",
+            "cwd": "/tmp",
+            "tool_name": "apply_patch",
+            "tool_input": {
+                "command": "*** Begin Patch\n*** Delete File: test.rs\n*** End Patch\n"
+            }
+        }))
+        .expect("parse hook");
+
+        assert!(matches!(
+            hook.as_slice(),
+            [NudgeHook::PreToolUse(crate::hook::PreToolUse {
+                tool: ToolUse::Delete(_),
+                ..
+            })]
+        ));
+
+        let rules = rules(
+            r#"
+version: 1
+rules:
+  - name: no-inline-imports
+    message: "Move import"
+    description: test
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.rs"
+        content:
+          - kind: Regex
+            pattern: ".*"
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.rs"
+        new_content:
+          - kind: Regex
+            pattern: ".*"
+"#,
+        );
+
+        assert_eq!(evaluate_hooks(&hook, &rules), HookOutcome::Passthrough);
+    }
+}

--- a/packages/nudge/src/hook/evaluate.rs
+++ b/packages/nudge/src/hook/evaluate.rs
@@ -203,6 +203,8 @@ fn evaluate_all_url_matched(url: &str, matchers: &[UrlMatcher]) -> Vec<Match> {
 mod tests {
     use serde_json::json;
 
+    use pretty_assertions::assert_eq as pretty_assert_eq;
+
     use crate::{
         agent::{claude, codex},
         hook::{NudgeHook, ToolUse, evaluate::evaluate_hooks, response::HookOutcome},
@@ -246,7 +248,7 @@ rules:
 "#,
         );
 
-        assert_eq!(evaluate_hooks(&hook, &rules), HookOutcome::Passthrough);
+        pretty_assert_eq!(evaluate_hooks(&hook, &rules), HookOutcome::Passthrough);
     }
 
     #[test]
@@ -292,6 +294,6 @@ rules:
 "#,
         );
 
-        assert_eq!(evaluate_hooks(&hook, &rules), HookOutcome::Passthrough);
+        pretty_assert_eq!(evaluate_hooks(&hook, &rules), HookOutcome::Passthrough);
     }
 }

--- a/packages/nudge/src/hook/response.rs
+++ b/packages/nudge/src/hook/response.rs
@@ -1,0 +1,160 @@
+//! Provider-specific hook response rendering.
+
+use color_eyre::eyre::{Context, Result};
+use serde::Serialize;
+
+use crate::agent::AgentKind;
+
+/// Agent-neutral response decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HookOutcome {
+    /// Exit successfully with no output.
+    Passthrough,
+
+    /// Deny a `PreToolUse` operation.
+    DenyPreToolUse {
+        /// Feedback shown to the agent and user.
+        message: String,
+    },
+
+    /// Add context for `UserPromptSubmit`.
+    AddContext {
+        /// Context text.
+        context: String,
+    },
+}
+
+/// Render and print a hook outcome.
+pub fn emit(agent: AgentKind, outcome: HookOutcome) -> Result<()> {
+    match render(agent, outcome)? {
+        RenderedHookOutcome::NoOutput => {}
+        RenderedHookOutcome::Stdout(output) => println!("{output}"),
+    }
+
+    Ok(())
+}
+
+/// Render a hook outcome without printing.
+pub fn render(_agent: AgentKind, outcome: HookOutcome) -> Result<RenderedHookOutcome> {
+    match outcome {
+        HookOutcome::Passthrough => Ok(RenderedHookOutcome::NoOutput),
+        HookOutcome::AddContext { context } => Ok(RenderedHookOutcome::Stdout(context)),
+        HookOutcome::DenyPreToolUse { message } => {
+            let response = PreToolUseDenyResponse {
+                system_message: "Nudge blocked operation due to rule violation.".to_string(),
+                hook_specific_output: PreToolUseDenyOutput {
+                    hook_event_name: "PreToolUse".to_string(),
+                    permission_decision: "deny".to_string(),
+                    permission_decision_reason: message,
+                },
+            };
+
+            Ok(RenderedHookOutcome::Stdout(
+                serde_json::to_string(&response).context("serialize hook response")?,
+            ))
+        }
+    }
+}
+
+/// Rendered hook output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RenderedHookOutcome {
+    /// No output should be emitted.
+    NoOutput,
+
+    /// Text should be emitted on stdout.
+    Stdout(String),
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PreToolUseDenyResponse {
+    system_message: String,
+    hook_specific_output: PreToolUseDenyOutput,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PreToolUseDenyOutput {
+    hook_event_name: String,
+    permission_decision: String,
+    permission_decision_reason: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+
+    use crate::{
+        agent::AgentKind,
+        hook::response::{HookOutcome, RenderedHookOutcome, render},
+    };
+
+    #[test]
+    fn claude_denial_json_contains_permission_decision() {
+        let rendered = render(
+            AgentKind::Claude,
+            HookOutcome::DenyPreToolUse {
+                message: "blocked".to_string(),
+            },
+        )
+        .expect("render");
+
+        let RenderedHookOutcome::Stdout(output) = rendered else {
+            panic!("expected stdout");
+        };
+        let json = serde_json::from_str::<Value>(&output).expect("valid json");
+        assert_eq!(
+            json["hookSpecificOutput"]["permissionDecision"],
+            Value::String("deny".to_string())
+        );
+    }
+
+    #[test]
+    fn codex_denial_json_omits_unsupported_fields() {
+        let rendered = render(
+            AgentKind::Codex,
+            HookOutcome::DenyPreToolUse {
+                message: "blocked".to_string(),
+            },
+        )
+        .expect("render");
+
+        let RenderedHookOutcome::Stdout(output) = rendered else {
+            panic!("expected stdout");
+        };
+        let json = serde_json::from_str::<Value>(&output).expect("valid json");
+        assert_eq!(
+            json["hookSpecificOutput"]["permissionDecision"],
+            Value::String("deny".to_string())
+        );
+        assert!(json.get("continue").is_none());
+        assert!(json.get("stopReason").is_none());
+        assert!(json.get("suppressOutput").is_none());
+    }
+
+    #[test]
+    fn permission_request_passthrough_renders_no_output() {
+        let rendered = render(AgentKind::Claude, HookOutcome::Passthrough).expect("render");
+        assert_eq!(rendered, RenderedHookOutcome::NoOutput);
+
+        let rendered = render(AgentKind::Codex, HookOutcome::Passthrough).expect("render");
+        assert_eq!(rendered, RenderedHookOutcome::NoOutput);
+    }
+
+    #[test]
+    fn user_prompt_context_renders_plain_text() {
+        let rendered = render(
+            AgentKind::Codex,
+            HookOutcome::AddContext {
+                context: "remember this".to_string(),
+            },
+        )
+        .expect("render");
+
+        assert_eq!(
+            rendered,
+            RenderedHookOutcome::Stdout("remember this".to_string())
+        );
+    }
+}

--- a/packages/nudge/src/hook/response.rs
+++ b/packages/nudge/src/hook/response.rs
@@ -83,6 +83,7 @@ struct PreToolUseDenyOutput {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq as pretty_assert_eq;
     use serde_json::Value;
 
     use crate::{
@@ -104,7 +105,7 @@ mod tests {
             panic!("expected stdout");
         };
         let json = serde_json::from_str::<Value>(&output).expect("valid json");
-        assert_eq!(
+        pretty_assert_eq!(
             json["hookSpecificOutput"]["permissionDecision"],
             Value::String("deny".to_string())
         );
@@ -124,7 +125,7 @@ mod tests {
             panic!("expected stdout");
         };
         let json = serde_json::from_str::<Value>(&output).expect("valid json");
-        assert_eq!(
+        pretty_assert_eq!(
             json["hookSpecificOutput"]["permissionDecision"],
             Value::String("deny".to_string())
         );
@@ -136,10 +137,10 @@ mod tests {
     #[test]
     fn permission_request_passthrough_renders_no_output() {
         let rendered = render(AgentKind::Claude, HookOutcome::Passthrough).expect("render");
-        assert_eq!(rendered, RenderedHookOutcome::NoOutput);
+        pretty_assert_eq!(rendered, RenderedHookOutcome::NoOutput);
 
         let rendered = render(AgentKind::Codex, HookOutcome::Passthrough).expect("render");
-        assert_eq!(rendered, RenderedHookOutcome::NoOutput);
+        pretty_assert_eq!(rendered, RenderedHookOutcome::NoOutput);
     }
 
     #[test]
@@ -152,7 +153,7 @@ mod tests {
         )
         .expect("render");
 
-        assert_eq!(
+        pretty_assert_eq!(
             rendered,
             RenderedHookOutcome::Stdout("remember this".to_string())
         );

--- a/packages/nudge/src/lib.rs
+++ b/packages/nudge/src/lib.rs
@@ -1,7 +1,9 @@
 //! Main library for Nudge, used by its CLI.
 
+pub mod agent;
 pub mod claude;
 pub mod git;
+pub mod hook;
 pub mod rules;
 pub mod snippet;
 pub mod template;

--- a/packages/nudge/src/main.rs
+++ b/packages/nudge/src/main.rs
@@ -25,6 +25,9 @@ enum Commands {
     /// Integration with Claude Code.
     Claude(cmd::claude::Config),
 
+    /// Integration with Codex CLI.
+    Codex(cmd::codex::Config),
+
     /// Display the syntax tree for code (for writing tree-sitter queries).
     Syntaxtree(cmd::syntaxtree::Config),
 
@@ -78,9 +81,10 @@ fn main() -> Result<()> {
     match cli.command {
         Commands::Check(config) => cmd::check::main(config),
         Commands::Claude(config) => cmd::claude::main(config),
+        Commands::Codex(config) => cmd::codex::main(config),
         Commands::Syntaxtree(config) => cmd::syntaxtree::main(config),
         Commands::Validate(config) => cmd::validate::main(config),
         Commands::Test(config) => cmd::test::main(config),
     }
-    .suggestion("Run `nudge claude docs` for documentation on writing/debugging Claude Code rules.")
+    .suggestion("Run `nudge claude docs` or `nudge codex docs` for documentation on writing/debugging Nudge rules.")
 }

--- a/packages/nudge/tests/it/codex.rs
+++ b/packages/nudge/tests/it/codex.rs
@@ -1,0 +1,151 @@
+//! Codex hook integration tests.
+
+use std::io::Write as _;
+use std::process::{Command, Stdio};
+use std::{fs, path::PathBuf};
+
+use tempfile::TempDir;
+
+use crate::{Expected, assert_expected, codex_apply_patch_hook, run_codex_hook, user_prompt_hook};
+
+#[test]
+fn codex_apply_patch_write_blocks_inline_imports() {
+    let patch = "*** Begin Patch\n*** Add File: test.rs\n+fn main() {\n+    use std::io;\n+}\n*** End Patch\n";
+    let input = codex_apply_patch_hook("/tmp", patch);
+
+    let (exit_code, output) = run_codex_hook(&input);
+
+    assert_expected(exit_code, &output, Expected::Interrupt);
+    assert!(
+        !output.contains(r#""continue""#),
+        "Codex PreToolUse response must not include unsupported continue field: {output}"
+    );
+    assert!(
+        !output.contains(r#""stopReason""#),
+        "Codex PreToolUse response must not include unsupported stopReason field: {output}"
+    );
+    assert!(
+        !output.contains(r#""suppressOutput""#),
+        "Codex PreToolUse response must not include unsupported suppressOutput field: {output}"
+    );
+}
+
+#[test]
+fn codex_apply_patch_update_blocks_inline_imports() {
+    let temp = TempDir::new().expect("temp dir");
+    fs::write(temp.path().join("test.rs"), "fn main() {\n}\n").expect("write file");
+
+    let patch = "*** Begin Patch\n*** Update File: test.rs\n@@\n fn main() {\n+    use std::io;\n }\n*** End Patch\n";
+    let input = codex_apply_patch_hook(temp.path().to_str().expect("utf-8 path"), patch);
+
+    let (exit_code, output) = run_codex_hook(&input);
+
+    assert_expected(exit_code, &output, Expected::Interrupt);
+}
+
+#[test]
+fn codex_apply_patch_multi_file_aggregates_matches() {
+    let patch = "*** Begin Patch\n*** Add File: first.rs\n+fn first() {\n+    use std::io;\n+}\n*** Add File: second.rs\n+fn second() {\n+    use std::fs;\n+}\n*** End Patch\n";
+    let input = codex_apply_patch_hook("/tmp", patch);
+
+    let (exit_code, output) = run_codex_hook(&input);
+
+    assert_expected(exit_code, &output, Expected::Interrupt);
+    assert!(
+        output.contains("std::io") && output.contains("std::fs"),
+        "expected one denial to include matches from both files, got: {output}"
+    );
+}
+
+#[test]
+fn codex_permission_request_passes_through() {
+    let input = serde_json::json!({
+        "hook_event_name": "PermissionRequest",
+        "cwd": "/tmp",
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": "rm -rf target"
+        }
+    })
+    .to_string();
+
+    let (exit_code, output) = run_codex_hook(&input);
+
+    assert_expected(exit_code, &output, Expected::Passthrough);
+}
+
+#[test]
+fn codex_user_prompt_submit_injects_plain_text_context() {
+    let temp = TempDir::new().expect("temp dir");
+    fs::write(
+        temp.path().join(".nudge.yaml"),
+        r#"
+version: 1
+rules:
+  - name: dev-server-hint
+    description: Help start development server
+    message: "Use `cargo run -p nudge -- codex hook` for Codex hook checks."
+    on:
+      - hook: UserPromptSubmit
+        prompt:
+          - kind: Regex
+            pattern: "(?i)dev server"
+"#,
+    )
+    .expect("write config");
+    let input = user_prompt_hook("Can you start the dev server?");
+
+    let (exit_code, output) = run_codex_hook_in_dir(&temp, &input);
+
+    assert_expected(exit_code, &output, Expected::Continue);
+    assert!(
+        !output.trim_start().starts_with('{'),
+        "expected plain text context, got: {output}"
+    );
+}
+
+fn run_codex_hook_in_dir(dir: &TempDir, input: &str) -> (i32, String) {
+    let binary = get_binary_path();
+    let mut child = Command::new(&binary)
+        .args(["codex", "hook"])
+        .current_dir(dir.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn nudge");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(input.as_bytes())
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("wait for nudge");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = if !stdout.trim().is_empty() {
+        stdout.trim().to_string()
+    } else {
+        stderr.trim().to_string()
+    };
+
+    (output.status.code().unwrap_or(-1), combined)
+}
+
+fn get_binary_path() -> PathBuf {
+    let status = Command::new("cargo")
+        .args(["build", "--quiet", "-p", "nudge"])
+        .status()
+        .expect("build nudge");
+    assert!(status.success(), "cargo build failed");
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .parent()
+        .expect("manifest dir has parent")
+        .parent()
+        .expect("parent has parent")
+        .join("target/debug/nudge")
+}

--- a/packages/nudge/tests/it/main.rs
+++ b/packages/nudge/tests/it/main.rs
@@ -8,12 +8,14 @@
 mod bash;
 mod basic;
 mod cli;
+mod codex;
 mod edit_tool;
 mod external;
 mod inline_imports;
 mod message_content;
 mod multiple_rules;
 mod non_rust_files;
+mod setup;
 mod syntax_tree;
 mod user_prompt;
 mod webfetch;
@@ -129,9 +131,34 @@ pub fn bash_hook_with_cwd(command: &str, cwd: &str) -> String {
     .to_string()
 }
 
+/// Build a Codex PreToolUse hook JSON payload for the apply_patch tool.
+pub fn codex_apply_patch_hook(cwd: &str, command: &str) -> String {
+    serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "test",
+        "turn_id": "turn",
+        "cwd": cwd,
+        "tool_name": "apply_patch",
+        "tool_input": {
+            "command": command
+        }
+    })
+    .to_string()
+}
+
 /// Run nudge claude hook with the given input JSON and return (exit_code,
 /// output).
 pub fn run_hook(_sh: &Shell, input: &str) -> (i32, String) {
+    run_agent_hook("claude", input)
+}
+
+/// Run nudge codex hook with the given input JSON and return (exit_code,
+/// output).
+pub fn run_codex_hook(input: &str) -> (i32, String) {
+    run_agent_hook("codex", input)
+}
+
+fn run_agent_hook(agent: &str, input: &str) -> (i32, String) {
     // Build and get the binary path
     let status = Command::new("cargo")
         .args(["build", "--quiet", "-p", "nudge"])
@@ -141,7 +168,7 @@ pub fn run_hook(_sh: &Shell, input: &str) -> (i32, String) {
 
     // Run the binary directly with stdin
     let mut child = Command::new("cargo")
-        .args(["run", "--quiet", "-p", "nudge", "--", "claude", "hook"])
+        .args(["run", "--quiet", "-p", "nudge", "--", agent, "hook"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/packages/nudge/tests/it/setup.rs
+++ b/packages/nudge/tests/it/setup.rs
@@ -1,0 +1,249 @@
+//! Hook setup integration tests.
+
+use std::process::{Command, Stdio};
+
+use pretty_assertions::assert_eq as pretty_assert_eq;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn run_nudge(args: &[&str]) -> (i32, String, String) {
+    let mut cmd_args = vec!["run", "--quiet", "-p", "nudge", "--"];
+    cmd_args.extend(args);
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir
+        .parent()
+        .expect("manifest dir has parent")
+        .parent()
+        .expect("parent has parent");
+
+    let output = Command::new("cargo")
+        .args(&cmd_args)
+        .current_dir(workspace_root)
+        .env("RUST_BACKTRACE", "0")
+        .env("NUDGE_LOG", "error")
+        .output()
+        .expect("run nudge");
+
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    (exit_code, stdout, stderr)
+}
+
+fn run_built_nudge_in(dir: &TempDir, args: &[&str]) -> (i32, String, String) {
+    let status = Command::new("cargo")
+        .args(["build", "--quiet", "-p", "nudge"])
+        .status()
+        .expect("build nudge");
+    assert!(status.success(), "cargo build failed");
+
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let binary = manifest_dir
+        .parent()
+        .expect("manifest dir has parent")
+        .parent()
+        .expect("parent has parent")
+        .join("target/debug/nudge");
+
+    let output = Command::new(binary)
+        .args(args)
+        .current_dir(dir.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("run nudge")
+        .wait_with_output()
+        .expect("wait for nudge");
+
+    (
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
+}
+
+#[test]
+fn claude_setup_is_idempotent_and_installs_only_handled_events() {
+    let temp = TempDir::new().expect("temp dir");
+    let claude_dir = temp.path().join(".claude");
+    let claude_dir = claude_dir.to_str().expect("utf-8 path");
+
+    let args = [
+        "claude",
+        "setup",
+        "--claude-dir",
+        claude_dir,
+        "--skip-claude-md",
+    ];
+    let (exit_code, _, stderr) = run_nudge(&args);
+    pretty_assert_eq!(exit_code, 0, "setup failed: {stderr}");
+    let first = std::fs::read_to_string(temp.path().join(".claude/settings.local.json"))
+        .expect("read settings");
+
+    let (exit_code, _, stderr) = run_nudge(&args);
+    pretty_assert_eq!(exit_code, 0, "setup failed: {stderr}");
+    let second = std::fs::read_to_string(temp.path().join(".claude/settings.local.json"))
+        .expect("read settings");
+
+    pretty_assert_eq!(first, second);
+
+    let json = serde_json::from_str::<Value>(&second).expect("valid json");
+    assert!(json["hooks"]["PreToolUse"].is_array());
+    assert!(json["hooks"]["UserPromptSubmit"].is_array());
+    assert!(json["hooks"].get("PostToolUse").is_none());
+    assert!(json["hooks"].get("Stop").is_none());
+    assert_eq!(
+        json["hooks"]["PreToolUse"][0]["matcher"],
+        "Write|Edit|WebFetch|Bash"
+    );
+
+    let command = json["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+        .as_str()
+        .expect("command")
+        .to_string();
+    let mut with_old_events = json;
+    with_old_events["hooks"]["PostToolUse"] = serde_json::json!([
+        {
+            "matcher": "*",
+            "hooks": [{ "type": "command", "command": command, "timeout": 5 }]
+        }
+    ]);
+    with_old_events["hooks"]["Stop"] = serde_json::json!([
+        {
+            "hooks": [{ "type": "command", "command": command, "timeout": 5 }]
+        }
+    ]);
+    std::fs::write(
+        temp.path().join(".claude/settings.local.json"),
+        serde_json::to_string_pretty(&with_old_events).expect("serialize settings"),
+    )
+    .expect("write settings");
+
+    let (exit_code, _, stderr) = run_nudge(&args);
+    pretty_assert_eq!(exit_code, 0, "setup failed: {stderr}");
+    let cleaned = serde_json::from_str::<Value>(
+        &std::fs::read_to_string(temp.path().join(".claude/settings.local.json"))
+            .expect("read settings"),
+    )
+    .expect("valid json");
+    assert!(cleaned["hooks"].get("PostToolUse").is_none());
+    assert!(cleaned["hooks"].get("Stop").is_none());
+}
+
+#[test]
+fn codex_setup_creates_hooks_json_and_is_idempotent() {
+    let temp = TempDir::new().expect("temp dir");
+    let codex_dir = temp.path().join(".codex");
+    let codex_dir = codex_dir.to_str().expect("utf-8 path");
+    let args = ["codex", "setup", "--codex-dir", codex_dir];
+
+    let (exit_code, _, stderr) = run_nudge(&args);
+    pretty_assert_eq!(exit_code, 0, "setup failed: {stderr}");
+    let first = std::fs::read_to_string(temp.path().join(".codex/hooks.json")).expect("read hooks");
+
+    let (exit_code, _, stderr) = run_nudge(&args);
+    pretty_assert_eq!(exit_code, 0, "setup failed: {stderr}");
+    let second =
+        std::fs::read_to_string(temp.path().join(".codex/hooks.json")).expect("read hooks");
+
+    pretty_assert_eq!(first, second);
+
+    let json = serde_json::from_str::<Value>(&second).expect("valid json");
+    assert_eq!(
+        json["hooks"]["PreToolUse"][0]["matcher"],
+        "Bash|apply_patch"
+    );
+    assert!(json["hooks"]["UserPromptSubmit"][0]["hooks"].is_array());
+}
+
+#[test]
+fn codex_setup_preserves_existing_unrelated_hooks() {
+    let temp = TempDir::new().expect("temp dir");
+    let codex_dir = temp.path().join(".codex");
+    std::fs::create_dir_all(&codex_dir).expect("create .codex");
+    std::fs::write(
+        codex_dir.join("hooks.json"),
+        r#"{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"echo hi"}]}]}}"#,
+    )
+    .expect("write hooks");
+
+    let args = [
+        "codex",
+        "setup",
+        "--codex-dir",
+        codex_dir.to_str().expect("utf-8 path"),
+    ];
+    let (exit_code, _, stderr) = run_nudge(&args);
+    pretty_assert_eq!(exit_code, 0, "setup failed: {stderr}");
+
+    let json = serde_json::from_str::<Value>(
+        &std::fs::read_to_string(codex_dir.join("hooks.json")).expect("read hooks"),
+    )
+    .expect("valid json");
+    assert_eq!(
+        json["hooks"]["SessionStart"][0]["hooks"][0]["command"],
+        "echo hi"
+    );
+    assert!(json["hooks"]["PreToolUse"].is_array());
+}
+
+#[test]
+fn codex_setup_warns_and_skips_inline_toml_hooks() {
+    let temp = TempDir::new().expect("temp dir");
+    let codex_dir = temp.path().join(".codex");
+    std::fs::create_dir_all(&codex_dir).expect("create .codex");
+    std::fs::write(codex_dir.join("config.toml"), "[hooks]\n").expect("write config");
+
+    let args = [
+        "codex",
+        "setup",
+        "--codex-dir",
+        codex_dir.to_str().expect("utf-8 path"),
+    ];
+    let (exit_code, _stdout, stderr) = run_nudge(&args);
+
+    pretty_assert_eq!(exit_code, 0, "setup failed: {stderr}");
+    assert!(
+        stderr.contains("warning:"),
+        "expected warning for inline hooks, got: {stderr}"
+    );
+    assert!(
+        !codex_dir.join("hooks.json").exists(),
+        "setup should skip hooks.json when inline hooks exist"
+    );
+}
+
+#[test]
+fn validate_warns_for_codex_unsupported_webfetch_rules() {
+    let temp = TempDir::new().expect("temp dir");
+    std::fs::create_dir_all(temp.path().join(".codex")).expect("create .codex");
+    std::fs::write(
+        temp.path().join(".nudge.yaml"),
+        r#"
+version: 1
+rules:
+  - name: prefer-local-docs
+    description: Read local docs
+    message: "Use local docs"
+    on:
+      - hook: PreToolUse
+        tool: WebFetch
+        url:
+          - kind: Regex
+            pattern: "docs\\.rs"
+"#,
+    )
+    .expect("write rules");
+
+    let (exit_code, _stdout, stderr) = run_built_nudge_in(&temp, &["validate"]);
+
+    pretty_assert_eq!(exit_code, 0, "validate failed: {stderr}");
+    assert!(
+        stderr.contains(
+            "warning: rule \"prefer-local-docs\" uses PreToolUse WebFetch, which Claude Code supports but Codex hooks do not currently intercept."
+        ),
+        "expected Codex WebFetch warning, got: {stderr}"
+    );
+}

--- a/packages/nudge/tests/it/setup.rs
+++ b/packages/nudge/tests/it/setup.rs
@@ -1,15 +1,19 @@
 //! Hook setup integration tests.
 
-use std::process::{Command, Stdio};
+use std::{
+    fs,
+    path::PathBuf,
+    process::{Command, Stdio},
+};
 
 use pretty_assertions::assert_eq as pretty_assert_eq;
-use serde_json::Value;
+use serde_json::{Value, json};
 use tempfile::TempDir;
 
 fn run_nudge(args: &[&str]) -> (i32, String, String) {
     let mut cmd_args = vec!["run", "--quiet", "-p", "nudge", "--"];
     cmd_args.extend(args);
-    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let workspace_root = manifest_dir
         .parent()
         .expect("manifest dir has parent")
@@ -38,7 +42,7 @@ fn run_built_nudge_in(dir: &TempDir, args: &[&str]) -> (i32, String, String) {
         .expect("build nudge");
     assert!(status.success(), "cargo build failed");
 
-    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let binary = manifest_dir
         .parent()
         .expect("manifest dir has parent")
@@ -79,13 +83,13 @@ fn claude_setup_is_idempotent_and_installs_only_handled_events() {
     ];
     let (exit_code, _, stderr) = run_nudge(&args);
     pretty_assert_eq!(exit_code, 0, "setup failed: {stderr}");
-    let first = std::fs::read_to_string(temp.path().join(".claude/settings.local.json"))
-        .expect("read settings");
+    let first =
+        fs::read_to_string(temp.path().join(".claude/settings.local.json")).expect("read settings");
 
     let (exit_code, _, stderr) = run_nudge(&args);
     pretty_assert_eq!(exit_code, 0, "setup failed: {stderr}");
-    let second = std::fs::read_to_string(temp.path().join(".claude/settings.local.json"))
-        .expect("read settings");
+    let second =
+        fs::read_to_string(temp.path().join(".claude/settings.local.json")).expect("read settings");
 
     pretty_assert_eq!(first, second);
 
@@ -94,7 +98,7 @@ fn claude_setup_is_idempotent_and_installs_only_handled_events() {
     assert!(json["hooks"]["UserPromptSubmit"].is_array());
     assert!(json["hooks"].get("PostToolUse").is_none());
     assert!(json["hooks"].get("Stop").is_none());
-    assert_eq!(
+    pretty_assert_eq!(
         json["hooks"]["PreToolUse"][0]["matcher"],
         "Write|Edit|WebFetch|Bash"
     );
@@ -104,18 +108,18 @@ fn claude_setup_is_idempotent_and_installs_only_handled_events() {
         .expect("command")
         .to_string();
     let mut with_old_events = json;
-    with_old_events["hooks"]["PostToolUse"] = serde_json::json!([
+    with_old_events["hooks"]["PostToolUse"] = json!([
         {
             "matcher": "*",
             "hooks": [{ "type": "command", "command": command, "timeout": 5 }]
         }
     ]);
-    with_old_events["hooks"]["Stop"] = serde_json::json!([
+    with_old_events["hooks"]["Stop"] = json!([
         {
             "hooks": [{ "type": "command", "command": command, "timeout": 5 }]
         }
     ]);
-    std::fs::write(
+    fs::write(
         temp.path().join(".claude/settings.local.json"),
         serde_json::to_string_pretty(&with_old_events).expect("serialize settings"),
     )
@@ -124,7 +128,7 @@ fn claude_setup_is_idempotent_and_installs_only_handled_events() {
     let (exit_code, _, stderr) = run_nudge(&args);
     pretty_assert_eq!(exit_code, 0, "setup failed: {stderr}");
     let cleaned = serde_json::from_str::<Value>(
-        &std::fs::read_to_string(temp.path().join(".claude/settings.local.json"))
+        &fs::read_to_string(temp.path().join(".claude/settings.local.json"))
             .expect("read settings"),
     )
     .expect("valid json");
@@ -141,17 +145,16 @@ fn codex_setup_creates_hooks_json_and_is_idempotent() {
 
     let (exit_code, _, stderr) = run_nudge(&args);
     pretty_assert_eq!(exit_code, 0, "setup failed: {stderr}");
-    let first = std::fs::read_to_string(temp.path().join(".codex/hooks.json")).expect("read hooks");
+    let first = fs::read_to_string(temp.path().join(".codex/hooks.json")).expect("read hooks");
 
     let (exit_code, _, stderr) = run_nudge(&args);
     pretty_assert_eq!(exit_code, 0, "setup failed: {stderr}");
-    let second =
-        std::fs::read_to_string(temp.path().join(".codex/hooks.json")).expect("read hooks");
+    let second = fs::read_to_string(temp.path().join(".codex/hooks.json")).expect("read hooks");
 
     pretty_assert_eq!(first, second);
 
     let json = serde_json::from_str::<Value>(&second).expect("valid json");
-    assert_eq!(
+    pretty_assert_eq!(
         json["hooks"]["PreToolUse"][0]["matcher"],
         "Bash|apply_patch"
     );
@@ -162,8 +165,8 @@ fn codex_setup_creates_hooks_json_and_is_idempotent() {
 fn codex_setup_preserves_existing_unrelated_hooks() {
     let temp = TempDir::new().expect("temp dir");
     let codex_dir = temp.path().join(".codex");
-    std::fs::create_dir_all(&codex_dir).expect("create .codex");
-    std::fs::write(
+    fs::create_dir_all(&codex_dir).expect("create .codex");
+    fs::write(
         codex_dir.join("hooks.json"),
         r#"{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"echo hi"}]}]}}"#,
     )
@@ -179,10 +182,10 @@ fn codex_setup_preserves_existing_unrelated_hooks() {
     pretty_assert_eq!(exit_code, 0, "setup failed: {stderr}");
 
     let json = serde_json::from_str::<Value>(
-        &std::fs::read_to_string(codex_dir.join("hooks.json")).expect("read hooks"),
+        &fs::read_to_string(codex_dir.join("hooks.json")).expect("read hooks"),
     )
     .expect("valid json");
-    assert_eq!(
+    pretty_assert_eq!(
         json["hooks"]["SessionStart"][0]["hooks"][0]["command"],
         "echo hi"
     );
@@ -193,8 +196,8 @@ fn codex_setup_preserves_existing_unrelated_hooks() {
 fn codex_setup_warns_and_skips_inline_toml_hooks() {
     let temp = TempDir::new().expect("temp dir");
     let codex_dir = temp.path().join(".codex");
-    std::fs::create_dir_all(&codex_dir).expect("create .codex");
-    std::fs::write(codex_dir.join("config.toml"), "[hooks]\n").expect("write config");
+    fs::create_dir_all(&codex_dir).expect("create .codex");
+    fs::write(codex_dir.join("config.toml"), "[hooks]\n").expect("write config");
 
     let args = [
         "codex",
@@ -218,8 +221,8 @@ fn codex_setup_warns_and_skips_inline_toml_hooks() {
 #[test]
 fn validate_warns_for_codex_unsupported_webfetch_rules() {
     let temp = TempDir::new().expect("temp dir");
-    std::fs::create_dir_all(temp.path().join(".codex")).expect("create .codex");
-    std::fs::write(
+    fs::create_dir_all(temp.path().join(".codex")).expect("create .codex");
+    fs::write(
         temp.path().join(".nudge.yaml"),
         r#"
 version: 1


### PR DESCRIPTION
**Why this change**

- Nudge was still centered on Claude Code hook payloads, even though the rule language already describes provider-neutral concepts like `PreToolUse`, `UserPromptSubmit`, `Write`, `Edit`, `WebFetch`, and `Bash`.
- Codex CLI hooks are now generally available, so Nudge should support Codex without requiring users to fork rule files or think in terms of Codex-specific `apply_patch` payloads.
- This PR introduces a normalized hook layer: provider adapters parse Claude Code or Codex wire formats, Nudge evaluates one shared event model, and provider-specific response renderers produce the correct hook output.
- Codex `apply_patch` is normalized into `Write`, `Edit`, and parsed-but-unmatchable `Delete` events. `PermissionRequest` is parsed for both providers but intentionally passes through until Nudge has a permission-specific rule surface.
- Claude setup is narrowed to events Nudge actually handles, and Codex setup installs local `.codex/hooks.json` command hooks for `PreToolUse` and `UserPromptSubmit`.

**Configuration changes after merge**

1. Existing Claude Code users can keep their current rules. To refresh local hook setup and remove older Nudge-managed `PostToolUse` / `Stop` hooks, run:

   ```bash
   nudge claude setup
   ```

2. Codex users can install equivalent project-local hooks with:

   ```bash
   nudge codex setup
   ```

3. After `nudge codex setup`, restart open Codex sessions, run `/hooks`, review the new Nudge command hooks, and trust them.

4. If Codex hooks do not appear, verify that the project `.codex/` layer is trusted and `[features].hooks` has not been disabled in Codex config.

**Testing steps performed**

```bash
cargo test -p nudge
```

```text
test result: ok. 56 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 70 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 6.65s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

```bash
cargo run -p nudge -- check
```

```text
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.05s
Running `target/debug/nudge check`
Checked 73 files against 6 rules
  - .nudge.yaml: 6 rules
```

```bash
cargo run -p nudge -- claude docs
cargo run -p nudge -- codex docs
```

```text
Running `target/debug/nudge claude docs`
Nudge Rule Writing Guide
...
Running `target/debug/nudge codex docs`
Nudge Rule Writing Guide
...
```

```bash
git diff --check
```

```text
clean
```

I also installed Codex hooks locally in this repo:

```bash
cargo run -p nudge -- codex setup
```

```text
Wrote hooks configuration to /Users/jess/org/attune/nudge/.codex/hooks.json
```

Then I smoke-tested the real Codex hook path by attempting to write a Rust file with an inline `use` statement through `apply_patch`. The hook blocked the write before the file was created:

```text
Command blocked by PreToolUse hook: Nudge blocked operation due to rule violation.
Fix all issues immediately and try again:

error: Rule violation. Fix this error and immediately retry.
  |
1 | fn main() {
2 |     use std::io;
  |     ^^^^^^^^^^^^ Move this `use` statement to the top of the file with other imports, then retry.
3 |
4 |     let _ = io::stdout();
5 | }
  |. Command: *** Begin Patch
*** Add File: nudge_hook_probe.rs
+fn main() {
+    use std::io;
+
+    let _ = io::stdout();
+}
*** End Patch
```

**Notes**

- Codex `WebSearch` / `WebFetch` interception is documented as unsupported for current Codex hooks, so the docs and `nudge validate` warn about `WebFetch` rules in Codex-targeted projects instead of claiming enforcement there.
- `nudge check` remains repository-file validation. It evaluates file rules directly from the shared rule schema and does not attempt to replay Codex hook payloads.
