### PR TITLE
Add Rust check-then-unwrap matcher

### DIFF
--- a/.nudge.yaml
+++ b/.nudge.yaml
@@ -100,6 +100,23 @@ rules:
                 macro: (identifier) @macro
                 (#eq? @macro "assert_eq"))
 
+  # Catch guard clauses that check Option/Result state and then unwrap the same value.
+  # Prefer `let-else` or match-style control flow so the invariant stays explicit.
+  - name: prefer-let-else-over-check-unwrap
+    description: Prefer let-else or match-style control flow over check-then-unwrap
+    message: "Replace the {{ $check_method }} + unwrap guard for `{{ $receiver }}` with let-else or match-style control flow, then retry."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.rs"
+        content:
+          - kind: RustCheckThenUnwrap
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.rs"
+        new_content:
+          - kind: RustCheckThenUnwrap
+
   # Catch .unwrap() calls and suggest .expect() instead.
   # Uses tree-sitter to match actual method calls, avoiding false positives
   # from doc comments or string literals containing ".unwrap()".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ nudge check         - Check project files against rules (CI/linter mode)
 - `src/cmd/check.rs` - Check command: validate project files against rules for CI
 - `src/rules.rs` - Rule loading from config files
 - `src/rules/schema.rs` - Rule schema facade and hook matcher types
-- `src/rules/schema/` - Focused matcher implementations for content, glob paths, project state, tree-sitter syntax, and URLs
+- `src/rules/schema/` - Focused matcher implementations for content, glob paths, project state, Rust semantic checks, tree-sitter syntax, and URLs
 - `src/snippet.rs` - Code snippet rendering for rule violations (uses `annotate-snippets`)
 
 ### How Nudge Communicates

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ These are the rules Nudge uses on its own codebase (yes, we dogfood):
 | LHS type annotations | Prefer turbofish (`::<T>`) over `let x: T = ...`            |
 | Qualified paths      | Import and use shorter names instead of long paths          |
 | Pretty assertions    | Use `pretty_assertions` in tests for better diff output     |
+| Check then unwrap    | Prefer `let-else` or `match` over guard clauses plus unwrap |
 | No `.unwrap()`       | Use `.expect("...")` with a descriptive message             |
 
 Other Attune codebases of course have other rules.
@@ -89,6 +90,21 @@ rules:
 ```
 
 Substitutions work for Claude Code and Codex CLI. Nudge returns the provider's full updated tool input with only `command` changed, and adds `hookSpecificOutput.additionalContext` so the model sees what was rewritten.
+
+For Rust guard clauses that check `Option` or `Result` state and then unwrap the same value, use the semantic `RustCheckThenUnwrap` matcher:
+
+```yaml
+version: 1
+rules:
+  - name: prefer-let-else-over-check-unwrap
+    message: "Replace the {{ $check_method }} + unwrap guard for `{{ $receiver }}` with let-else or match-style control flow, then retry."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.rs"
+        content:
+          - kind: RustCheckThenUnwrap
+```
 
 For the full rule syntax and copy-pasteable examples, run `nudge claude docs` or `nudge codex docs`.
 
@@ -190,14 +206,14 @@ x Found 3 issues in 2 files
 ./src/lib.rs:23 [no-inline-imports]
   Move this `use` statement to the top of the file, then retry.
 
-Checked 25 files against 6 rules
+Checked 25 files against 7 rules
 ```
 
 When all checks pass:
 
 ```
-Checked 25 files against 6 rules
-  - .nudge.yaml: 6 rules
+Checked 25 files against 7 rules
+  - .nudge.yaml: 7 rules
 ```
 
 ### Manual Testing

--- a/examples/rules/rust.yaml
+++ b/examples/rules/rust.yaml
@@ -46,6 +46,24 @@ rules:
           - kind: Regex
             pattern: "(?m)^\\s*let\\s+(mut\\s+)?[a-zA-Z_][a-zA-Z0-9_]*\\s*:\\s*"
 
+  # Catch guard clauses that check Option/Result state and then unwrap the same value.
+  # Patterns include `value.is_none()`, `!value.is_some()`, `result.is_err()`,
+  # and `!result.is_ok()` followed by a same-receiver `.unwrap()`.
+  - name: prefer-let-else-over-check-unwrap
+    description: Prefer let-else or match-style control flow over check-then-unwrap
+    message: "Replace the {{ $check_method }} + unwrap guard for `{{ $receiver }}` with let-else or match-style control flow, then retry."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.rs"
+        content:
+          - kind: RustCheckThenUnwrap
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.rs"
+        new_content:
+          - kind: RustCheckThenUnwrap
+
   # Catch unnecessarily fully qualified paths in code (not imports).
   # Pattern: paths with 2+ `::` separators followed by ::, (, or <
   - name: no-qualified-paths

--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -242,9 +242,40 @@ const DOCS: &str = cstr!("\
   <white>When to Use Each:</white>
     <green>Regex</green>       Simple text patterns, doesn't need AST structure
     <green>SyntaxTree</green>  Structural patterns (e.g., \"use inside function body\")
+    <green>RustCheckThenUnwrap</green>
+                  Rust Option/Result guard clauses followed by same-value unwrap
 
   <dim>Note: If code fails to parse (incomplete or invalid syntax), the matcher</dim>
   <dim>passes silently. This is intentional because code being written is often incomplete.</dim>
+
+<bold>Rust Check-Then-Unwrap Matching</bold>
+
+  Use <cyan>kind: RustCheckThenUnwrap</cyan> for Rust guard clauses that check
+  <cyan>Option</cyan> or <cyan>Result</cyan> state, exit early, and then call
+  <cyan>.unwrap()</cyan> on the same receiver. This is the multi-line pattern
+  where <cyan>let-else</cyan> or match-style control flow is usually clearer.
+
+  <white>Basic Syntax:</white>
+    <yellow>content:</yellow>
+      <yellow>- kind: RustCheckThenUnwrap</yellow>
+        <yellow>suggestion: \"...\"</yellow>           <dim># Optional: same as Regex</dim>
+
+  <white>Detected Guards:</white>
+    <green>value.is_none()</green>       followed by <green>value.unwrap()</green>
+    <green>!value.is_some()</green>      followed by <green>value.unwrap()</green>
+    <green>result.is_err()</green>       followed by <green>result.unwrap()</green>
+    <green>!result.is_ok()</green>       followed by <green>result.unwrap()</green>
+
+  The guard body must end with a top-level <cyan>return</cyan>, <cyan>break</cyan>, or
+  <cyan>continue</cyan>. The unwrap must be the next executable statement in the same
+  block; blank lines and comments between the guard and unwrap are allowed.
+
+  <white>Captures:</white>
+    <green>{{ $receiver }}</green>        Checked receiver, such as value or result
+    <green>{{ $check_method }}</green>    is_none, is_some, is_err, or is_ok
+    <green>{{ $checked_state }}</green>   none or err
+    <green>{{ $unwrap_binding }}</green>  Pattern bound by the let statement
+    <green>{{ $early_exit }}</green>      return, break, or continue
 
 <bold>External Program Matching</bold>
 
@@ -274,6 +305,8 @@ const DOCS: &str = cstr!("\
     <green>External</green>     Leverage existing linters (markdownlint, prettier --check, etc.)
     <green>Regex</green>        Simple patterns you can express in regex
     <green>SyntaxTree</green>   Structural patterns in supported languages
+    <green>RustCheckThenUnwrap</green>
+                  Built-in Rust Option/Result guard plus unwrap detection
 
   <dim>Note: External commands add latency. Use sparingly for checks that are</dim>
   <dim>difficult or impossible to express with Regex or SyntaxTree matchers.</dim>
@@ -349,6 +382,21 @@ const DOCS: &str = cstr!("\
             <yellow>- kind: Regex</yellow>
               <yellow>pattern: \"(?P<<expr>>\\\\w+)\\\\.unwrap\\\\(\\\\)\"</yellow>
               <yellow>suggestion: \"Replace {{ $expr }}.unwrap() with {{ $expr }}.expect(\\\"...\\\")\"</yellow>
+
+  <cyan>Prefer let-else over check-then-unwrap (Rust)</cyan>
+
+    <dim># Catches `if value.is_none() { return ...; }` followed by</dim>
+    <dim># `let value = value.unwrap();` and equivalent Result guards.</dim>
+
+    <yellow>- name: prefer-let-else-over-check-unwrap</yellow>
+      <yellow>description: Prefer let-else over checking state and unwrapping later</yellow>
+      <yellow>message: \"Replace the {{ $check_method }} + unwrap guard for `{{ $receiver }}` with let-else or match-style control flow, then retry.\"</yellow>
+      <yellow>on:</yellow>
+        <yellow>- hook: PreToolUse</yellow>
+          <yellow>tool: Write</yellow>
+          <yellow>file: \"**/*.rs\"</yellow>
+          <yellow>content:</yellow>
+            <yellow>- kind: RustCheckThenUnwrap</yellow>
 
   <cyan>Block use statements inside function bodies (SyntaxTree)</cyan>
 

--- a/packages/nudge/src/rules/schema.rs
+++ b/packages/nudge/src/rules/schema.rs
@@ -18,6 +18,7 @@ pub use url::UrlMatcher;
 mod content;
 mod path;
 mod project_state;
+mod rust;
 mod syntax;
 mod url;
 

--- a/packages/nudge/src/rules/schema/content.rs
+++ b/packages/nudge/src/rules/schema/content.rs
@@ -14,7 +14,7 @@ use crate::{
     template::{self, Captures},
 };
 
-use super::{Language, TreeSitterQuery, syntax::union_of_captures};
+use super::{Language, TreeSitterQuery, rust, syntax::union_of_captures};
 
 /// The method used to match hook content.
 ///
@@ -58,6 +58,22 @@ pub enum ContentMatcher {
         query: TreeSitterQuery,
 
         /// Optional suggestion template, same as Regex variant.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        suggestion: Option<String>,
+    },
+
+    /// Match Rust guard clauses that check an Option/Result and then unwrap.
+    ///
+    /// This catches multi-line patterns such as:
+    ///
+    /// ```rust,ignore
+    /// if value.is_none() {
+    ///     return Err(...);
+    /// }
+    /// let value = value.unwrap();
+    /// ```
+    RustCheckThenUnwrap {
+        /// Optional suggestion template, same as Regex and SyntaxTree.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         suggestion: Option<String>,
     },
@@ -112,6 +128,9 @@ impl<'de> Deserialize<'de> for ContentMatcher {
                     suggestion: raw.suggestion,
                 })
             }
+            "RustCheckThenUnwrap" => Ok(ContentMatcher::RustCheckThenUnwrap {
+                suggestion: raw.suggestion,
+            }),
             "External" => {
                 let command = raw
                     .command
@@ -123,7 +142,7 @@ impl<'de> Deserialize<'de> for ContentMatcher {
             }
             other => Err(serde::de::Error::unknown_variant(
                 other,
-                &["Regex", "SyntaxTree", "External"],
+                &["Regex", "SyntaxTree", "RustCheckThenUnwrap", "External"],
             )),
         }
     }
@@ -140,6 +159,10 @@ impl ContentMatcher {
                 .into_iter()
                 .next()
                 .is_some(),
+            ContentMatcher::RustCheckThenUnwrap { .. } => rust::check_then_unwrap_matches(s)
+                .into_iter()
+                .next()
+                .is_some(),
             ContentMatcher::External { command } => run_external_command(command, s).is_some(),
         }
     }
@@ -151,6 +174,10 @@ impl ContentMatcher {
             ContentMatcher::SyntaxTree {
                 language, query, ..
             } => syntax_tree_matches(*language, query, s)
+                .into_iter()
+                .map(|m| m.span)
+                .collect(),
+            ContentMatcher::RustCheckThenUnwrap { .. } => rust::check_then_unwrap_matches(s)
                 .into_iter()
                 .map(|m| m.span)
                 .collect(),
@@ -182,6 +209,11 @@ impl ContentMatcher {
                 suggestion,
             } => {
                 let mut matches = syntax_tree_matches(*language, query, s);
+                apply_suggestion(&mut matches, suggestion);
+                matches
+            }
+            ContentMatcher::RustCheckThenUnwrap { suggestion } => {
+                let mut matches = rust::check_then_unwrap_matches(s);
                 apply_suggestion(&mut matches, suggestion);
                 matches
             }
@@ -447,6 +479,50 @@ mod tests {
         .expect("valid regex matcher yaml");
 
         pretty_assert_eq!(matcher.replace_all("npm install lodash"), "yarn add lodash");
+    }
+
+    #[test]
+    fn test_content_matcher_rust_check_then_unwrap_deserialize() {
+        let yaml = r#"
+            kind: RustCheckThenUnwrap
+            suggestion: "Replace {{ $receiver }} with let-else"
+        "#;
+        let matcher = serde_yaml::from_str::<ContentMatcher>(yaml).expect("valid yaml");
+        assert!(matches!(
+            matcher,
+            ContentMatcher::RustCheckThenUnwrap { .. }
+        ));
+    }
+
+    #[test]
+    fn rust_check_then_unwrap_sets_captures_and_suggestion() {
+        let matcher = ContentMatcher::RustCheckThenUnwrap {
+            suggestion: Some("Use let-else for {{ $receiver }}".to_string()),
+        };
+        let code = r#"
+fn parse(value: Option<String>) -> Result<String, String> {
+    if value.is_none() {
+        return Err("missing".to_string());
+    }
+    let value = value.unwrap();
+    Ok(value)
+}
+"#;
+        let matches = matcher.matches_with_context(code);
+
+        pretty_assert_eq!(matches.len(), 1);
+        pretty_assert_eq!(
+            matches[0].captures.get("receiver"),
+            Some(&"value".to_string())
+        );
+        pretty_assert_eq!(
+            matches[0].captures.get("check_method"),
+            Some(&"is_none".to_string())
+        );
+        pretty_assert_eq!(
+            matches[0].captures.get("suggestion"),
+            Some(&"Use let-else for value".to_string())
+        );
     }
 
     #[test]

--- a/packages/nudge/src/rules/schema/rust.rs
+++ b/packages/nudge/src/rules/schema/rust.rs
@@ -1,0 +1,266 @@
+//! Rust-specific semantic matchers.
+
+use tree_sitter::Node;
+
+use crate::{
+    snippet::{Match, Span},
+    template::Captures,
+};
+
+use super::Language;
+
+#[derive(Debug)]
+struct StateCheck {
+    receiver: String,
+    check_method: String,
+    state: CheckedState,
+}
+
+#[derive(Debug)]
+enum CheckedState {
+    None,
+    Err,
+}
+
+#[derive(Debug)]
+struct UnwrapLet {
+    receiver: String,
+    binding: String,
+}
+
+pub(crate) fn check_then_unwrap_matches(source: &str) -> Vec<Match> {
+    let Some(tree) = Language::Rust.parse(source) else {
+        return Vec::new();
+    };
+
+    let mut matches = Vec::new();
+    collect_block_matches(tree.root_node(), source, &mut matches);
+    matches
+}
+
+fn collect_block_matches(node: Node<'_>, source: &str, matches: &mut Vec<Match>) {
+    if node.kind() == "block" {
+        matches.extend(block_check_then_unwrap_matches(node, source));
+    }
+
+    for child in named_children(node) {
+        collect_block_matches(child, source, matches);
+    }
+}
+
+fn block_check_then_unwrap_matches(block: Node<'_>, source: &str) -> Vec<Match> {
+    let children = executable_or_commentless_children(block);
+
+    children
+        .windows(2)
+        .filter_map(|window| check_then_unwrap_match(window[0], window[1], source))
+        .collect()
+}
+
+fn check_then_unwrap_match(
+    guard_statement: Node<'_>,
+    unwrap_statement: Node<'_>,
+    source: &str,
+) -> Option<Match> {
+    let if_expression = as_if_expression(guard_statement)?;
+    if if_expression.child_by_field_name("alternative").is_some() {
+        return None;
+    }
+
+    let condition = if_expression.child_by_field_name("condition")?;
+    let check = state_check(condition, source)?;
+
+    let consequence = if_expression.child_by_field_name("consequence")?;
+    let early_exit = top_level_early_exit(consequence)?;
+
+    let unwrap = unwrap_let(unwrap_statement, source)?;
+    if check.receiver != unwrap.receiver {
+        return None;
+    }
+
+    let span = Span {
+        start: guard_statement.byte_range().start,
+        end: unwrap_statement.byte_range().end,
+    };
+    let captures = Captures::from_iter([
+        ("receiver".to_string(), check.receiver),
+        ("check_method".to_string(), check.check_method),
+        (
+            "checked_state".to_string(),
+            check.state.capture_value().to_string(),
+        ),
+        ("unwrap_binding".to_string(), unwrap.binding),
+        ("early_exit".to_string(), early_exit.to_string()),
+        (
+            "guard".to_string(),
+            node_text(guard_statement, source).to_string(),
+        ),
+        (
+            "unwrap".to_string(),
+            node_text(unwrap_statement, source).to_string(),
+        ),
+    ]);
+
+    Some(Match { span, captures })
+}
+
+fn executable_or_commentless_children(node: Node<'_>) -> Vec<Node<'_>> {
+    named_children(node)
+        .filter(|child| !is_comment(*child))
+        .collect()
+}
+
+fn named_children(node: Node<'_>) -> impl DoubleEndedIterator<Item = Node<'_>> {
+    (0..node.named_child_count()).filter_map(move |index| node.named_child(index))
+}
+
+fn is_comment(node: Node<'_>) -> bool {
+    matches!(node.kind(), "line_comment" | "block_comment")
+}
+
+fn as_if_expression(statement: Node<'_>) -> Option<Node<'_>> {
+    match statement.kind() {
+        "if_expression" => Some(statement),
+        "expression_statement" => {
+            first_named_child(statement).filter(|child| child.kind() == "if_expression")
+        }
+        _ => None,
+    }
+}
+
+fn first_named_child(node: Node<'_>) -> Option<Node<'_>> {
+    named_children(node).next()
+}
+
+fn state_check(condition: Node<'_>, source: &str) -> Option<StateCheck> {
+    let condition = peel_parentheses(condition);
+
+    if condition.kind() == "unary_expression" && first_child_kind(condition) == Some("!") {
+        let call = first_named_child(condition).map(peel_parentheses)?;
+        let method_call = method_call(call, source)?;
+        return match method_call.method.as_str() {
+            "is_some" => Some(StateCheck {
+                receiver: method_call.receiver,
+                check_method: method_call.method,
+                state: CheckedState::None,
+            }),
+            "is_ok" => Some(StateCheck {
+                receiver: method_call.receiver,
+                check_method: method_call.method,
+                state: CheckedState::Err,
+            }),
+            _ => None,
+        };
+    }
+
+    let method_call = method_call(condition, source)?;
+    match method_call.method.as_str() {
+        "is_none" => Some(StateCheck {
+            receiver: method_call.receiver,
+            check_method: method_call.method,
+            state: CheckedState::None,
+        }),
+        "is_err" => Some(StateCheck {
+            receiver: method_call.receiver,
+            check_method: method_call.method,
+            state: CheckedState::Err,
+        }),
+        _ => None,
+    }
+}
+
+fn first_child_kind(node: Node<'_>) -> Option<&str> {
+    node.child(0).map(|child| child.kind())
+}
+
+fn peel_parentheses(node: Node<'_>) -> Node<'_> {
+    if node.kind() == "parenthesized_expression" {
+        first_named_child(node)
+            .map(peel_parentheses)
+            .unwrap_or(node)
+    } else {
+        node
+    }
+}
+
+struct MethodCall {
+    receiver: String,
+    method: String,
+}
+
+fn method_call(call: Node<'_>, source: &str) -> Option<MethodCall> {
+    if call.kind() != "call_expression" {
+        return None;
+    }
+
+    let arguments = call.child_by_field_name("arguments")?;
+    if arguments.named_child_count() != 0 {
+        return None;
+    }
+
+    let function = call.child_by_field_name("function")?;
+    if function.kind() != "field_expression" {
+        return None;
+    }
+
+    let receiver = function.child_by_field_name("value")?;
+    let method = function.child_by_field_name("field")?;
+
+    Some(MethodCall {
+        receiver: node_text(receiver, source).to_string(),
+        method: node_text(method, source).to_string(),
+    })
+}
+
+fn top_level_early_exit(block: Node<'_>) -> Option<&'static str> {
+    if block.kind() != "block" {
+        return None;
+    }
+
+    let last_statement = named_children(block)
+        .rev()
+        .find(|child| !is_comment(*child))?;
+    let expression = if last_statement.kind() == "expression_statement" {
+        first_named_child(last_statement)?
+    } else {
+        last_statement
+    };
+
+    match expression.kind() {
+        "return_expression" => Some("return"),
+        "break_expression" => Some("break"),
+        "continue_expression" => Some("continue"),
+        _ => None,
+    }
+}
+
+fn unwrap_let(statement: Node<'_>, source: &str) -> Option<UnwrapLet> {
+    if statement.kind() != "let_declaration" {
+        return None;
+    }
+
+    let binding = statement.child_by_field_name("pattern")?;
+    let value = statement.child_by_field_name("value")?;
+    let method_call = method_call(peel_parentheses(value), source)?;
+    if method_call.method != "unwrap" {
+        return None;
+    }
+
+    Some(UnwrapLet {
+        receiver: method_call.receiver,
+        binding: node_text(binding, source).to_string(),
+    })
+}
+
+fn node_text<'a>(node: Node<'_>, source: &'a str) -> &'a str {
+    node.utf8_text(source.as_bytes()).unwrap_or_default()
+}
+
+impl CheckedState {
+    fn capture_value(&self) -> &'static str {
+        match self {
+            CheckedState::None => "none",
+            CheckedState::Err => "err",
+        }
+    }
+}

--- a/packages/nudge/tests/it/main.rs
+++ b/packages/nudge/tests/it/main.rs
@@ -15,6 +15,7 @@ mod inline_imports;
 mod message_content;
 mod multiple_rules;
 mod non_rust_files;
+mod rust_check_then_unwrap;
 mod setup;
 mod syntax_tree;
 mod user_prompt;

--- a/packages/nudge/tests/it/rust_check_then_unwrap.rs
+++ b/packages/nudge/tests/it/rust_check_then_unwrap.rs
@@ -1,0 +1,352 @@
+//! Integration tests for the Rust check-then-unwrap matcher.
+//!
+//! This matcher catches guard clauses such as `if value.is_none() { return
+//! ...; }` followed by `value.unwrap()`, where `let-else` or match-style
+//! control flow makes the invariant visible in the type system.
+
+use std::fs;
+use std::io::Write as _;
+use std::process::{Command, Stdio};
+
+use pretty_assertions::assert_eq as pretty_assert_eq;
+use simple_test_case::test_case;
+use tempfile::TempDir;
+
+use crate::nudge_binary;
+
+const CONFIG: &str = r#"
+version: 1
+rules:
+  - name: prefer-let-else-over-check-unwrap
+    description: Prefer let-else over checking state and unwrapping later
+    message: "Replace the {{ $check_method }} + unwrap guard for `{{ $receiver }}` with let-else or match-style control flow, then retry."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.rs"
+        content:
+          - kind: RustCheckThenUnwrap
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.rs"
+        new_content:
+          - kind: RustCheckThenUnwrap
+"#;
+
+fn setup_config() -> TempDir {
+    let dir = TempDir::new().expect("create temp dir");
+    fs::write(dir.path().join(".nudge.yaml"), CONFIG).expect("write config");
+    dir
+}
+
+fn write_hook(file_path: &str, content: &str) -> String {
+    serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "test",
+        "transcript_path": "/tmp/test",
+        "permission_mode": "default",
+        "cwd": "/tmp",
+        "tool_name": "Write",
+        "tool_use_id": "123",
+        "tool_input": {
+            "file_path": file_path,
+            "content": content
+        }
+    })
+    .to_string()
+}
+
+fn edit_hook(file_path: &str, old_string: &str, new_string: &str) -> String {
+    serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "test",
+        "transcript_path": "/tmp/test",
+        "permission_mode": "default",
+        "cwd": "/tmp",
+        "tool_name": "Edit",
+        "tool_use_id": "123",
+        "tool_input": {
+            "file_path": file_path,
+            "old_string": old_string,
+            "new_string": new_string
+        }
+    })
+    .to_string()
+}
+
+fn run_agent_hook(dir: &TempDir, input: &str) -> (i32, String) {
+    let mut child = Command::new(nudge_binary())
+        .args(["claude", "hook"])
+        .current_dir(dir.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn nudge");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("failed to get stdin")
+        .write_all(input.as_bytes())
+        .expect("failed to write hook input");
+
+    let output = child.wait_with_output().expect("failed to wait for nudge");
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    let combined = if !stdout.trim().is_empty() {
+        stdout.trim().to_string()
+    } else {
+        stderr.trim().to_string()
+    };
+
+    (exit_code, combined)
+}
+
+fn run_check(dir: &TempDir, source: &str) -> (i32, String, String) {
+    let source_path = dir.path().join("src/lib.rs");
+    fs::create_dir_all(source_path.parent().expect("source has parent"))
+        .expect("create source dir");
+    fs::write(&source_path, source).expect("write source");
+
+    let output = Command::new(nudge_binary())
+        .args(["check", "src/lib.rs"])
+        .current_dir(dir.path())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to run nudge check");
+
+    (
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
+}
+
+fn assert_interrupt(output: &str, expected_check_method: &str, expected_receiver: &str) {
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected interrupt, got: {output}"
+    );
+    assert!(
+        output.contains(expected_check_method),
+        "expected check method `{expected_check_method}` in output, got: {output}"
+    );
+    assert!(
+        output.contains(expected_receiver),
+        "expected receiver `{expected_receiver}` in output, got: {output}"
+    );
+}
+
+#[test_case(
+    r#"
+fn parse(value: Option<String>) -> Result<String, String> {
+    if value.is_none() {
+        return Err("missing".to_string());
+    }
+    let value = value.unwrap();
+    Ok(value)
+}
+"#,
+    "is_none",
+    "value";
+    "option is_none guard then unwrap"
+)]
+#[test_case(
+    r#"
+fn parse(value: Option<String>) -> Result<String, String> {
+    if !value.is_some() {
+        return Err("missing".to_string());
+    }
+    let value = value.unwrap();
+    Ok(value)
+}
+"#,
+    "is_some",
+    "value";
+    "negated option is_some guard then unwrap"
+)]
+#[test_case(
+    r#"
+fn parse(result: Result<String, String>) -> String {
+    if result.is_err() {
+        return handle_error();
+    }
+    let value = result.unwrap();
+    value
+}
+"#,
+    "is_err",
+    "result";
+    "result is_err guard then unwrap"
+)]
+#[test_case(
+    r#"
+fn parse(result: Result<String, String>) -> String {
+    if !result.is_ok() {
+        return handle_error();
+    }
+    let value = result.unwrap();
+    value
+}
+"#,
+    "is_ok",
+    "result";
+    "negated result is_ok guard then unwrap"
+)]
+#[test]
+fn write_hook_detects_check_then_unwrap(
+    source: &str,
+    expected_check_method: &str,
+    expected_receiver: &str,
+) {
+    let dir = setup_config();
+    let input = write_hook("src/lib.rs", source);
+    let (exit_code, output) = run_agent_hook(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert_interrupt(&output, expected_check_method, expected_receiver);
+}
+
+#[test]
+fn edit_hook_detects_check_then_unwrap() {
+    let dir = setup_config();
+    let source = r#"
+fn parse(value: Option<String>) -> Result<String, String> {
+    if value.is_none() {
+        return Err("missing".to_string());
+    }
+    let value = value.unwrap();
+    Ok(value)
+}
+"#;
+    let input = edit_hook("src/lib.rs", "", source);
+    let (exit_code, output) = run_agent_hook(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert_interrupt(&output, "is_none", "value");
+}
+
+#[test_case(
+    r#"
+fn parse(value: Option<String>, fallback: Option<String>) -> Result<String, String> {
+    if value.is_none() {
+        return Err("missing".to_string());
+    }
+    let value = fallback.unwrap();
+    Ok(value)
+}
+"#;
+    "different unwrap receiver"
+)]
+#[test_case(
+    r#"
+fn parse(value: Option<String>) -> Result<String, String> {
+    if value.is_none() {
+        log::warn!("missing");
+    }
+    let value = value.unwrap();
+    Ok(value)
+}
+"#;
+    "guard does not exit"
+)]
+#[test_case(
+    r#"
+fn parse(value: Option<String>) -> Result<String, String> {
+    if value.is_none() {
+        return Err("missing".to_string());
+    } else {
+        log::debug!("present");
+    }
+    let value = value.unwrap();
+    Ok(value)
+}
+"#;
+    "if has else"
+)]
+#[test_case(
+    r#"
+fn parse(value: Option<String>) -> Result<String, String> {
+    if value.is_none() {
+        return Err("missing".to_string());
+    }
+    audit();
+    let value = value.unwrap();
+    Ok(value)
+}
+"#;
+    "executable statement between guard and unwrap"
+)]
+#[test_case(
+    r#"
+fn parse(value: Option<String>) -> Result<String, String> {
+    if value.is_some() {
+        return Err("unexpected".to_string());
+    }
+    let value = value.unwrap();
+    Ok(value)
+}
+"#;
+    "guard exits on present value"
+)]
+#[test]
+fn write_hook_avoids_false_positives(source: &str) {
+    let dir = setup_config();
+    let input = write_hook("src/lib.rs", source);
+    let (exit_code, output) = run_agent_hook(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0");
+    assert!(
+        output.is_empty(),
+        "expected passthrough for false positive case, got: {output}"
+    );
+}
+
+#[test]
+fn write_hook_allows_comment_between_guard_and_unwrap() {
+    let dir = setup_config();
+    let source = r#"
+fn parse(value: Option<String>) -> Result<String, String> {
+    if value.is_none() {
+        return Err("missing".to_string());
+    }
+    // Explains why absence returns early.
+    let value = value.unwrap();
+    Ok(value)
+}
+"#;
+    let input = write_hook("src/lib.rs", source);
+    let (exit_code, output) = run_agent_hook(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert_interrupt(&output, "is_none", "value");
+}
+
+#[test]
+fn check_command_reports_check_then_unwrap() {
+    let dir = setup_config();
+    let source = r#"
+fn parse(value: Option<String>) -> Result<String, String> {
+    if value.is_none() {
+        return Err("missing".to_string());
+    }
+    let value = value.unwrap();
+    Ok(value)
+}
+"#;
+    let (exit_code, stdout, stderr) = run_check(&dir, source);
+
+    pretty_assert_eq!(exit_code, 1, "expected check failure, stderr: {stderr}");
+    assert!(
+        stdout.contains("src/lib.rs:3 [prefer-let-else-over-check-unwrap]"),
+        "expected issue on guard line, got stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("is_none") && stdout.contains("value"),
+        "expected interpolated captures in check output, got: {stdout}"
+    );
+}


### PR DESCRIPTION
## Why this change

Resolves #5.

Nudge could already match single-line regexes and tree-sitter query shapes, but issue #5 needs a semantic Rust check: recognize a guard clause, confirm the guard exits early, track that the later `.unwrap()` uses the same receiver, and avoid nearby false positives. This adds a dedicated `RustCheckThenUnwrap` content matcher for that pattern instead of stretching regex or raw query syntax beyond what it can safely express.

## What changed

- Added a Rust AST matcher that scans sibling statements inside blocks for `Option`/`Result` guard clauses followed by same-receiver `unwrap()`.
- Detects `value.is_none()`, `!value.is_some()`, `result.is_err()`, and `!result.is_ok()` when the guard body ends in top-level `return`, `break`, or `continue`.
- Allows comments/blank lines between the guard and unwrap, but rejects intervening executable statements, `else` branches, non-exiting guards, different receivers, and guards that exit on the present/ok case.
- Exposes captures such as `receiver`, `check_method`, `checked_state`, `unwrap_binding`, and `early_exit` for rule messages and suggestions.
- Documents the new matcher in `nudge claude docs` / `nudge codex docs`, README, example Rust rules, and the root dogfood `.nudge.yaml`.

## Testing steps performed

Pre-fix regression proof:

```text
cargo test -p nudge --test it rust_check_then_unwrap -- --nocapture
...
rules[0].on: data did not match any variant of untagged enum Hook at line 8 column 7
...
test result: FAILED. 0 passed; 12 failed; 0 ignored; 0 measured; 72 filtered out
```

Focused post-fix coverage:

```text
cargo test -p nudge --test it rust_check_then_unwrap -- --nocapture
...
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 72 filtered out
```

Full package tests:

```text
cargo test -p nudge
...
test result: ok. 66 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
...
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
...
test result: ok. 84 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
...
test result: ok. 1 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
```

Clippy:

```text
cargo clippy -p nudge --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.22s
```

Rule config validation:

```text
cargo run -q -p nudge -- validate .nudge.yaml
# output includes prefer-let-else-over-check-unwrap with kind: RustCheckThenUnwrap

cargo run -q -p nudge -- validate examples/rules/rust.yaml
# output includes prefer-let-else-over-check-unwrap with kind: RustCheckThenUnwrap
```

Additional hygiene:

```text
git diff --check
# no output

rg -n "[\u2018\u2019\u201C\u201D\u00AB\u00BB]" .nudge.yaml AGENTS.md README.md examples/rules/rust.yaml packages/nudge/src/cmd/claude/docs.rs packages/nudge/src/rules/schema.rs packages/nudge/src/rules/schema/content.rs packages/nudge/src/rules/schema/rust.rs packages/nudge/tests/it/main.rs packages/nudge/tests/it/rust_check_then_unwrap.rs
# no output
```

## Configuration changes after merge

No setup or migration is required. Existing rules keep working. Projects that want this behavior can add `kind: RustCheckThenUnwrap` under `content` or `new_content` for Rust file rules; the root Nudge config and `examples/rules/rust.yaml` now show that opt-in form.

## Notes

This is a schema extension, not a breaking change. The matcher is intentionally conservative about statement order so it catches the issue pattern without flagging code that mutates or audits between the guard and unwrap.