### PR TITLE
Add Bash substitution rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,9 +88,11 @@ When Nudge has something to share, it responds in one of three ways:
 - **Passthrough**: Nothing to note. Carry on!
 - **Continue**: For UserPromptSubmit hooks, Nudge injects context as plain text
 - **Interrupt**: For PreToolUse hooks, Nudge blocks the operation and explains what to fix
+- **Substitute**: For deterministic PreToolUse Bash rules, Nudge rewrites the command and lets it proceed
 
 The response type is determined by the hook type:
-- `PreToolUse` rules always **interrupt** (block provider-supported Write/Edit/WebFetch/Bash operations)
+- `PreToolUse` block rules **interrupt** (block provider-supported Write/Edit/WebFetch/Bash operations)
+- `PreToolUse` substitute rules **allow with updated input** (Claude Code and Codex CLI Bash commands)
 - `UserPromptSubmit` rules always **continue** (inject guidance into the conversation)
 - `PermissionRequest` is parsed but always **passes through** until Nudge has a permission-specific rule surface
 - `Delete` is normalized but not yet matchable from YAML rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,9 +88,11 @@ When Nudge has something to share, it responds in one of three ways:
 - **Passthrough**: Nothing to note. Carry on!
 - **Continue**: For UserPromptSubmit hooks, Nudge injects context as plain text
 - **Interrupt**: For PreToolUse hooks, Nudge blocks the operation and explains what to fix
+- **Substitute**: For deterministic PreToolUse Bash rules, Nudge rewrites the command and lets it proceed
 
 The response type is determined by the hook type:
-- `PreToolUse` rules always **interrupt** (block provider-supported Write/Edit/WebFetch/Bash operations)
+- `PreToolUse` block rules **interrupt** (block provider-supported Write/Edit/WebFetch/Bash operations)
+- `PreToolUse` substitute rules **allow with updated input** (Claude Code and Codex CLI Bash commands)
 - `UserPromptSubmit` rules always **continue** (inject guidance into the conversation)
 - `PermissionRequest` is parsed but always **passes through** until Nudge has a permission-specific rule surface
 - `Delete` is normalized but not yet matchable from YAML rules

--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ nudge check "**/*.rs"
 nudge check || exit 1
 ```
 
+`nudge check` only evaluates file-based block rules for `PreToolUse` Write/Edit matchers. It ignores `action: substitute` rules because substitutions rewrite live Bash hook payloads and need a provider to receive `updatedInput`.
+
 Example output when violations are found:
 
 ```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Nudge uses agent hook systems to watch supported operations:
 When something matches a rule you've defined:
 
 - **Interrupt** (PreToolUse rules): Nudge catches the issue *before* it's written and explains what to fix
+- **Substitute** (PreToolUse Bash rules): Nudge rewrites simple deterministic commands, lets the tool proceed, and tells the model what changed
 - **Continue** (UserPromptSubmit rules): Nudge injects context into the conversation to guide the agent
 - **Passthrough**: No rules matched, everything proceeds normally
 
@@ -70,6 +71,24 @@ error: rule violation
 ```
 
 The pattern: **what's wrong** -> **how to fix** -> **retry**.
+
+For simple mechanical Bash command rewrites, use `action: substitute` with a regex `replace:` template instead of a blocking message:
+
+```yaml
+version: 1
+rules:
+  - name: use-yarn-add
+    action: substitute
+    on:
+      - hook: PreToolUse
+        tool: Bash
+        command:
+          - kind: Regex
+            pattern: "^npm install(?: (?P<args>.*))?$"
+            replace: "yarn add {{ $args }}"
+```
+
+Substitutions work for Claude Code and Codex CLI. Nudge returns the provider's full updated tool input with only `command` changed, and adds `hookSpecificOutput.additionalContext` so the model sees what was rewritten.
 
 For the full rule syntax and copy-pasteable examples, run `nudge claude docs` or `nudge codex docs`.
 
@@ -216,7 +235,7 @@ echo '{
   }
 }' | nudge codex hook
 
-# Exit 0 with JSON output = Interrupt (rule matched, operation blocked)
+# Exit 0 with JSON output = Interrupt or Substitute (rule matched)
 # Exit 0 with plain text = Continue (UserPromptSubmit context injected)
 # Exit 0 with no output = Passthrough (nothing to note)
 ```

--- a/docs/rfc/0002-claude-and-codex-hooks.md
+++ b/docs/rfc/0002-claude-and-codex-hooks.md
@@ -91,6 +91,24 @@ Codex `PreToolUse` denial should be returned through the hook-specific shape:
 }
 ```
 
+Codex `PreToolUse` substitution should use `permissionDecision: "allow"` with
+`updatedInput`, and should include `hookSpecificOutput.additionalContext` when
+Nudge needs the model to know what was rewritten:
+
+```json
+{
+  "systemMessage": "Nudge substituted `npm install foo` -> `yarn add foo`.",
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow",
+    "updatedInput": {
+      "command": "yarn add foo"
+    },
+    "additionalContext": "Nudge rewrote the Bash command from `npm install foo` to `yarn add foo` before execution."
+  }
+}
+```
+
 Important compatibility detail: Codex documents `continue`, `stopReason`, and
 `suppressOutput` as unsupported for `PreToolUse`. Returning those fields on
 `PreToolUse` makes the hook run fail and Codex continues the tool call. Nudge's
@@ -408,7 +426,8 @@ pub fn evaluate_hook(hook: &NudgeHook, rules: &[Rule]) -> Evaluation;
 
 The existing behavior remains:
 
-- `PreToolUse` matches produce a blocking denial.
+- `PreToolUse` block matches produce a blocking denial.
+- `PreToolUse` Bash substitute matches produce an allow response with updated input.
 - `UserPromptSubmit` matches produce context on stdout.
 - `PermissionRequest` always passes through in this update.
 - No matches produce no output and exit 0.
@@ -425,6 +444,11 @@ Define an abstract outcome:
 pub enum HookOutcome {
     Passthrough,
     DenyPreToolUse { message: String },
+    UpdatePreToolUse {
+        system_message: String,
+        additional_context: String,
+        updated_input: Value,
+    },
     AddContext { context: String },
 }
 ```
@@ -459,6 +483,12 @@ Codex `DenyPreToolUse`:
 
 Do not include `continue`, `stopReason`, or `suppressOutput` on `PreToolUse`.
 This is the key wire-format fix for Codex.
+
+For `UpdatePreToolUse`, render `permissionDecision: "allow"` with a full
+`updatedInput` object. Preserve every original tool input field and replace
+only the rewritten field. Put the model-visible explanation in
+`hookSpecificOutput.additionalContext`; use `systemMessage` only as an
+audit/user-visible note.
 
 For `UserPromptSubmit`, prefer plain stdout for both agents. It is simple and
 documented by both hook systems as model-visible context.

--- a/packages/nudge/src/agent/claude.rs
+++ b/packages/nudge/src/agent/claude.rs
@@ -23,6 +23,7 @@ pub fn parse_hook(raw: Value) -> Result<Vec<NudgeHook>> {
 
     match event {
         "PreToolUse" => Ok(vec![NudgeHook::PreToolUse(PreToolUse {
+            tool_input: raw.get("tool_input").cloned().unwrap_or(Value::Null),
             tool: tool_use(&raw)?,
             context,
         })]),
@@ -111,6 +112,8 @@ fn path_field(value: &Value, field: &str) -> Result<PathBuf> {
 mod tests {
     use serde_json::json;
 
+    use pretty_assertions::assert_eq as pretty_assert_eq;
+
     use crate::hook::{NudgeHook, ToolUse};
 
     use super::parse_hook;
@@ -154,13 +157,17 @@ mod tests {
             "hook_event_name": "PreToolUse",
             "cwd": "/tmp",
             "tool_name": "Bash",
-            "tool_input": { "command": "cargo test" }
+            "tool_input": { "command": "cargo test", "timeout": 120 }
         }))
         .expect("parse hook");
 
         assert!(
             matches!(hooks.as_slice(), [NudgeHook::PreToolUse(payload)] if matches!(payload.tool, ToolUse::Bash(_)))
         );
+        let [NudgeHook::PreToolUse(payload)] = hooks.as_slice() else {
+            panic!("expected PreToolUse");
+        };
+        pretty_assert_eq!(payload.tool_input["timeout"], 120);
     }
 
     #[test]

--- a/packages/nudge/src/agent/codex.rs
+++ b/packages/nudge/src/agent/codex.rs
@@ -37,6 +37,7 @@ pub fn parse_hook(raw: Value) -> Result<Vec<NudgeHook>> {
 
 fn pretooluse(raw: Value, context: HookContext) -> Vec<NudgeHook> {
     let tool = tool_use(&raw);
+    let tool_input = raw.get("tool_input").cloned().unwrap_or(Value::Null);
     match tool {
         ToolUse::Other { tool_name, input } if tool_name == "apply_patch" => {
             let command = input
@@ -49,6 +50,7 @@ fn pretooluse(raw: Value, context: HookContext) -> Vec<NudgeHook> {
                     .map(|tool| {
                         NudgeHook::PreToolUse(PreToolUse {
                             context: context.clone(),
+                            tool_input: tool_input.clone(),
                             tool,
                         })
                     })
@@ -59,7 +61,11 @@ fn pretooluse(raw: Value, context: HookContext) -> Vec<NudgeHook> {
                 }
             }
         }
-        tool => vec![NudgeHook::PreToolUse(PreToolUse { context, tool })],
+        tool => vec![NudgeHook::PreToolUse(PreToolUse {
+            context,
+            tool_input,
+            tool,
+        })],
     }
 }
 

--- a/packages/nudge/src/cmd/check.rs
+++ b/packages/nudge/src/cmd/check.rs
@@ -13,7 +13,7 @@ use color_eyre::eyre::{Context, Result};
 use glob::Pattern;
 use ignore::WalkBuilder;
 
-use nudge::rules::{self, ContentMatcher, GlobMatcher, Hook, PreToolUseMatcher, Rule};
+use nudge::rules::{self, ContentMatcher, GlobMatcher, Hook, PreToolUseMatcher, Rule, RuleAction};
 
 #[derive(Args, Clone, Debug)]
 pub struct Config {
@@ -93,19 +93,27 @@ fn collect_file_rules(rules_by_source: &[(PathBuf, Vec<Rule>)]) -> (Vec<FileRule
 }
 
 fn file_rules_for_rule(rule: &Rule) -> impl Iterator<Item = FileRule<'_>> {
-    rule.on.iter().filter_map(move |hook| match hook {
-        Hook::PreToolUse(PreToolUseMatcher::Write(matcher)) => Some(FileRule {
-            pattern: &matcher.file,
-            matchers: ContentMatcherSet::Write(&matcher.content),
-            rule,
-        }),
-        Hook::PreToolUse(PreToolUseMatcher::Edit(matcher)) => Some(FileRule {
-            pattern: &matcher.file,
-            matchers: ContentMatcherSet::Edit(&matcher.new_content),
-            rule,
-        }),
-        _ => None,
-    })
+    if rule.action != RuleAction::Block {
+        return Vec::new().into_iter();
+    }
+
+    rule.on
+        .iter()
+        .filter_map(move |hook| match hook {
+            Hook::PreToolUse(PreToolUseMatcher::Write(matcher)) => Some(FileRule {
+                pattern: &matcher.file,
+                matchers: ContentMatcherSet::Write(&matcher.content),
+                rule,
+            }),
+            Hook::PreToolUse(PreToolUseMatcher::Edit(matcher)) => Some(FileRule {
+                pattern: &matcher.file,
+                matchers: ContentMatcherSet::Edit(&matcher.new_content),
+                rule,
+            }),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .into_iter()
 }
 
 fn check_files(files: &[PathBuf], file_rules: &[FileRule<'_>]) -> (Vec<Issue>, usize) {
@@ -164,7 +172,7 @@ fn rule_issues(file: &Path, content: &str, file_rule: &FileRule<'_>) -> Vec<Issu
         .flat_map(|matcher| matcher.matches_with_context(content))
         .map(|m| {
             let line = byte_offset_to_line(content, m.span.start);
-            let message = nudge::template::interpolate(&file_rule.rule.message, &m.captures);
+            let message = nudge::template::interpolate(file_rule.rule.message(), &m.captures);
 
             Issue {
                 file: file.to_path_buf(),

--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -45,7 +45,8 @@ const DOCS: &str = cstr!("\
   <yellow>rules:</yellow>
     <yellow>- name: rule-identifier</yellow>
       <yellow>description: \"Human-readable description\"</yellow>  <dim># Optional</dim>
-      <yellow>message: \"Your message shown at each match\"</yellow>
+      <yellow>action: block</yellow>                         <dim># block (default) or substitute</dim>
+      <yellow>message: \"Your message shown at each match\"</yellow> <dim># Required for useful block rules</dim>
 
       <yellow>on:</yellow>                           <dim># List of matchers (any match triggers the rule)</dim>
         <yellow>- hook: PreToolUse</yellow>          <dim># PreToolUse or UserPromptSubmit</dim>
@@ -54,6 +55,7 @@ const DOCS: &str = cstr!("\
           <yellow>content:</yellow>                   <dim># Patterns to match (Write tool)</dim>
             <yellow>- kind: Regex</yellow>
               <yellow>pattern: \"your-regex\"</yellow>
+              <yellow>replace: \"optional\"</yellow>      <dim># Template for substitute action</dim>
               <yellow>suggestion: \"optional\"</yellow>   <dim># Template for suggested fix</dim>
 
         <yellow>- hook: PreToolUse</yellow>          <dim># Same rule can match multiple scenarios</dim>
@@ -67,8 +69,8 @@ const DOCS: &str = cstr!("\
 <bold>Hook Types</bold>
 
   <green>PreToolUse</green>        Triggers before provider-supported Write/Edit/WebFetch/Bash
-                    operations. Always <cyan>interrupts</cyan> (blocks the operation until
-                    the issue is fixed).
+                    operations. Block rules <cyan>interrupt</cyan>; Bash substitute rules
+                    rewrite the command and allow it to proceed.
 
   <green>UserPromptSubmit</green>  Triggers when user submits a prompt. Always <cyan>continues</cyan>
                     (injects context into the conversation).
@@ -143,6 +145,31 @@ const DOCS: &str = cstr!("\
     <green>Replace with foo.expect(\"error message\")</green>
 
   Each match gets its own suggestion with its specific captures.
+
+<bold>Substitution Rules</bold>
+
+  Use <cyan>action: substitute</cyan> for deterministic Bash command rewrites. Substitute rules
+  do not need a message. They match the current Bash command, apply Regex <cyan>replace:</cyan>
+  templates in rule order, return the provider's full updated tool input, and add
+  <cyan>hookSpecificOutput.additionalContext</cyan> so the model sees what changed.
+
+  <white>Basic Syntax:</white>
+    <yellow>- name: use-yarn-add</yellow>
+      <yellow>description: Use yarn add instead of npm install</yellow>
+      <yellow>action: substitute</yellow>
+      <yellow>on:</yellow>
+        <yellow>- hook: PreToolUse</yellow>
+          <yellow>tool: Bash</yellow>
+          <yellow>command:</yellow>
+            <yellow>- kind: Regex</yellow>
+              <yellow>pattern: \"^npm install(?: (?P<<args>>.*))?$\"</yellow>
+              <yellow>replace: \"yarn add {{ $args }}\"</yellow>
+
+  <dim>For input</dim> <green>npm install lodash</green><dim>, Nudge runs</dim> <green>yarn add lodash</green><dim>.</dim>
+
+  <dim>Substitutions currently apply to Bash commands for Claude Code and Codex CLI.</dim>
+  <dim>Write/Edit substitutions are intentionally not exposed because Codex apply_patch</dim>
+  <dim>normalization would need a lossless patch rewrite.</dim>
 
 <bold>How Messages Are Displayed</bold>
 
@@ -394,6 +421,21 @@ const DOCS: &str = cstr!("\
               <yellow>branch:</yellow>
                 <yellow>- kind: Regex</yellow>
                   <yellow>pattern: \"^main$\"</yellow>
+
+  <cyan>Substitute npm install with yarn add (Bash)</cyan>
+
+    <dim># Mechanical command rewrites can proceed without a retry loop.</dim>
+
+    <yellow>- name: use-yarn-add</yellow>
+      <yellow>description: Use yarn add instead of npm install</yellow>
+      <yellow>action: substitute</yellow>
+      <yellow>on:</yellow>
+        <yellow>- hook: PreToolUse</yellow>
+          <yellow>tool: Bash</yellow>
+          <yellow>command:</yellow>
+            <yellow>- kind: Regex</yellow>
+              <yellow>pattern: \"^npm install(?: (?P<<args>>.*))?$\"</yellow>
+              <yellow>replace: \"yarn add {{ $args }}\"</yellow>
 
   <cyan>Block dangerous commands (Bash)</cyan>
 

--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -171,6 +171,10 @@ const DOCS: &str = cstr!("\
   <dim>Write/Edit substitutions are intentionally not exposed because Codex apply_patch</dim>
   <dim>normalization would need a lossless patch rewrite.</dim>
 
+  <dim>CI note: nudge check ignores substitute rules. Check mode scans repository</dim>
+  <dim>files against file-based block rules; substitutions need a live Bash hook</dim>
+  <dim>payload and a provider that can receive updatedInput.</dim>
+
 <bold>How Messages Are Displayed</bold>
 
   When a rule matches, Nudge displays a <cyan>code snippet</cyan> with your message shown

--- a/packages/nudge/src/cmd/test.rs
+++ b/packages/nudge/src/cmd/test.rs
@@ -67,6 +67,17 @@ pub fn main(config: Config) -> Result<()> {
             println!("Matched content:");
             println!("{message}");
         }
+        HookOutcome::UpdatePreToolUse {
+            system_message,
+            additional_context,
+            updated_input,
+        } => {
+            println!("Result: Substitute");
+            println!();
+            println!("{system_message}");
+            println!("{additional_context}");
+            println!("{}", serde_json::to_string_pretty(&updated_input)?);
+        }
         HookOutcome::AddContext { context } => {
             println!("Result: Continue");
             println!();

--- a/packages/nudge/src/hook.rs
+++ b/packages/nudge/src/hook.rs
@@ -57,6 +57,13 @@ pub struct PreToolUse {
     /// Shared hook context.
     pub context: HookContext,
 
+    /// Original provider tool input.
+    ///
+    /// Nudge evaluates normalized tool shapes, but provider rewrite responses
+    /// must return the complete tool input object with only the intended fields
+    /// changed.
+    pub tool_input: Value,
+
     /// Normalized tool input.
     pub tool: ToolUse,
 }

--- a/packages/nudge/src/hook/evaluate.rs
+++ b/packages/nudge/src/hook/evaluate.rs
@@ -2,6 +2,7 @@
 
 use indoc::formatdoc;
 use itertools::Itertools;
+use serde_json::Value;
 
 use crate::{
     hook::{
@@ -10,7 +11,7 @@ use crate::{
     },
     rules::{
         ContentMatcher, PreToolUseBashMatcher, PreToolUseEditMatcher, PreToolUseWebFetchMatcher,
-        PreToolUseWriteMatcher, Rule, UrlMatcher, UserPromptSubmitMatcher,
+        PreToolUseWriteMatcher, Rule, RuleAction, UrlMatcher, UserPromptSubmitMatcher,
     },
     snippet::{Annotation, Match, Source},
 };
@@ -21,12 +22,15 @@ use crate::{
 /// for Codex `apply_patch`, where one tool call can touch several files.
 pub fn evaluate_hooks(hooks: &[NudgeHook], rules: &[Rule]) -> HookOutcome {
     let mut pretooluse_matches = Vec::new();
+    let mut pretooluse_update = None;
     let mut user_prompt_matches = Vec::new();
 
     for hook in hooks {
         match hook {
             NudgeHook::PreToolUse(payload) => {
-                pretooluse_matches.extend(evaluate_pretooluse(payload, rules));
+                let (payload, update) = apply_pretooluse_substitutions(payload, rules);
+                pretooluse_update = pretooluse_update.or(update);
+                pretooluse_matches.extend(evaluate_pretooluse(&payload, rules));
             }
             NudgeHook::UserPromptSubmit(payload) => {
                 user_prompt_matches.extend(evaluate_userpromptsubmit(payload, rules));
@@ -53,12 +57,106 @@ pub fn evaluate_hooks(hooks: &[NudgeHook], rules: &[Rule]) -> HookOutcome {
         };
     }
 
+    if let Some(update) = pretooluse_update {
+        return HookOutcome::UpdatePreToolUse {
+            system_message: update.user_message,
+            additional_context: update.model_context,
+            updated_input: update.updated_input,
+        };
+    }
+
     HookOutcome::Passthrough
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct PreToolUseSubstitution {
+    updated_input: Value,
+    user_message: String,
+    model_context: String,
+}
+
+fn apply_pretooluse_substitutions(
+    payload: &PreToolUse,
+    rules: &[Rule],
+) -> (PreToolUse, Option<PreToolUseSubstitution>) {
+    let ToolUse::Bash(input) = &payload.tool else {
+        return (payload.clone(), None);
+    };
+
+    let original_command = input.command.clone();
+    let mut command = original_command.clone();
+
+    for rule in rules
+        .iter()
+        .filter(|rule| rule.action == RuleAction::Substitute)
+    {
+        for matcher in rule.hooks_pretooluse_bash() {
+            command = substitute_bash_command(payload, &command, matcher);
+        }
+    }
+
+    if command == original_command {
+        return (payload.clone(), None);
+    }
+
+    let mut updated_payload = payload.clone();
+    if let ToolUse::Bash(input) = &mut updated_payload.tool {
+        input.command = command.clone();
+    }
+    updated_payload.tool_input = updated_tool_input(&payload.tool_input, &command);
+
+    let user_message = format!("Nudge substituted `{original_command}` -> `{command}`.");
+    let model_context = format!(
+        "Nudge rewrote the Bash command from `{original_command}` to `{command}` before execution."
+    );
+
+    (
+        updated_payload.clone(),
+        Some(PreToolUseSubstitution {
+            updated_input: updated_payload.tool_input,
+            user_message,
+            model_context,
+        }),
+    )
+}
+
+fn substitute_bash_command(
+    payload: &PreToolUse,
+    command: &str,
+    matcher: &PreToolUseBashMatcher,
+) -> String {
+    if !bash_project_state_matches(payload, matcher) {
+        return command.to_string();
+    }
+
+    if evaluate_all_matched(command, &matcher.command).is_empty() {
+        return command.to_string();
+    }
+
+    matcher
+        .command
+        .iter()
+        .filter(|matcher| matcher.has_replacement())
+        .fold(command.to_string(), |command, matcher| {
+            matcher.replace_all(&command)
+        })
+}
+
+fn updated_tool_input(tool_input: &Value, command: &str) -> Value {
+    let mut updated_input = tool_input.clone();
+    match &mut updated_input {
+        Value::Object(map) => {
+            map.insert("command".to_string(), Value::String(command.to_string()));
+            updated_input
+        }
+        _ => serde_json::json!({ "command": command }),
+    }
 }
 
 fn evaluate_pretooluse(payload: &PreToolUse, rules: &[Rule]) -> Vec<String> {
     let annotations = rules
         .iter()
+        .filter(|rule| rule.action == RuleAction::Block)
         .flat_map(|rule| match &payload.tool {
             ToolUse::Write(input) => annotate_write(rule, input),
             ToolUse::Edit(input) => annotate_edit(rule, input),
@@ -149,13 +247,18 @@ fn evaluate_bash(
     input: &BashInput,
     matcher: &PreToolUseBashMatcher,
 ) -> Vec<Match> {
-    for state_matcher in &matcher.project_state {
-        if !state_matcher.is_match(&payload.context.cwd) {
-            return Vec::new();
-        }
+    if !bash_project_state_matches(payload, matcher) {
+        return Vec::new();
     }
 
     evaluate_all_matched(&input.command, &matcher.command)
+}
+
+fn bash_project_state_matches(payload: &PreToolUse, matcher: &PreToolUseBashMatcher) -> bool {
+    matcher
+        .project_state
+        .iter()
+        .all(|state_matcher| state_matcher.is_match(&payload.context.cwd))
 }
 
 fn evaluate_user_prompt(input: &UserPromptSubmit, matcher: &UserPromptSubmitMatcher) -> Vec<Match> {
@@ -249,6 +352,138 @@ rules:
         );
 
         pretty_assert_eq!(evaluate_hooks(&hook, &rules), HookOutcome::Passthrough);
+    }
+
+    #[test]
+    fn bash_substitution_updates_command_and_preserves_tool_input() {
+        let hook = claude::parse_hook(json!({
+            "hook_event_name": "PreToolUse",
+            "session_id": "test",
+            "transcript_path": "/tmp/test",
+            "permission_mode": "default",
+            "cwd": "/tmp",
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": "npm install lodash",
+                "description": "Install lodash",
+                "timeout": 120
+            }
+        }))
+        .expect("parse hook");
+
+        let rules = rules(
+            r#"
+version: 1
+rules:
+  - name: yarn-add
+    action: substitute
+    description: Use yarn add instead of npm install
+    on:
+      - hook: PreToolUse
+        tool: Bash
+        command:
+          - kind: Regex
+            pattern: "^npm install(?: (?P<args>.*))?$"
+            replace: "yarn add {{ $args }}"
+"#,
+        );
+
+        let HookOutcome::UpdatePreToolUse {
+            updated_input,
+            additional_context,
+            ..
+        } = evaluate_hooks(&hook, &rules)
+        else {
+            panic!("expected PreToolUse update");
+        };
+
+        pretty_assert_eq!(updated_input["command"], "yarn add lodash");
+        pretty_assert_eq!(updated_input["description"], "Install lodash");
+        pretty_assert_eq!(updated_input["timeout"], 120);
+        assert!(additional_context.contains("npm install lodash"));
+        assert!(additional_context.contains("yarn add lodash"));
+    }
+
+    #[test]
+    fn substitution_happens_before_block_rules() {
+        let hook = claude::parse_hook(json!({
+            "hook_event_name": "PreToolUse",
+            "cwd": "/tmp",
+            "tool_name": "Bash",
+            "tool_input": { "command": "npm run test" }
+        }))
+        .expect("parse hook");
+
+        let rules = rules(
+            r#"
+version: 1
+rules:
+  - name: yarn-run
+    action: substitute
+    on:
+      - hook: PreToolUse
+        tool: Bash
+        command:
+          - kind: Regex
+            pattern: "^npm run(?: (?P<args>.*))?$"
+            replace: "yarn {{ $args }}"
+  - name: block-npm
+    message: "Use yarn."
+    on:
+      - hook: PreToolUse
+        tool: Bash
+        command:
+          - kind: Regex
+            pattern: "^npm\\b"
+"#,
+        );
+
+        let HookOutcome::UpdatePreToolUse { updated_input, .. } = evaluate_hooks(&hook, &rules)
+        else {
+            panic!("expected PreToolUse update");
+        };
+
+        pretty_assert_eq!(updated_input["command"], "yarn test");
+    }
+
+    #[test]
+    fn block_rules_after_substitution_override_update() {
+        let hook = claude::parse_hook(json!({
+            "hook_event_name": "PreToolUse",
+            "cwd": "/tmp",
+            "tool_name": "Bash",
+            "tool_input": { "command": "npm install lodash" }
+        }))
+        .expect("parse hook");
+
+        let rules = rules(
+            r#"
+version: 1
+rules:
+  - name: yarn-add
+    action: substitute
+    on:
+      - hook: PreToolUse
+        tool: Bash
+        command:
+          - kind: Regex
+            pattern: "^npm install(?: (?P<args>.*))?$"
+            replace: "yarn add {{ $args }}"
+  - name: block-yarn-add
+    message: "Do not install packages right now."
+    on:
+      - hook: PreToolUse
+        tool: Bash
+        command:
+          - kind: Regex
+            pattern: "^yarn add\\b"
+"#,
+        );
+
+        assert!(matches!(
+            evaluate_hooks(&hook, &rules),
+            HookOutcome::DenyPreToolUse { .. }
+        ));
     }
 
     #[test]

--- a/packages/nudge/src/hook/response.rs
+++ b/packages/nudge/src/hook/response.rs
@@ -2,11 +2,12 @@
 
 use color_eyre::eyre::{Context, Result};
 use serde::Serialize;
+use serde_json::Value;
 
 use crate::agent::AgentKind;
 
 /// Agent-neutral response decision.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum HookOutcome {
     /// Exit successfully with no output.
     Passthrough,
@@ -15,6 +16,18 @@ pub enum HookOutcome {
     DenyPreToolUse {
         /// Feedback shown to the agent and user.
         message: String,
+    },
+
+    /// Update a `PreToolUse` operation and allow it to proceed.
+    UpdatePreToolUse {
+        /// User-visible audit message.
+        system_message: String,
+
+        /// Model-visible context explaining the rewrite.
+        additional_context: String,
+
+        /// Full updated provider tool input.
+        updated_input: Value,
     },
 
     /// Add context for `UserPromptSubmit`.
@@ -40,12 +53,34 @@ pub fn render(_agent: AgentKind, outcome: HookOutcome) -> Result<RenderedHookOut
         HookOutcome::Passthrough => Ok(RenderedHookOutcome::NoOutput),
         HookOutcome::AddContext { context } => Ok(RenderedHookOutcome::Stdout(context)),
         HookOutcome::DenyPreToolUse { message } => {
-            let response = PreToolUseDenyResponse {
-                system_message: "Nudge blocked operation due to rule violation.".to_string(),
-                hook_specific_output: PreToolUseDenyOutput {
+            let response = PreToolUseResponse {
+                system_message: Some("Nudge blocked operation due to rule violation.".to_string()),
+                hook_specific_output: PreToolUseOutput {
                     hook_event_name: "PreToolUse".to_string(),
                     permission_decision: "deny".to_string(),
-                    permission_decision_reason: message,
+                    permission_decision_reason: Some(message),
+                    updated_input: None,
+                    additional_context: None,
+                },
+            };
+
+            Ok(RenderedHookOutcome::Stdout(
+                serde_json::to_string(&response).context("serialize hook response")?,
+            ))
+        }
+        HookOutcome::UpdatePreToolUse {
+            system_message,
+            additional_context,
+            updated_input,
+        } => {
+            let response = PreToolUseResponse {
+                system_message: Some(system_message),
+                hook_specific_output: PreToolUseOutput {
+                    hook_event_name: "PreToolUse".to_string(),
+                    permission_decision: "allow".to_string(),
+                    permission_decision_reason: None,
+                    updated_input: Some(updated_input),
+                    additional_context: Some(additional_context),
                 },
             };
 
@@ -68,17 +103,23 @@ pub enum RenderedHookOutcome {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct PreToolUseDenyResponse {
-    system_message: String,
-    hook_specific_output: PreToolUseDenyOutput,
+struct PreToolUseResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system_message: Option<String>,
+    hook_specific_output: PreToolUseOutput,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct PreToolUseDenyOutput {
+struct PreToolUseOutput {
     hook_event_name: String,
     permission_decision: String,
-    permission_decision_reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    permission_decision_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    updated_input: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    additional_context: Option<String>,
 }
 
 #[cfg(test)]
@@ -132,6 +173,43 @@ mod tests {
         assert!(json.get("continue").is_none());
         assert!(json.get("stopReason").is_none());
         assert!(json.get("suppressOutput").is_none());
+    }
+
+    #[test]
+    fn substitution_response_allows_with_updated_input_and_context() {
+        let rendered = render(
+            AgentKind::Codex,
+            HookOutcome::UpdatePreToolUse {
+                system_message: "Nudge substituted `npm install foo` -> `yarn add foo`."
+                    .to_string(),
+                additional_context:
+                    "Nudge rewrote the Bash command from `npm install foo` to `yarn add foo` before execution."
+                        .to_string(),
+                updated_input: serde_json::json!({
+                    "command": "yarn add foo",
+                    "description": "Install foo"
+                }),
+            },
+        )
+        .expect("render");
+
+        let RenderedHookOutcome::Stdout(output) = rendered else {
+            panic!("expected stdout");
+        };
+        let json = serde_json::from_str::<Value>(&output).expect("valid json");
+        pretty_assert_eq!(
+            json["hookSpecificOutput"]["permissionDecision"],
+            Value::String("allow".to_string())
+        );
+        pretty_assert_eq!(
+            json["hookSpecificOutput"]["updatedInput"]["command"],
+            Value::String("yarn add foo".to_string())
+        );
+        pretty_assert_eq!(
+            json["hookSpecificOutput"]["updatedInput"]["description"],
+            Value::String("Install foo".to_string())
+        );
+        assert!(json["hookSpecificOutput"]["additionalContext"].is_string());
     }
 
     #[test]

--- a/packages/nudge/src/rules/schema.rs
+++ b/packages/nudge/src/rules/schema.rs
@@ -49,7 +49,12 @@ pub struct Rule {
     ///
     /// If multiple hook events match, this message is displayed to the agent
     /// for every matching hook event, still in context of the matching content.
-    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+
+    /// What to do when this rule matches.
+    #[serde(default)]
+    pub action: RuleAction,
 
     /// The criteria under which this rule matches.
     ///
@@ -107,7 +112,7 @@ impl Rule {
         spans.into_iter().map(|span| {
             Annotation::builder()
                 .span(span)
-                .label(&self.message)
+                .label(self.message())
                 .build()
         })
     }
@@ -122,10 +127,29 @@ impl Rule {
         matches: impl IntoIterator<Item = Match>,
     ) -> impl Iterator<Item = Annotation> {
         matches.into_iter().map(|m| {
-            let label = template::interpolate(&self.message, &m.captures);
+            let label = template::interpolate(self.message(), &m.captures);
             Annotation::builder().span(m.span).label(label).build()
         })
     }
+
+    /// Message text for blocking annotations.
+    pub fn message(&self) -> &str {
+        self.message
+            .as_deref()
+            .unwrap_or("Rule matched. Fix this issue and retry.")
+    }
+}
+
+/// Rule action when a match is found.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuleAction {
+    /// Block the operation and show the rule message.
+    #[default]
+    Block,
+
+    /// Rewrite matching Bash commands and let the operation proceed.
+    Substitute,
 }
 
 impl From<&Rule> for Rule {

--- a/packages/nudge/src/rules/schema/content.rs
+++ b/packages/nudge/src/rules/schema/content.rs
@@ -29,6 +29,13 @@ pub enum ContentMatcher {
         /// The regex pattern to match.
         pattern: RegexMatcher,
 
+        /// Optional replacement template for substitution rules.
+        ///
+        /// Replacement templates use the same capture interpolation syntax as
+        /// suggestions, such as `{{ $1 }}` and `{{ $name }}`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        replace: Option<String>,
+
         /// Optional suggestion template for this matcher.
         ///
         /// When provided, the suggestion is interpolated with the match's
@@ -78,6 +85,7 @@ impl<'de> Deserialize<'de> for ContentMatcher {
             query: Option<String>,
             command: Option<Vec<String>>,
             suggestion: Option<String>,
+            replace: Option<String>,
         }
 
         let raw = Raw::deserialize(deserializer)?;
@@ -85,6 +93,7 @@ impl<'de> Deserialize<'de> for ContentMatcher {
         match raw.kind.as_str() {
             "Regex" => Ok(ContentMatcher::Regex {
                 pattern: deserialize_regex(raw.pattern)?,
+                replace: raw.replace,
                 suggestion: raw.suggestion,
             }),
             "SyntaxTree" => {
@@ -161,6 +170,7 @@ impl ContentMatcher {
             ContentMatcher::Regex {
                 pattern,
                 suggestion,
+                ..
             } => {
                 let mut matches = pattern.matches_with_context(s);
                 apply_suggestion(&mut matches, suggestion);
@@ -187,6 +197,33 @@ impl ContentMatcher {
                 }
             }
         }
+    }
+
+    /// Apply this matcher's replacement template to a string.
+    ///
+    /// Only regex matchers support mechanical substitution. Other matcher
+    /// types can still participate in gating a substitute rule, but they do not
+    /// rewrite content.
+    pub fn replace_all(&self, s: &str) -> String {
+        match self {
+            ContentMatcher::Regex {
+                pattern,
+                replace: Some(template),
+                ..
+            } => pattern.replace_all(s, template),
+            _ => s.to_string(),
+        }
+    }
+
+    /// Whether this matcher can change content for a substitution rule.
+    pub fn has_replacement(&self) -> bool {
+        matches!(
+            self,
+            ContentMatcher::Regex {
+                replace: Some(_),
+                ..
+            }
+        )
     }
 }
 
@@ -317,23 +354,38 @@ impl RegexMatcher {
             .map(|caps| {
                 let full_match = caps.get(0).expect("capture 0 always exists");
                 let span = Span::from(full_match.range());
-                let mut captures = Captures::new();
-
-                for i in 0..caps.len() {
-                    if let Some(cap) = caps.get(i) {
-                        captures.insert(i.to_string(), cap.as_str().to_string());
-                    }
-                }
-
-                for name in self.0.capture_names().flatten() {
-                    if let Some(cap) = caps.name(name) {
-                        captures.insert(name.to_string(), cap.as_str().to_string());
-                    }
-                }
+                let captures = self.captures(&caps);
 
                 Match { span, captures }
             })
             .collect()
+    }
+
+    pub fn replace_all(&self, s: &str, replacement_template: &str) -> String {
+        self.0
+            .replace_all(s, |caps: &regex::Captures<'_>| {
+                let captures = self.captures(caps);
+                template::interpolate(replacement_template, &captures)
+            })
+            .into_owned()
+    }
+
+    fn captures(&self, caps: &regex::Captures<'_>) -> Captures {
+        let mut captures = Captures::new();
+
+        for i in 0..caps.len() {
+            if let Some(cap) = caps.get(i) {
+                captures.insert(i.to_string(), cap.as_str().to_string());
+            }
+        }
+
+        for name in self.0.capture_names().flatten() {
+            if let Some(cap) = caps.name(name) {
+                captures.insert(name.to_string(), cap.as_str().to_string());
+            }
+        }
+
+        captures
     }
 }
 
@@ -381,6 +433,20 @@ mod tests {
         "#;
         let matcher = serde_yaml::from_str::<ContentMatcher>(yaml).expect("valid yaml");
         assert!(matches!(matcher, ContentMatcher::SyntaxTree { .. }));
+    }
+
+    #[test]
+    fn regex_replace_interpolates_captures() {
+        let matcher = serde_yaml::from_str::<ContentMatcher>(
+            r#"
+            kind: Regex
+            pattern: "^npm install(?: (?P<args>.*))?$"
+            replace: "yarn add {{ $args }}"
+        "#,
+        )
+        .expect("valid regex matcher yaml");
+
+        pretty_assert_eq!(matcher.replace_all("npm install lodash"), "yarn add lodash");
     }
 
     #[test]

--- a/packages/nudge/tests/it/bash.rs
+++ b/packages/nudge/tests/it/bash.rs
@@ -191,6 +191,45 @@ rules:
 }
 
 #[test]
+fn test_bash_substitution_allows_with_updated_input() {
+    let config = r#"
+version: 1
+rules:
+  - name: yarn-add
+    description: Use yarn add instead of npm install
+    action: substitute
+    on:
+      - hook: PreToolUse
+        tool: Bash
+        command:
+          - kind: Regex
+            pattern: "^npm install(?: (?P<args>.*))?$"
+            replace: "yarn add {{ $args }}"
+"#;
+
+    let dir = setup_config(config);
+    let input = bash_hook(
+        "npm install lodash",
+        dir.path().to_str().expect("temp dir path is valid utf-8"),
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    let json = serde_json::from_str::<serde_json::Value>(&output).expect("valid json output");
+    pretty_assert_eq!(json["hookSpecificOutput"]["permissionDecision"], "allow");
+    pretty_assert_eq!(
+        json["hookSpecificOutput"]["updatedInput"]["command"],
+        "yarn add lodash"
+    );
+    pretty_assert_eq!(
+        json["hookSpecificOutput"]["updatedInput"]["description"],
+        "Test command"
+    );
+    assert!(json["hookSpecificOutput"]["additionalContext"].is_string());
+    assert!(json["systemMessage"].is_string());
+}
+
+#[test]
 fn test_bash_project_state_git_branch_match() {
     let config = r#"
 version: 1

--- a/packages/nudge/tests/it/codex.rs
+++ b/packages/nudge/tests/it/codex.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::io::Write as _;
 use std::process::{Command, Stdio};
 
+use pretty_assertions::assert_eq as pretty_assert_eq;
 use tempfile::TempDir;
 
 use crate::{
@@ -104,6 +105,70 @@ rules:
     assert!(
         !output.trim_start().starts_with('{'),
         "expected plain text context, got: {output}"
+    );
+}
+
+#[test]
+fn codex_bash_substitution_allows_with_updated_input_and_context() {
+    let temp = TempDir::new().expect("temp dir");
+    fs::write(
+        temp.path().join(".nudge.yaml"),
+        r#"
+version: 1
+rules:
+  - name: yarn-add
+    description: Use yarn add instead of npm install
+    action: substitute
+    on:
+      - hook: PreToolUse
+        tool: Bash
+        command:
+          - kind: Regex
+            pattern: "^npm install(?: (?P<args>.*))?$"
+            replace: "yarn add {{ $args }}"
+"#,
+    )
+    .expect("write config");
+    let input = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "test",
+        "turn_id": "turn",
+        "cwd": temp.path(),
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": "npm install lodash",
+            "description": "Install lodash",
+            "timeout": 120
+        }
+    })
+    .to_string();
+
+    let (exit_code, output) = run_codex_hook_in_dir(&temp, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    let json = serde_json::from_str::<serde_json::Value>(&output).expect("valid json output");
+    assert!(
+        json["hookSpecificOutput"]["permissionDecision"] == "allow",
+        "expected permissionDecision:allow, got: {output}"
+    );
+    assert!(
+        json["hookSpecificOutput"]["updatedInput"]["command"] == "yarn add lodash",
+        "expected rewritten command, got: {output}"
+    );
+    assert!(
+        json["hookSpecificOutput"]["updatedInput"]["description"] == "Install lodash",
+        "expected preserved description, got: {output}"
+    );
+    assert!(
+        json["hookSpecificOutput"]["updatedInput"]["timeout"] == 120,
+        "expected preserved timeout, got: {output}"
+    );
+    assert!(
+        json["hookSpecificOutput"]["additionalContext"]
+            .as_str()
+            .is_some_and(|context| context.contains("npm install lodash")
+                && context.contains("yarn add lodash")),
+        "expected model context describing substitution, got: {output}"
     );
 }
 


### PR DESCRIPTION
## Why this change

Issue #19 asks Nudge to avoid blocking and retrying when a rule can be handled by a deterministic mechanical Bash command rewrite, such as replacing `npm install foo` with `yarn add foo`.

Before this change, all `PreToolUse` matches were blocking rule violations, even when the desired fix was a simple substitution. This added unnecessary round trips for agents and made project-specific command wrapper rules more cumbersome than they needed to be.

This PR adds first-class `action: substitute` support for `PreToolUse` Bash rules. Substitute rules use regex `replace:` templates, preserve the provider's full original `tool_input`, return `permissionDecision: "allow"` with `updatedInput`, and add `hookSpecificOutput.additionalContext` so both Claude Code and Codex CLI models can see what Nudge rewrote before the command runs.

Block rules still run after substitution, so rewritten commands remain subject to normal policy checks. `nudge check` explicitly ignores substitute rules because check mode scans repository files, while substitutions require a live Bash hook payload and a provider that can receive `updatedInput`.

Fixes #19.

## Testing steps performed

```text
$ cargo fmt --all
Warning: can't set `wrap_comments = true`, unstable features are only available in nightly channel.
Warning: can't set `wrap_comments = true`, unstable features are only available in nightly channel.
Warning: can't set `wrap_comments = true`, unstable features are only available in nightly channel.
Warning: can't set `wrap_comments = true`, unstable features are only available in nightly channel.
```

```text
$ cargo test -p nudge
running 64 tests
...
test result: ok. 64 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

running 1 test
...
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 72 tests
...
test result: ok. 72 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.79s

Doc-tests nudge

running 1 test
...
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

```text
$ cargo run -p nudge --quiet -- claude docs >/tmp/nudge-docs.out && rg -n 'Substitution Rules|use-yarn-add|action: substitute|additionalContext|CI note: nudge check ignores substitute rules|updatedInput' /tmp/nudge-docs.out
134:Substitution Rules
136:  Use action: substitute for deterministic Bash command rewrites. Substitute rules
139:  hookSpecificOutput.additionalContext so the model sees what changed.
142:    - name: use-yarn-add
144:      action: substitute
159:  CI note: nudge check ignores substitute rules. Check mode scans repository
161:  payload and a provider that can receive updatedInput.
414:    - name: use-yarn-add
416:      action: substitute
```