### PR TITLE
Add Rust indexed iteration matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ These are the rules Nudge uses on its own codebase (yes, we dogfood):
 | Qualified paths      | Import and use shorter names instead of long paths          |
 | Pretty assertions    | Use `pretty_assertions` in tests for better diff output     |
 | No `.unwrap()`       | Use `.expect("...")` with a descriptive message             |
+| Indexed iteration    | Use `.iter().enumerate()` instead of `0..items.len()` loops |
 
 Other Attune codebases of course have other rules.
 
@@ -91,6 +92,11 @@ rules:
 Substitutions work for Claude Code and Codex CLI. Nudge returns the provider's full updated tool input with only `command` changed, and adds `hookSpecificOutput.additionalContext` so the model sees what was rewritten.
 
 For the full rule syntax and copy-pasteable examples, run `nudge claude docs` or `nudge codex docs`.
+
+Rust rules that need scope-aware loop analysis can use `kind: RustIndexedIteration`
+to catch `for i in 0..items.len() { items[i] }` and
+`(0..items.len()).map(|i| items[i])` while skipping unrelated indexing such as
+`args[0]`, macro arguments, and assertion macros.
 
 ### Rule Writing Is Iterative
 

--- a/examples/rules/rust.yaml
+++ b/examples/rules/rust.yaml
@@ -82,3 +82,22 @@ rules:
         new_content:
           - kind: Regex
             pattern: "assert_eq!"
+
+  # Catch range-based iteration that indexes into the same collection.
+  # Skips unrelated indexing like args[0], macro arguments, and assertions.
+  - name: prefer-enumerate
+    description: Prefer enumerate over 0..items.len() indexing
+    message: "{{ $suggestion }}"
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.rs"
+        content:
+          - kind: RustIndexedIteration
+            suggestion: "Use {{ $collection }}.iter().enumerate() instead of indexing {{ $collection }} with {{ $index }}, then retry."
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.rs"
+        new_content:
+          - kind: RustIndexedIteration
+            suggestion: "Use {{ $collection }}.iter().enumerate() instead of indexing {{ $collection }} with {{ $index }}, then retry."

--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -242,9 +242,36 @@ const DOCS: &str = cstr!("\
   <white>When to Use Each:</white>
     <green>Regex</green>       Simple text patterns, doesn't need AST structure
     <green>SyntaxTree</green>  Structural patterns (e.g., \"use inside function body\")
+    <green>RustIndexedIteration</green>
+                 Rust-specific `0..items.len()` iteration that indexes `items[i]`
 
   <dim>Note: If code fails to parse (incomplete or invalid syntax), the matcher</dim>
   <dim>passes silently. This is intentional because code being written is often incomplete.</dim>
+
+<bold>Rust Indexed Iteration Matching</bold>
+
+  Use <cyan>kind: RustIndexedIteration</cyan> to catch Rust iteration that ranges over
+  <cyan>0..collection.len()</cyan> and then indexes the same collection with the loop
+  or closure index. It is purpose-built for the common enumerate rewrite:
+
+    <dim>for i in 0..items.len() { let item = &items[i]; }</dim>
+    <dim>(0..items.len()).map(|i| items[i].clone())</dim>
+
+  <white>Basic Syntax:</white>
+    <yellow>content:</yellow>
+      <yellow>- kind: RustIndexedIteration</yellow>
+        <yellow>suggestion: \"Use {{ $collection }}.iter().enumerate() instead of indexing {{ $collection }} with {{ $index }}, then retry.\"</yellow>
+
+  <white>Captures:</white>
+    <green>{{ $collection }}</green>  The collection used in both `.len()` and indexing
+    <green>{{ $index }}</green>       The loop or closure index variable
+    <green>{{ $indexed }}</green>     The matched index expression, such as `items[i]`
+
+  <white>False-positive controls:</white>
+    - Matches only zero-based ranges over the same collection: <cyan>0..items.len()</cyan>
+    - Skips unrelated literal indexing such as <cyan>args[0]</cyan> and <cyan>matches[1]</cyan>
+    - Skips macro invocations, including <cyan>assert_eq!(items[i], expected[i])</cyan>
+    - Skips non-zero ranges such as <cyan>1..items.len()</cyan>
 
 <bold>External Program Matching</bold>
 
@@ -370,6 +397,22 @@ const DOCS: &str = cstr!("\
                   <yellow>body: (block</yellow>
                     <yellow>(use_declaration</yellow>
                       <yellow>argument: (scoped_identifier) @path)))</yellow>
+
+  <cyan>Prefer enumerate over range indexing (RustIndexedIteration)</cyan>
+
+    <dim># This matches `for i in 0..items.len() { items[i] }` and</dim>
+    <dim># `(0..items.len()).map(|i| items[i])`, while skipping macro arguments.</dim>
+
+    <yellow>- name: prefer-enumerate</yellow>
+      <yellow>description: Prefer enumerate over 0..items.len() indexing</yellow>
+      <yellow>message: \"{{ $suggestion }}\"</yellow>
+      <yellow>on:</yellow>
+        <yellow>- hook: PreToolUse</yellow>
+          <yellow>tool: Write</yellow>
+          <yellow>file: \"**/*.rs\"</yellow>
+          <yellow>content:</yellow>
+            <yellow>- kind: RustIndexedIteration</yellow>
+              <yellow>suggestion: \"Use {{ $collection }}.iter().enumerate() instead of indexing {{ $collection }} with {{ $index }}, then retry.\"</yellow>
 
   <cyan>Enforce markdown table formatting (External)</cyan>
 

--- a/packages/nudge/src/rules/schema.rs
+++ b/packages/nudge/src/rules/schema.rs
@@ -18,6 +18,7 @@ pub use url::UrlMatcher;
 mod content;
 mod path;
 mod project_state;
+mod rust_indexed_iteration;
 mod syntax;
 mod url;
 

--- a/packages/nudge/src/rules/schema/content.rs
+++ b/packages/nudge/src/rules/schema/content.rs
@@ -14,7 +14,7 @@ use crate::{
     template::{self, Captures},
 };
 
-use super::{Language, TreeSitterQuery, syntax::union_of_captures};
+use super::{Language, TreeSitterQuery, rust_indexed_iteration, syntax::union_of_captures};
 
 /// The method used to match hook content.
 ///
@@ -70,6 +70,17 @@ pub enum ContentMatcher {
         /// The command to run, as a list of arguments.
         command: Vec<String>,
     },
+
+    /// Match Rust range-based iteration that indexes into the same collection.
+    ///
+    /// This catches patterns like `for i in 0..items.len() { items[i] }` and
+    /// `(0..items.len()).map(|i| items[i])` while ignoring unrelated indexing
+    /// such as `args[0]` and macro token trees.
+    RustIndexedIteration {
+        /// Optional suggestion template, same as Regex and SyntaxTree.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        suggestion: Option<String>,
+    },
 }
 
 impl<'de> Deserialize<'de> for ContentMatcher {
@@ -121,9 +132,12 @@ impl<'de> Deserialize<'de> for ContentMatcher {
                 }
                 Ok(ContentMatcher::External { command })
             }
+            "RustIndexedIteration" => Ok(ContentMatcher::RustIndexedIteration {
+                suggestion: raw.suggestion,
+            }),
             other => Err(serde::de::Error::unknown_variant(
                 other,
-                &["Regex", "SyntaxTree", "External"],
+                &["Regex", "SyntaxTree", "External", "RustIndexedIteration"],
             )),
         }
     }
@@ -141,6 +155,10 @@ impl ContentMatcher {
                 .next()
                 .is_some(),
             ContentMatcher::External { command } => run_external_command(command, s).is_some(),
+            ContentMatcher::RustIndexedIteration { .. } => rust_indexed_iteration::matches(s)
+                .into_iter()
+                .next()
+                .is_some(),
         }
     }
 
@@ -161,6 +179,10 @@ impl ContentMatcher {
                     Vec::new()
                 }
             }
+            ContentMatcher::RustIndexedIteration { .. } => rust_indexed_iteration::matches(s)
+                .into_iter()
+                .map(|m| m.span)
+                .collect(),
         }
     }
 
@@ -195,6 +217,11 @@ impl ContentMatcher {
                 } else {
                     Vec::new()
                 }
+            }
+            ContentMatcher::RustIndexedIteration { suggestion } => {
+                let mut matches = rust_indexed_iteration::matches(s);
+                apply_suggestion(&mut matches, suggestion);
+                matches
             }
         }
     }
@@ -543,6 +570,20 @@ mod tests {
         let matcher =
             serde_yaml::from_str::<ContentMatcher>(yaml).expect("valid external matcher yaml");
         assert!(matches!(matcher, ContentMatcher::External { .. }));
+    }
+
+    #[test]
+    fn test_rust_indexed_iteration_deserialize() {
+        let yaml = r#"
+            kind: RustIndexedIteration
+            suggestion: "Use {{ $collection }}.iter().enumerate()"
+        "#;
+        let matcher =
+            serde_yaml::from_str::<ContentMatcher>(yaml).expect("valid rust matcher yaml");
+        assert!(matches!(
+            matcher,
+            ContentMatcher::RustIndexedIteration { .. }
+        ));
     }
 
     #[test]

--- a/packages/nudge/src/rules/schema/rust_indexed_iteration.rs
+++ b/packages/nudge/src/rules/schema/rust_indexed_iteration.rs
@@ -1,0 +1,434 @@
+use tree_sitter::Node;
+
+use crate::{snippet::Match, template::Captures};
+
+use super::Language;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Collection {
+    display: String,
+    normalized: String,
+}
+
+pub(super) fn matches(source: &str) -> Vec<Match> {
+    let Some(tree) = Language::Rust.parse(source) else {
+        return Vec::new();
+    };
+
+    let mut matches = Vec::new();
+    visit(tree.root_node(), source, &mut matches);
+    matches
+}
+
+fn visit(node: Node<'_>, source: &str, matches: &mut Vec<Match>) {
+    match node.kind() {
+        "for_expression" => collect_for_expression_matches(node, source, matches),
+        "call_expression" => collect_range_method_matches(node, source, matches),
+        _ => {}
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        visit(child, source, matches);
+    }
+}
+
+fn collect_for_expression_matches(node: Node<'_>, source: &str, matches: &mut Vec<Match>) {
+    let Some(index) = loop_index_name(node, source) else {
+        return;
+    };
+    let Some(range) = node.child_by_field_name("value") else {
+        return;
+    };
+    let Some(collection) = collection_from_zero_len_range(range, source) else {
+        return;
+    };
+    let Some(body) = node.child_by_field_name("body") else {
+        return;
+    };
+
+    collect_index_expression_matches(body, source, &collection, &index, matches);
+}
+
+fn collect_range_method_matches(node: Node<'_>, source: &str, matches: &mut Vec<Match>) {
+    let Some(function) = node.child_by_field_name("function") else {
+        return;
+    };
+    if function.kind() != "field_expression" {
+        return;
+    }
+
+    let Some(method) = field_name(function, source) else {
+        return;
+    };
+    if !is_index_closure_method(&method) {
+        return;
+    }
+
+    let Some(receiver) = function.child_by_field_name("value") else {
+        return;
+    };
+    let Some(collection) = collection_from_zero_len_range(receiver, source) else {
+        return;
+    };
+    let Some(arguments) = node.child_by_field_name("arguments") else {
+        return;
+    };
+    let Some(closure) = first_closure_argument(arguments) else {
+        return;
+    };
+    let Some(index) = closure_index_parameter_name(closure, source, &method) else {
+        return;
+    };
+    let Some(body) = closure.child_by_field_name("body") else {
+        return;
+    };
+
+    collect_index_expression_matches(body, source, &collection, &index, matches);
+}
+
+fn collect_index_expression_matches(
+    node: Node<'_>,
+    source: &str,
+    collection: &Collection,
+    index: &str,
+    matches: &mut Vec<Match>,
+) {
+    if introduces_scope_for(node, source, index) {
+        return;
+    }
+
+    if node.kind() == "index_expression"
+        && let Some(indexed_collection) = indexed_collection(node, source)
+        && indexed_collection.normalized == collection.normalized
+        && let Some(index_expression) = index_expression(node)
+        && normalized_node_text(index_expression, source) == index
+    {
+        matches.push(match_for_index_expression(node, source, collection, index));
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_index_expression_matches(child, source, collection, index, matches);
+    }
+}
+
+fn match_for_index_expression(
+    node: Node<'_>,
+    source: &str,
+    collection: &Collection,
+    index: &str,
+) -> Match {
+    let captures = Captures::from_iter([
+        ("collection".to_string(), collection.display.clone()),
+        ("index".to_string(), index.to_string()),
+        (
+            "indexed".to_string(),
+            node_text(node, source).trim().to_string(),
+        ),
+    ]);
+
+    Match {
+        span: node.byte_range().into(),
+        captures,
+    }
+}
+
+fn loop_index_name(node: Node<'_>, source: &str) -> Option<String> {
+    let pattern = node.child_by_field_name("pattern")?;
+    pattern_identifier_name(pattern, source)
+}
+
+fn collection_from_zero_len_range(node: Node<'_>, source: &str) -> Option<Collection> {
+    let range = strip_parenthesized_expression(node);
+    if range.kind() != "range_expression" || node_text(range, source).contains("..=") {
+        return None;
+    }
+
+    let start = range.named_child(0)?;
+    if normalized_node_text(start, source) != "0" {
+        return None;
+    }
+
+    let end = range.named_child(1)?;
+    let receiver = len_call_receiver(end, source)?;
+    Some(collection_from_node(receiver, source))
+}
+
+fn len_call_receiver<'tree>(node: Node<'tree>, source: &str) -> Option<Node<'tree>> {
+    if node.kind() != "call_expression" {
+        return None;
+    }
+
+    let arguments = node.child_by_field_name("arguments")?;
+    if arguments.named_child_count() != 0 {
+        return None;
+    }
+
+    let function = node.child_by_field_name("function")?;
+    if function.kind() != "field_expression" || field_name(function, source)? != "len" {
+        return None;
+    }
+
+    function.child_by_field_name("value")
+}
+
+fn field_name(node: Node<'_>, source: &str) -> Option<String> {
+    let field = node.child_by_field_name("field")?;
+    Some(node_text(field, source).trim().to_string())
+}
+
+fn indexed_collection(node: Node<'_>, source: &str) -> Option<Collection> {
+    let collection = node.named_child(0)?;
+    Some(collection_from_node(collection, source))
+}
+
+fn index_expression(node: Node<'_>) -> Option<Node<'_>> {
+    node.named_child(1)
+}
+
+fn collection_from_node(node: Node<'_>, source: &str) -> Collection {
+    let node = strip_parenthesized_expression(node);
+    let display = node_text(node, source).trim().to_string();
+    let normalized = normalize_expression(&display);
+    Collection {
+        display,
+        normalized,
+    }
+}
+
+fn strip_parenthesized_expression(mut node: Node<'_>) -> Node<'_> {
+    while node.kind() == "parenthesized_expression" {
+        let Some(child) = node.named_child(0) else {
+            break;
+        };
+        node = child;
+    }
+    node
+}
+
+fn normalized_node_text(node: Node<'_>, source: &str) -> String {
+    normalize_expression(node_text(strip_parenthesized_expression(node), source))
+}
+
+fn normalize_expression(text: &str) -> String {
+    text.chars()
+        .filter(|ch| !ch.is_ascii_whitespace())
+        .collect()
+}
+
+fn node_text<'a>(node: Node<'_>, source: &'a str) -> &'a str {
+    node.utf8_text(source.as_bytes()).unwrap_or_default()
+}
+
+fn is_index_closure_method(method: &str) -> bool {
+    matches!(
+        method,
+        "all"
+            | "any"
+            | "filter"
+            | "filter_map"
+            | "find"
+            | "flat_map"
+            | "fold"
+            | "for_each"
+            | "inspect"
+            | "map"
+            | "position"
+            | "rfold"
+            | "try_fold"
+            | "try_rfold"
+    )
+}
+
+fn first_closure_argument(arguments: Node<'_>) -> Option<Node<'_>> {
+    let mut cursor = arguments.walk();
+    arguments
+        .named_children(&mut cursor)
+        .find(|child| child.kind() == "closure_expression")
+}
+
+fn closure_index_parameter_name(closure: Node<'_>, source: &str, method: &str) -> Option<String> {
+    let parameter_index = match method {
+        "fold" | "try_fold" | "rfold" | "try_rfold" => 1,
+        _ => 0,
+    };
+
+    let parameters = closure.child_by_field_name("parameters")?;
+    closure_parameter_names(parameters, source)
+        .into_iter()
+        .nth(parameter_index)
+}
+
+fn closure_parameter_names(parameters: Node<'_>, source: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut cursor = parameters.walk();
+
+    for child in parameters.named_children(&mut cursor) {
+        if let Some(name) = pattern_identifier_name(child, source) {
+            names.push(name);
+        }
+    }
+
+    names
+}
+
+fn introduces_scope_for(node: Node<'_>, source: &str, index: &str) -> bool {
+    match node.kind() {
+        "macro_invocation" | "function_item" => true,
+        "closure_expression" => node
+            .child_by_field_name("parameters")
+            .map(|parameters| {
+                closure_parameter_names(parameters, source)
+                    .into_iter()
+                    .any(|name| name == index)
+            })
+            .unwrap_or(false),
+        "for_expression" => node
+            .child_by_field_name("pattern")
+            .and_then(|pattern| pattern_identifier_name(pattern, source))
+            .is_some_and(|name| name == index),
+        _ => false,
+    }
+}
+
+fn pattern_identifier_name(node: Node<'_>, source: &str) -> Option<String> {
+    match node.kind() {
+        "identifier" => Some(node_text(node, source).trim().to_string()),
+        "parameter" => node
+            .child_by_field_name("pattern")
+            .and_then(|pattern| pattern_identifier_name(pattern, source)),
+        "mut_pattern" | "ref_pattern" => {
+            let mut cursor = node.walk();
+            node.named_children(&mut cursor)
+                .find_map(|child| pattern_identifier_name(child, source))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq as pretty_assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn matches_for_loop_range_indexing() {
+        let matches = matches(
+            r#"
+fn process_items(items: &[String]) {
+    for i in 0..items.len() {
+        let item = &items[i];
+        process(i, item);
+    }
+}
+"#,
+        );
+
+        pretty_assert_eq!(matches.len(), 1);
+        pretty_assert_eq!(
+            matches[0].captures.get("collection"),
+            Some(&"items".to_string())
+        );
+        pretty_assert_eq!(matches[0].captures.get("index"), Some(&"i".to_string()));
+        pretty_assert_eq!(
+            matches[0].captures.get("indexed"),
+            Some(&"items[i]".to_string())
+        );
+    }
+
+    #[test]
+    fn matches_range_map_indexing() {
+        let matches = matches(
+            r#"
+fn clone_items(items: &[String]) -> Vec<String> {
+    (0..items.len()).map(|i| items[i].clone()).collect()
+}
+"#,
+        );
+
+        pretty_assert_eq!(matches.len(), 1);
+        pretty_assert_eq!(
+            matches[0].captures.get("collection"),
+            Some(&"items".to_string())
+        );
+    }
+
+    #[test]
+    fn matches_fold_index_parameter() {
+        let matches = matches(
+            r#"
+fn total_len(items: &[String]) -> usize {
+    (0..items.len()).fold(0, |total, i| total + items[i].len())
+}
+"#,
+        );
+
+        pretty_assert_eq!(matches.len(), 1);
+        pretty_assert_eq!(matches[0].captures.get("index"), Some(&"i".to_string()));
+    }
+
+    #[test]
+    fn ignores_macro_token_trees() {
+        let matches = matches(
+            r#"
+fn assert_items(items: &[String], expected: &[String]) {
+    for i in 0..items.len() {
+        assert_eq!(items[i], expected[i]);
+    }
+}
+"#,
+        );
+
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn ignores_unrelated_indexing() {
+        let matches = matches(
+            r#"
+fn first_arg(args: &[String]) -> Option<&String> {
+    args.get(0).or_else(|| Some(&args[0]))
+}
+"#,
+        );
+
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn ignores_other_collection_inside_loop() {
+        let matches = matches(
+            r#"
+fn compare(items: &[String], expected: &[String]) {
+    for i in 0..items.len() {
+        let expected_item = &expected[i];
+        process(expected_item);
+    }
+}
+"#,
+        );
+
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn matches_field_receiver_collection() {
+        let matches = matches(
+            r#"
+fn process(self_: &Thing) {
+    for i in 0..self_.items.len() {
+        process(&self_.items[i]);
+    }
+}
+"#,
+        );
+
+        pretty_assert_eq!(matches.len(), 1);
+        pretty_assert_eq!(
+            matches[0].captures.get("collection"),
+            Some(&"self_.items".to_string())
+        );
+    }
+}

--- a/packages/nudge/tests/it/main.rs
+++ b/packages/nudge/tests/it/main.rs
@@ -15,6 +15,7 @@ mod inline_imports;
 mod message_content;
 mod multiple_rules;
 mod non_rust_files;
+mod rust_indexed_iteration;
 mod setup;
 mod syntax_tree;
 mod user_prompt;

--- a/packages/nudge/tests/it/rust_indexed_iteration.rs
+++ b/packages/nudge/tests/it/rust_indexed_iteration.rs
@@ -1,0 +1,259 @@
+//! Integration tests for RustIndexedIteration matcher.
+//!
+//! These tests cover the issue #1 behavior end to end: detect indexing tied to
+//! range-based iteration while skipping common legitimate indexing patterns.
+
+use std::fs;
+use std::io::Write as _;
+use std::process::{Command, Stdio};
+
+use pretty_assertions::assert_eq as pretty_assert_eq;
+use tempfile::TempDir;
+
+use crate::nudge_binary;
+
+fn setup_config() -> TempDir {
+    let dir = TempDir::new().expect("create temp dir");
+    fs::write(
+        dir.path().join(".nudge.yaml"),
+        r#"
+version: 1
+rules:
+  - name: prefer-enumerate
+    description: Prefer enumerate over range indexing
+    message: "{{ $suggestion }}"
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.rs"
+        content:
+          - kind: RustIndexedIteration
+            suggestion: "Use {{ $collection }}.iter().enumerate() instead of indexing {{ $collection }} with {{ $index }}, then retry."
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.rs"
+        new_content:
+          - kind: RustIndexedIteration
+            suggestion: "Use {{ $collection }}.iter().enumerate() instead of indexing {{ $collection }} with {{ $index }}, then retry."
+"#,
+    )
+    .expect("write config");
+    dir
+}
+
+fn run_hook_in_dir(dir: &TempDir, input: &str) -> (i32, String) {
+    let mut child = Command::new(nudge_binary())
+        .args(["claude", "hook"])
+        .current_dir(dir.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn nudge");
+
+    {
+        let stdin = child.stdin.as_mut().expect("failed to get stdin");
+        stdin
+            .write_all(input.as_bytes())
+            .expect("failed to write to stdin");
+    }
+
+    let output = child.wait_with_output().expect("failed to wait for nudge");
+
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    let combined = if !stdout.trim().is_empty() {
+        stdout.trim().to_string()
+    } else {
+        stderr.trim().to_string()
+    };
+
+    (exit_code, combined)
+}
+
+fn write_hook(file_path: &str, content: &str) -> String {
+    serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "test",
+        "transcript_path": "/tmp/test",
+        "permission_mode": "default",
+        "cwd": "/tmp",
+        "tool_name": "Write",
+        "tool_use_id": "123",
+        "tool_input": {
+            "file_path": file_path,
+            "content": content
+        }
+    })
+    .to_string()
+}
+
+fn assert_interrupt(output: &str) {
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected interrupt, got: {output}"
+    );
+}
+
+fn assert_passthrough(output: &str) {
+    assert!(output.is_empty(), "expected passthrough, got: {output}");
+}
+
+#[test]
+fn detects_for_loop_indexing_over_len_range() {
+    let dir = setup_config();
+    let input = write_hook(
+        "src/main.rs",
+        r#"
+fn process_items(items: &[String]) {
+    for i in 0..items.len() {
+        let item = &items[i];
+        process(i, item);
+    }
+}
+"#,
+    );
+
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert_interrupt(&output);
+    assert!(
+        output.contains("items.iter().enumerate()"),
+        "expected interpolated enumerate suggestion, got: {output}"
+    );
+}
+
+#[test]
+fn detects_range_iterator_closure_indexing() {
+    let dir = setup_config();
+    let input = write_hook(
+        "src/main.rs",
+        r#"
+fn clone_items(items: &[String]) -> Vec<String> {
+    (0..items.len()).map(|i| items[i].clone()).collect()
+}
+"#,
+    );
+
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert_interrupt(&output);
+    assert!(
+        output.contains("indexing items with i"),
+        "expected collection and index captures, got: {output}"
+    );
+}
+
+#[test]
+fn check_command_reports_indexed_iteration() {
+    let dir = setup_config();
+    let source = dir.path().join("src");
+    fs::create_dir(&source).expect("create src dir");
+    fs::write(
+        source.join("main.rs"),
+        r#"
+fn process_items(items: &[String]) {
+    for i in 0..items.len() {
+        process(&items[i]);
+    }
+}
+"#,
+    )
+    .expect("write source file");
+
+    let output = Command::new(nudge_binary())
+        .arg("check")
+        .current_dir(dir.path())
+        .output()
+        .expect("run nudge check");
+
+    pretty_assert_eq!(output.status.code(), Some(1), "expected check failure");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("src/main.rs:4 [prefer-enumerate]"),
+        "expected check output to include file, line, and rule, got: {stdout}"
+    );
+}
+
+#[test]
+fn skips_macro_arguments_and_test_assertions() {
+    let dir = setup_config();
+    let input = write_hook(
+        "src/main.rs",
+        r#"
+fn assert_items(items: &[String], expected: &[String]) {
+    for i in 0..items.len() {
+        assert_eq!(items[i], expected[i]);
+    }
+}
+"#,
+    );
+
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert_passthrough(&output);
+}
+
+#[test]
+fn skips_unrelated_literal_indexing() {
+    let dir = setup_config();
+    let input = write_hook(
+        "src/main.rs",
+        r#"
+fn first_arg(args: &[String]) -> Option<&String> {
+    args.get(0).or_else(|| Some(&args[0]))
+}
+"#,
+    );
+
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert_passthrough(&output);
+}
+
+#[test]
+fn skips_indexing_other_collections_inside_len_loop() {
+    let dir = setup_config();
+    let input = write_hook(
+        "src/main.rs",
+        r#"
+fn compare(items: &[String], expected: &[String]) {
+    for i in 0..items.len() {
+        let expected_item = &expected[i];
+        process(expected_item);
+    }
+}
+"#,
+    );
+
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert_passthrough(&output);
+}
+
+#[test]
+fn skips_non_zero_start_ranges() {
+    let dir = setup_config();
+    let input = write_hook(
+        "src/main.rs",
+        r#"
+fn process_tail(items: &[String]) {
+    for i in 1..items.len() {
+        process(&items[i]);
+    }
+}
+"#,
+    );
+
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert_passthrough(&output);
+}


### PR DESCRIPTION
Closes #1.

**Why this change**
- Rust style rules often need to catch `for i in 0..items.len() { items[i] }` and `(0..items.len()).map(|i| items[i])`, but a plain regex is too noisy and a generic tree-sitter query cannot comfortably express same-collection, same-index, scoped matching.
- This adds a `RustIndexedIteration` content matcher that parses Rust with tree-sitter and reports only index expressions tied to zero-based range iteration over the same collection.
- The matcher exposes `{{ $collection }}`, `{{ $index }}`, and `{{ $indexed }}` captures for actionable rule messages.
- It intentionally skips common false-positive shapes from the issue: macro invocations such as `assert_eq!(items[i], expected[i])`, unrelated literal indexing like `args[0]` and `matches[1]`, indexing a different collection inside the loop, and non-zero ranges such as `1..items.len()`.
- The rule-writing docs and Rust example rules now show how to use the new matcher.

**Testing steps performed**

```text
$ cargo test -p nudge
...
test rules::schema::rust_indexed_iteration::tests::ignores_macro_token_trees ... ok
test rules::schema::rust_indexed_iteration::tests::ignores_other_collection_inside_loop ... ok
test rules::schema::rust_indexed_iteration::tests::ignores_unrelated_indexing ... ok
test rules::schema::rust_indexed_iteration::tests::matches_field_receiver_collection ... ok
test rules::schema::rust_indexed_iteration::tests::matches_fold_index_parameter ... ok
test rules::schema::rust_indexed_iteration::tests::matches_for_loop_range_indexing ... ok
test rules::schema::rust_indexed_iteration::tests::matches_range_map_indexing ... ok
...
test result: ok. 72 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
...
test rust_indexed_iteration::detects_for_loop_indexing_over_len_range ... ok
test rust_indexed_iteration::detects_range_iterator_closure_indexing ... ok
test rust_indexed_iteration::skips_macro_arguments_and_test_assertions ... ok
test rust_indexed_iteration::skips_indexing_other_collections_inside_len_loop ... ok
test rust_indexed_iteration::check_command_reports_indexed_iteration ... ok
test rust_indexed_iteration::skips_non_zero_start_ranges ... ok
test rust_indexed_iteration::skips_unrelated_literal_indexing ... ok
...
test result: ok. 79 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.94s
...
Doc-tests nudge

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

```text
$ cargo clippy -p nudge --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.14s
```

```text
$ cargo run -q -p nudge -- validate examples/rules/rust.yaml
- name: prefer-enumerate
  description: Prefer enumerate over 0..items.len() indexing
  message: '{{ $suggestion }}'
  action: block
  on:
  - hook: PreToolUse
    tool: Write
    file: '**/*.rs'
    content:
    - kind: RustIndexedIteration
      suggestion: Use {{ $collection }}.iter().enumerate() instead of indexing {{ $collection }} with {{ $index }}, then retry.
  - hook: PreToolUse
    tool: Edit
    file: '**/*.rs'
    new_content:
    - kind: RustIndexedIteration
      suggestion: Use {{ $collection }}.iter().enumerate() instead of indexing {{ $collection }} with {{ $index }}, then retry.
```