### PR TITLE
Detect Rust stuttering type names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ nudge check         - Check project files against rules (CI/linter mode)
 - `src/rules.rs` - Rule loading from config files
 - `src/rules/schema.rs` - Rule schema facade and hook matcher types
 - `src/rules/schema/` - Focused matcher implementations for content, glob paths, project state, tree-sitter syntax, and URLs
+- `src/rules/schema/stuttering.rs` - Rust module-aware stuttering type-name matcher
 - `src/snippet.rs` - Code snippet rendering for rule violations (uses `annotate-snippets`)
 
 ### How Nudge Communicates

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ These are the rules Nudge uses on its own codebase (yes, we dogfood):
 | No inline imports    | Move `use` statements to the top of the file                |
 | LHS type annotations | Prefer turbofish (`::<T>`) over `let x: T = ...`            |
 | Qualified paths      | Import and use shorter names instead of long paths          |
+| Stuttering types     | Avoid type names that repeat their Rust module context      |
 | Pretty assertions    | Use `pretty_assertions` in tests for better diff output     |
 | No `.unwrap()`       | Use `.expect("...")` with a descriptive message             |
 
@@ -89,6 +90,24 @@ rules:
 ```
 
 Substitutions work for Claude Code and Codex CLI. Nudge returns the provider's full updated tool input with only `command` changed, and adds `hookSpecificOutput.additionalContext` so the model sees what was rewritten.
+
+For Rust modules, use `kind: StutteringTypeName` when a type should not repeat
+context that the module path already supplies. The matcher understands inline
+modules and file-derived modules such as `src/storage.rs`, flags configured
+suffixes like `Manager`, `Service`, and `Handler`, and supports an `allow` list
+for intentional repetitions:
+
+```yaml
+content:
+  - kind: StutteringTypeName
+    language: rust
+    redundant_suffixes: ["Manager", "Service", "Handler"]
+    module_aliases:
+      db: ["Database"]
+    allow:
+      - "storage::StorageEngine"
+    suggestion: "Rename `{{ $type }}` to `{{ $replacement }}`; {{ $reason }}."
+```
 
 For the full rule syntax and copy-pasteable examples, run `nudge claude docs` or `nudge codex docs`.
 

--- a/packages/nudge/src/cmd/check.rs
+++ b/packages/nudge/src/cmd/check.rs
@@ -163,13 +163,21 @@ fn check_file(file: &Path, file_rules: &[FileRule<'_>]) -> (Vec<Issue>, bool) {
 
 fn rule_issues(file: &Path, content: &str, file_rule: &FileRule<'_>) -> Vec<Issue> {
     let matchers = file_rule.matchers.as_slice();
-    if matchers.is_empty() || !matchers.iter().all(|m| m.is_match(content)) {
+    if matchers.is_empty() {
         return Vec::new();
     }
 
-    matchers
+    let matches_by_matcher = matchers
         .iter()
-        .flat_map(|matcher| matcher.matches_with_context(content))
+        .map(|matcher| matcher.matches_with_path_context(Some(file), content))
+        .collect::<Vec<_>>();
+    if matches_by_matcher.iter().any(Vec::is_empty) {
+        return Vec::new();
+    }
+
+    matches_by_matcher
+        .into_iter()
+        .flatten()
         .map(|m| {
             let line = byte_offset_to_line(content, m.span.start);
             let message = nudge::template::interpolate(file_rule.rule.message(), &m.captures);

--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -246,6 +246,36 @@ const DOCS: &str = cstr!("\
   <dim>Note: If code fails to parse (incomplete or invalid syntax), the matcher</dim>
   <dim>passes silently. This is intentional because code being written is often incomplete.</dim>
 
+<bold>Rust Stuttering Type Names</bold>
+
+  Use <cyan>kind: StutteringTypeName</cyan> to catch Rust types that repeat module
+  context or generic suffixes. It parses Rust with tree-sitter, understands inline
+  modules and file-derived modules like <cyan>src/storage.rs</cyan>, and reports the
+  type identifier span.
+
+  <white>Basic Syntax:</white>
+    <yellow>content:</yellow>
+      <yellow>- kind: StutteringTypeName</yellow>
+        <yellow>language: rust</yellow>
+        <yellow>redundant_suffixes: [\"Manager\", \"Service\", \"Handler\"]</yellow>
+        <yellow>module_aliases:</yellow>
+          <yellow>db: [\"Database\"]</yellow>
+        <yellow>allow:</yellow>
+          <yellow>- \"storage::StorageEngine\"</yellow>
+        <yellow>suggestion: \"Rename `{{ $type }}` to `{{ $replacement }}`; {{ $reason }}.\"</yellow>
+
+  <white>Captures:</white>
+    <green>{{ $type }}</green>         Type name that matched, e.g. <cyan>CasStorage</cyan>
+    <green>{{ $kind }}</green>         Rust item kind: struct, enum, trait, type, or union
+    <green>{{ $module }}</green>       Module path, e.g. <cyan>storage</cyan> or <cyan>auth::jwt</cyan>
+    <green>{{ $term }}</green>         Redundant term, e.g. <cyan>Storage</cyan> or <cyan>Manager</cyan>
+    <green>{{ $replacement }}</green>  Best mechanical rename, or \"a concrete name\"
+    <green>{{ $reason }}</green>       Human-readable explanation for the match
+
+  <white>False Positive Controls:</white>
+    <green>allow</green> accepts exact type names or module-qualified names. Use it for
+    intentional domain phrases where the repetition is useful.
+
 <bold>External Program Matching</bold>
 
   Use <cyan>kind: External</cyan> to delegate matching to an external program (linter, formatter,
@@ -370,6 +400,28 @@ const DOCS: &str = cstr!("\
                   <yellow>body: (block</yellow>
                     <yellow>(use_declaration</yellow>
                       <yellow>argument: (scoped_identifier) @path)))</yellow>
+
+  <cyan>Block stuttering Rust type names</cyan>
+
+    <dim># Flags names like storage::CasStorage, cache::KeyCache, auth::JwtManager,</dim>
+    <dim># and db::Database while allowing intentional names.</dim>
+
+    <yellow>- name: rust-stuttering-types</yellow>
+      <yellow>description: Avoid repeating module context in Rust type names</yellow>
+      <yellow>message: \"{{ $suggestion }}\"</yellow>
+      <yellow>on:</yellow>
+        <yellow>- hook: PreToolUse</yellow>
+          <yellow>tool: Write</yellow>
+          <yellow>file: \"**/*.rs\"</yellow>
+          <yellow>content:</yellow>
+            <yellow>- kind: StutteringTypeName</yellow>
+              <yellow>language: rust</yellow>
+              <yellow>redundant_suffixes: [\"Manager\", \"Service\", \"Handler\"]</yellow>
+              <yellow>module_aliases:</yellow>
+                <yellow>db: [\"Database\"]</yellow>
+              <yellow>allow:</yellow>
+                <yellow>- \"storage::StorageEngine\"</yellow>
+              <yellow>suggestion: \"Rename `{{ $type }}` to `{{ $replacement }}`; {{ $reason }}.\"</yellow>
 
   <cyan>Enforce markdown table formatting (External)</cyan>
 

--- a/packages/nudge/src/hook/evaluate.rs
+++ b/packages/nudge/src/hook/evaluate.rs
@@ -224,7 +224,7 @@ fn annotate_bash(rule: &Rule, payload: &PreToolUse, input: &BashInput) -> Vec<An
 
 fn evaluate_write(input: &WriteInput, matcher: &PreToolUseWriteMatcher) -> Vec<Match> {
     if matcher.file.is_match_path(&input.file_path) {
-        evaluate_all_matched(&input.content, &matcher.content)
+        evaluate_all_file_matched(&input.file_path, &input.content, &matcher.content)
     } else {
         Vec::new()
     }
@@ -232,7 +232,7 @@ fn evaluate_write(input: &WriteInput, matcher: &PreToolUseWriteMatcher) -> Vec<M
 
 fn evaluate_edit(input: &EditInput, matcher: &PreToolUseEditMatcher) -> Vec<Match> {
     if matcher.file.is_match_path(&input.file_path) {
-        evaluate_all_matched(&input.new_string, &matcher.new_content)
+        evaluate_all_file_matched(&input.file_path, &input.new_string, &matcher.new_content)
     } else {
         Vec::new()
     }
@@ -278,9 +278,19 @@ fn source_for_tool(tool: &ToolUse) -> Source {
 /// Evaluate all content matchers and return matches only if every matcher
 /// matched.
 fn evaluate_all_matched(content: &str, matchers: &[ContentMatcher]) -> Vec<Match> {
+    evaluate_all_file_matched(std::path::Path::new(""), content, matchers)
+}
+
+/// Evaluate all content matchers with file path context and return matches only
+/// if every matcher matched.
+fn evaluate_all_file_matched(
+    path: &std::path::Path,
+    content: &str,
+    matchers: &[ContentMatcher],
+) -> Vec<Match> {
     let mut matches = Vec::new();
     for matcher in matchers {
-        let matcher_matches = matcher.matches_with_context(content);
+        let matcher_matches = matcher.matches_with_path_context(Some(path), content);
         if matcher_matches.is_empty() {
             return Vec::new();
         }

--- a/packages/nudge/src/rules/schema.rs
+++ b/packages/nudge/src/rules/schema.rs
@@ -18,6 +18,7 @@ pub use url::UrlMatcher;
 mod content;
 mod path;
 mod project_state;
+mod stuttering;
 mod syntax;
 mod url;
 

--- a/packages/nudge/src/rules/schema/content.rs
+++ b/packages/nudge/src/rules/schema/content.rs
@@ -1,5 +1,7 @@
 use std::{
+    collections::BTreeMap,
     io::Write,
+    path::Path,
     process::{Command, Stdio},
     sync::LazyLock,
 };
@@ -14,7 +16,7 @@ use crate::{
     template::{self, Captures},
 };
 
-use super::{Language, TreeSitterQuery, syntax::union_of_captures};
+use super::{Language, TreeSitterQuery, stuttering, syntax::union_of_captures};
 
 /// The method used to match hook content.
 ///
@@ -70,6 +72,29 @@ pub enum ContentMatcher {
         /// The command to run, as a list of arguments.
         command: Vec<String>,
     },
+
+    /// Match Rust type names that repeat module context or generic suffixes.
+    StutteringTypeName {
+        /// The language grammar to use for parsing. Currently only `rust` is
+        /// supported.
+        language: Language,
+
+        /// Suffixes that do not add useful type information.
+        #[serde(default = "stuttering::default_redundant_suffixes")]
+        redundant_suffixes: Vec<String>,
+
+        /// Extra terms that should count as module context.
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        module_aliases: BTreeMap<String, Vec<String>>,
+
+        /// Type names or module-qualified type names to suppress.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        allow: Vec<String>,
+
+        /// Optional suggestion template, same as Regex and SyntaxTree.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        suggestion: Option<String>,
+    },
 }
 
 impl<'de> Deserialize<'de> for ContentMatcher {
@@ -86,6 +111,10 @@ impl<'de> Deserialize<'de> for ContentMatcher {
             command: Option<Vec<String>>,
             suggestion: Option<String>,
             replace: Option<String>,
+            redundant_suffixes: Option<Vec<String>>,
+            module_aliases: Option<BTreeMap<String, Vec<String>>>,
+            allow: Option<Vec<String>>,
+            allowed: Option<Vec<String>>,
         }
 
         let raw = Raw::deserialize(deserializer)?;
@@ -121,9 +150,32 @@ impl<'de> Deserialize<'de> for ContentMatcher {
                 }
                 Ok(ContentMatcher::External { command })
             }
+            "StutteringTypeName" => {
+                let language = raw
+                    .language
+                    .ok_or_else(|| serde::de::Error::missing_field("language"))?;
+                if language != Language::Rust {
+                    return Err(serde::de::Error::custom(
+                        "StutteringTypeName currently supports only language: rust",
+                    ));
+                }
+
+                let mut allow = raw.allow.unwrap_or_default();
+                allow.extend(raw.allowed.unwrap_or_default());
+
+                Ok(ContentMatcher::StutteringTypeName {
+                    language,
+                    redundant_suffixes: raw
+                        .redundant_suffixes
+                        .unwrap_or_else(stuttering::default_redundant_suffixes),
+                    module_aliases: raw.module_aliases.unwrap_or_default(),
+                    allow,
+                    suggestion: raw.suggestion,
+                })
+            }
             other => Err(serde::de::Error::unknown_variant(
                 other,
-                &["Regex", "SyntaxTree", "External"],
+                &["Regex", "SyntaxTree", "External", "StutteringTypeName"],
             )),
         }
     }
@@ -141,6 +193,11 @@ impl ContentMatcher {
                 .next()
                 .is_some(),
             ContentMatcher::External { command } => run_external_command(command, s).is_some(),
+            ContentMatcher::StutteringTypeName { .. } => self
+                .matches_with_path_context(None, s)
+                .into_iter()
+                .next()
+                .is_some(),
         }
     }
 
@@ -161,6 +218,11 @@ impl ContentMatcher {
                     Vec::new()
                 }
             }
+            ContentMatcher::StutteringTypeName { .. } => self
+                .matches_with_path_context(None, s)
+                .into_iter()
+                .map(|m| m.span)
+                .collect(),
         }
     }
 
@@ -196,6 +258,32 @@ impl ContentMatcher {
                     Vec::new()
                 }
             }
+            ContentMatcher::StutteringTypeName { .. } => self.matches_with_path_context(None, s),
+        }
+    }
+
+    /// Get matches with capture groups using optional file path context.
+    pub fn matches_with_path_context(&self, path: Option<&Path>, s: &str) -> Vec<Match> {
+        match self {
+            ContentMatcher::StutteringTypeName {
+                language,
+                redundant_suffixes,
+                module_aliases,
+                allow,
+                suggestion,
+            } => {
+                let mut matches = stuttering::rust_type_name_matches(
+                    *language,
+                    path,
+                    s,
+                    redundant_suffixes,
+                    module_aliases,
+                    allow,
+                );
+                apply_suggestion(&mut matches, suggestion);
+                matches
+            }
+            _ => self.matches_with_context(s),
         }
     }
 
@@ -455,6 +543,39 @@ mod tests {
             kind: SyntaxTree
             language: rust
             query: "(not_a_real_node)"
+        "#;
+        let result = serde_yaml::from_str::<ContentMatcher>(yaml);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_content_matcher_stuttering_type_name_deserialize() {
+        let yaml = r#"
+            kind: StutteringTypeName
+            language: rust
+            redundant_suffixes: ["Manager", "Service"]
+            module_aliases:
+              db: ["Database"]
+            allow:
+              - "storage::StorageEngine"
+            suggestion: "Rename {{ $type }}"
+        "#;
+        let matcher = serde_yaml::from_str::<ContentMatcher>(yaml).expect("valid yaml");
+
+        assert!(matches!(
+            matcher,
+            ContentMatcher::StutteringTypeName {
+                language: Language::Rust,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_content_matcher_stuttering_type_name_rejects_non_rust() {
+        let yaml = r#"
+            kind: StutteringTypeName
+            language: typescript
         "#;
         let result = serde_yaml::from_str::<ContentMatcher>(yaml);
         assert!(result.is_err());

--- a/packages/nudge/src/rules/schema/stuttering.rs
+++ b/packages/nudge/src/rules/schema/stuttering.rs
@@ -55,39 +55,37 @@ fn visit_node(
     allow: &[String],
     matches: &mut Vec<Match>,
 ) {
-    if node.kind() == "mod_item" {
-        if let Some(body) = node.child_by_field_name("body") {
-            if let Some(name) = node
-                .child_by_field_name("name")
-                .and_then(|node| node_text(node, source))
-            {
-                module_stack.push(name);
-                visit_children(
-                    body,
-                    source,
-                    module_stack,
-                    redundant_suffixes,
-                    module_aliases,
-                    allow,
-                    matches,
-                );
-                module_stack.pop();
-                return;
-            }
-        }
+    if node.kind() == "mod_item"
+        && let Some(body) = node.child_by_field_name("body")
+        && let Some(name) = node
+            .child_by_field_name("name")
+            .and_then(|node| node_text(node, source))
+    {
+        module_stack.push(name);
+        visit_children(
+            body,
+            source,
+            module_stack,
+            redundant_suffixes,
+            module_aliases,
+            allow,
+            matches,
+        );
+        module_stack.pop();
+        return;
     }
 
-    if is_type_item(node.kind()) {
-        if let Some(type_match) = type_item_match(
+    if is_type_item(node.kind())
+        && let Some(type_match) = type_item_match(
             node,
             source,
             module_stack,
             redundant_suffixes,
             module_aliases,
             allow,
-        ) {
-            matches.push(type_match);
-        }
+        )
+    {
+        matches.push(type_match);
     }
 
     visit_children(
@@ -423,7 +421,7 @@ fn configured_term(value: &str) -> String {
 
 fn to_pascal_case(value: &str) -> String {
     value
-        .split(|c: char| c == '_' || c == '-' || c == ' ')
+        .split(['_', '-', ' '])
         .filter(|part| !part.is_empty())
         .map(|part| {
             let mut chars = part.chars();

--- a/packages/nudge/src/rules/schema/stuttering.rs
+++ b/packages/nudge/src/rules/schema/stuttering.rs
@@ -1,0 +1,587 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::{Component, Path},
+};
+
+use crate::{
+    rules::schema::Language,
+    snippet::{Match, Span},
+    template::Captures,
+};
+
+pub fn default_redundant_suffixes() -> Vec<String> {
+    ["Manager", "Service", "Handler"]
+        .into_iter()
+        .map(String::from)
+        .collect()
+}
+
+pub fn rust_type_name_matches(
+    language: Language,
+    path: Option<&Path>,
+    source: &str,
+    redundant_suffixes: &[String],
+    module_aliases: &BTreeMap<String, Vec<String>>,
+    allow: &[String],
+) -> Vec<Match> {
+    if language != Language::Rust {
+        return Vec::new();
+    }
+
+    let Some(tree) = language.parse(source) else {
+        return Vec::new();
+    };
+
+    let mut module_stack = file_module_stack(path);
+    let mut matches = Vec::new();
+    visit_node(
+        tree.root_node(),
+        source,
+        &mut module_stack,
+        redundant_suffixes,
+        module_aliases,
+        allow,
+        &mut matches,
+    );
+    matches
+}
+
+fn visit_node(
+    node: tree_sitter::Node<'_>,
+    source: &str,
+    module_stack: &mut Vec<String>,
+    redundant_suffixes: &[String],
+    module_aliases: &BTreeMap<String, Vec<String>>,
+    allow: &[String],
+    matches: &mut Vec<Match>,
+) {
+    if node.kind() == "mod_item" {
+        if let Some(body) = node.child_by_field_name("body") {
+            if let Some(name) = node
+                .child_by_field_name("name")
+                .and_then(|node| node_text(node, source))
+            {
+                module_stack.push(name);
+                visit_children(
+                    body,
+                    source,
+                    module_stack,
+                    redundant_suffixes,
+                    module_aliases,
+                    allow,
+                    matches,
+                );
+                module_stack.pop();
+                return;
+            }
+        }
+    }
+
+    if is_type_item(node.kind()) {
+        if let Some(type_match) = type_item_match(
+            node,
+            source,
+            module_stack,
+            redundant_suffixes,
+            module_aliases,
+            allow,
+        ) {
+            matches.push(type_match);
+        }
+    }
+
+    visit_children(
+        node,
+        source,
+        module_stack,
+        redundant_suffixes,
+        module_aliases,
+        allow,
+        matches,
+    );
+}
+
+fn visit_children(
+    node: tree_sitter::Node<'_>,
+    source: &str,
+    module_stack: &mut Vec<String>,
+    redundant_suffixes: &[String],
+    module_aliases: &BTreeMap<String, Vec<String>>,
+    allow: &[String],
+    matches: &mut Vec<Match>,
+) {
+    let mut cursor = node.walk();
+    if !cursor.goto_first_child() {
+        return;
+    }
+
+    loop {
+        visit_node(
+            cursor.node(),
+            source,
+            module_stack,
+            redundant_suffixes,
+            module_aliases,
+            allow,
+            matches,
+        );
+
+        if !cursor.goto_next_sibling() {
+            break;
+        }
+    }
+}
+
+fn type_item_match(
+    node: tree_sitter::Node<'_>,
+    source: &str,
+    module_stack: &[String],
+    redundant_suffixes: &[String],
+    module_aliases: &BTreeMap<String, Vec<String>>,
+    allow: &[String],
+) -> Option<Match> {
+    let name_node = node.child_by_field_name("name")?;
+    let type_name = node_text(name_node, source)?;
+    let module_path = module_stack.join("::");
+
+    if is_allowed(allow, &module_path, &type_name) {
+        return None;
+    }
+
+    let module_terms = module_terms(module_stack, module_aliases);
+    let redundant_terms = redundant_terms(redundant_suffixes);
+    let findings = findings_for_type(&type_name, &module_terms, &redundant_terms);
+    if findings.is_empty() {
+        return None;
+    }
+
+    let replacement = replacement_for(&type_name, &module_terms, &redundant_terms);
+    let primary = findings
+        .iter()
+        .find(|finding| finding.source == TermSource::Module)
+        .unwrap_or_else(|| findings.first().expect("findings is not empty"));
+    let span = name_node.byte_range();
+    let captures = Captures::from_iter([
+        ("0".to_string(), type_name.clone()),
+        ("type".to_string(), type_name),
+        ("kind".to_string(), type_kind(node.kind()).to_string()),
+        ("module".to_string(), module_path.clone()),
+        (
+            "module_name".to_string(),
+            module_stack.last().cloned().unwrap_or_default(),
+        ),
+        ("term".to_string(), primary.term.clone()),
+        (
+            "position".to_string(),
+            primary.position.as_str().to_string(),
+        ),
+        ("replacement".to_string(), replacement),
+        ("reason".to_string(), primary.reason(&module_path)),
+    ]);
+
+    Some(Match {
+        span: Span::from(span),
+        captures,
+    })
+}
+
+fn is_type_item(kind: &str) -> bool {
+    matches!(
+        kind,
+        "struct_item" | "enum_item" | "trait_item" | "type_item" | "union_item"
+    )
+}
+
+fn type_kind(kind: &str) -> &str {
+    match kind {
+        "struct_item" => "struct",
+        "enum_item" => "enum",
+        "trait_item" => "trait",
+        "type_item" => "type",
+        "union_item" => "union",
+        _ => "type",
+    }
+}
+
+fn node_text(node: tree_sitter::Node<'_>, source: &str) -> Option<String> {
+    node.utf8_text(source.as_bytes()).ok().map(String::from)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Term {
+    text: String,
+    source: TermSource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TermSource {
+    Module,
+    RedundantSuffix,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Finding {
+    term: String,
+    source: TermSource,
+    position: Position,
+}
+
+impl Finding {
+    fn reason(&self, module_path: &str) -> String {
+        match self.source {
+            TermSource::Module => {
+                if module_path.is_empty() {
+                    format!("the surrounding module already provides `{}`", self.term)
+                } else {
+                    format!("module `{module_path}` already provides `{}`", self.term)
+                }
+            }
+            TermSource::RedundantSuffix => {
+                format!("`{}` is configured as a redundant type suffix", self.term)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Position {
+    Exact,
+    Prefix,
+    Suffix,
+}
+
+impl Position {
+    fn as_str(self) -> &'static str {
+        match self {
+            Position::Exact => "exact",
+            Position::Prefix => "prefix",
+            Position::Suffix => "suffix",
+        }
+    }
+}
+
+fn findings_for_type(name: &str, module_terms: &[Term], redundant_terms: &[Term]) -> Vec<Finding> {
+    let mut findings = Vec::new();
+
+    for term in module_terms {
+        if name == term.text {
+            findings.push(Finding {
+                term: term.text.clone(),
+                source: term.source,
+                position: Position::Exact,
+            });
+        } else if strip_suffix(name, &term.text).is_some() {
+            findings.push(Finding {
+                term: term.text.clone(),
+                source: term.source,
+                position: Position::Suffix,
+            });
+        } else if strip_prefix(name, &term.text).is_some() {
+            findings.push(Finding {
+                term: term.text.clone(),
+                source: term.source,
+                position: Position::Prefix,
+            });
+        }
+    }
+
+    for term in redundant_terms {
+        if strip_suffix(name, &term.text).is_some() {
+            findings.push(Finding {
+                term: term.text.clone(),
+                source: term.source,
+                position: Position::Suffix,
+            });
+        }
+    }
+
+    findings
+}
+
+fn replacement_for(name: &str, module_terms: &[Term], redundant_terms: &[Term]) -> String {
+    let mut candidate = name.to_string();
+    let mut terms = module_terms
+        .iter()
+        .chain(redundant_terms)
+        .map(|term| term.text.as_str())
+        .collect::<Vec<_>>();
+    terms.sort_by_key(|term| std::cmp::Reverse(term.len()));
+    terms.dedup();
+
+    loop {
+        let before = candidate.clone();
+
+        for term in &terms {
+            if let Some(stripped) = strip_suffix(&candidate, term) {
+                candidate = stripped;
+                break;
+            }
+        }
+
+        for term in &terms {
+            if let Some(stripped) = strip_prefix(&candidate, term) {
+                candidate = stripped;
+                break;
+            }
+        }
+
+        if candidate == before {
+            break;
+        }
+    }
+
+    if candidate == name || module_terms.iter().any(|term| term.text == candidate) {
+        "a concrete name".to_string()
+    } else {
+        candidate
+    }
+}
+
+fn strip_suffix(name: &str, term: &str) -> Option<String> {
+    let prefix = name.strip_suffix(term)?;
+    if prefix.is_empty() {
+        return None;
+    }
+    Some(prefix.to_string())
+}
+
+fn strip_prefix(name: &str, term: &str) -> Option<String> {
+    let suffix = name.strip_prefix(term)?;
+    if suffix.is_empty() {
+        return None;
+    }
+    let mut chars = suffix.chars();
+    let first = chars.next()?;
+    if !first.is_uppercase() {
+        return None;
+    }
+    Some(suffix.to_string())
+}
+
+fn module_terms(
+    module_stack: &[String],
+    module_aliases: &BTreeMap<String, Vec<String>>,
+) -> Vec<Term> {
+    let mut terms = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    for module in module_stack {
+        push_term(
+            &mut terms,
+            &mut seen,
+            to_pascal_case(module),
+            TermSource::Module,
+        );
+
+        if let Some(aliases) = module_aliases.get(module) {
+            for alias in aliases {
+                push_term(
+                    &mut terms,
+                    &mut seen,
+                    configured_term(alias),
+                    TermSource::Module,
+                );
+            }
+        }
+    }
+
+    terms.sort_by_key(|term| std::cmp::Reverse(term.text.len()));
+    terms
+}
+
+fn redundant_terms(suffixes: &[String]) -> Vec<Term> {
+    let mut terms = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    for suffix in suffixes {
+        push_term(
+            &mut terms,
+            &mut seen,
+            configured_term(suffix),
+            TermSource::RedundantSuffix,
+        );
+    }
+
+    terms.sort_by_key(|term| std::cmp::Reverse(term.text.len()));
+    terms
+}
+
+fn push_term(terms: &mut Vec<Term>, seen: &mut BTreeSet<String>, text: String, source: TermSource) {
+    if text.is_empty() || !seen.insert(text.clone()) {
+        return;
+    }
+    terms.push(Term { text, source });
+}
+
+fn configured_term(value: &str) -> String {
+    if value.chars().any(char::is_uppercase) {
+        value.to_string()
+    } else {
+        to_pascal_case(value)
+    }
+}
+
+fn to_pascal_case(value: &str) -> String {
+    value
+        .split(|c: char| c == '_' || c == '-' || c == ' ')
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            let mut chars = part.chars();
+            let Some(first) = chars.next() else {
+                return String::new();
+            };
+            first
+                .to_uppercase()
+                .chain(chars.flat_map(char::to_lowercase))
+                .collect::<String>()
+        })
+        .collect()
+}
+
+fn is_allowed(allow: &[String], module_path: &str, type_name: &str) -> bool {
+    let qualified = if module_path.is_empty() {
+        type_name.to_string()
+    } else {
+        format!("{module_path}::{type_name}")
+    };
+
+    allow.iter().any(|allowed| {
+        allowed == type_name
+            || allowed == &qualified
+            || (allowed.contains("::") && qualified.ends_with(&format!("::{allowed}")))
+    })
+}
+
+fn file_module_stack(path: Option<&Path>) -> Vec<String> {
+    let Some(path) = path else {
+        return Vec::new();
+    };
+
+    let components = path
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(value) => value.to_str().map(String::from),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let start = components
+        .iter()
+        .rposition(|component| component == "src")
+        .map_or(0, |index| index + 1);
+    let module_components = &components[start..];
+    if module_components
+        .first()
+        .is_some_and(|component| is_non_module_source_root(component))
+    {
+        return Vec::new();
+    }
+
+    module_components
+        .iter()
+        .enumerate()
+        .filter_map(|(index, component)| {
+            let is_last = index + 1 == module_components.len();
+            let module = if is_last {
+                Path::new(component).file_stem()?.to_str()?
+            } else {
+                component
+            };
+
+            if is_skipped_module_name(module) || !is_rust_identifier(module) {
+                return None;
+            }
+
+            Some(module.to_string())
+        })
+        .collect()
+}
+
+fn is_non_module_source_root(component: &str) -> bool {
+    matches!(component, "bin" | "benches" | "examples" | "tests")
+}
+
+fn is_skipped_module_name(module: &str) -> bool {
+    matches!(module, "" | "." | "lib" | "main" | "mod")
+}
+
+fn is_rust_identifier(module: &str) -> bool {
+    let mut chars = module.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn matches(path: Option<&Path>, source: &str) -> Vec<Match> {
+        rust_type_name_matches(
+            Language::Rust,
+            path,
+            source,
+            &default_redundant_suffixes(),
+            &BTreeMap::from([("db".to_string(), vec!["Database".to_string()])]),
+            &[],
+        )
+    }
+
+    #[test]
+    fn detects_file_module_suffix() {
+        let matches = matches(
+            Some(Path::new("src/storage.rs")),
+            "pub struct CasStorage;\n",
+        );
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].captures["type"], "CasStorage");
+        assert_eq!(matches[0].captures["module"], "storage");
+        assert_eq!(matches[0].captures["replacement"], "Cas");
+    }
+
+    #[test]
+    fn detects_inline_module_alias_exact() {
+        let matches = matches(None, "mod db { pub struct Database; }");
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].captures["type"], "Database");
+        assert_eq!(matches[0].captures["term"], "Database");
+        assert_eq!(matches[0].captures["replacement"], "a concrete name");
+    }
+
+    #[test]
+    fn allow_list_suppresses_exact_qualified_name() {
+        let matches = rust_type_name_matches(
+            Language::Rust,
+            Some(Path::new("src/storage.rs")),
+            "pub struct StorageEngine;\n",
+            &default_redundant_suffixes(),
+            &BTreeMap::new(),
+            &["storage::StorageEngine".to_string()],
+        );
+
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn file_module_stack_uses_path_after_src() {
+        assert_eq!(
+            file_module_stack(Some(Path::new(
+                "packages/nudge/src/rules/schema/content.rs"
+            ))),
+            vec!["rules", "schema", "content"]
+        );
+        assert_eq!(
+            file_module_stack(Some(Path::new("src/storage/mod.rs"))),
+            vec!["storage"]
+        );
+    }
+
+    #[test]
+    fn file_module_stack_ignores_non_module_roots() {
+        assert!(file_module_stack(Some(Path::new("src/bin/tool.rs"))).is_empty());
+        assert!(file_module_stack(Some(Path::new("tests/storage.rs"))).is_empty());
+    }
+}

--- a/packages/nudge/tests/it/main.rs
+++ b/packages/nudge/tests/it/main.rs
@@ -16,6 +16,7 @@ mod message_content;
 mod multiple_rules;
 mod non_rust_files;
 mod setup;
+mod stuttering_types;
 mod syntax_tree;
 mod user_prompt;
 mod webfetch;

--- a/packages/nudge/tests/it/stuttering_types.rs
+++ b/packages/nudge/tests/it/stuttering_types.rs
@@ -1,0 +1,246 @@
+//! Integration tests for Rust stuttering type-name detection.
+
+use std::fs;
+use std::io::Write as _;
+use std::process::{Command, Stdio};
+
+use pretty_assertions::assert_eq as pretty_assert_eq;
+use tempfile::TempDir;
+
+use crate::nudge_binary;
+
+fn setup_config(rules_yaml: &str) -> TempDir {
+    let dir = TempDir::new().expect("create temp dir");
+    fs::write(dir.path().join(".nudge.yaml"), rules_yaml).expect("write config");
+    dir
+}
+
+fn run_hook_in_dir(dir: &TempDir, input: &str) -> (i32, String) {
+    let mut child = Command::new(nudge_binary())
+        .args(["claude", "hook"])
+        .current_dir(dir.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn nudge");
+
+    {
+        let stdin = child.stdin.as_mut().expect("failed to get stdin");
+        stdin
+            .write_all(input.as_bytes())
+            .expect("failed to write to stdin");
+    }
+
+    let output = child.wait_with_output().expect("failed to wait for nudge");
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    let combined = if !stdout.trim().is_empty() {
+        stdout.trim().to_string()
+    } else {
+        stderr.trim().to_string()
+    };
+
+    (exit_code, combined)
+}
+
+fn run_nudge_in_dir(dir: &TempDir, args: &[&str]) -> (i32, String, String) {
+    let output = Command::new(nudge_binary())
+        .args(args)
+        .current_dir(dir.path())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to run nudge");
+
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    (exit_code, stdout, stderr)
+}
+
+fn write_hook(file_path: &str, content: &str) -> String {
+    serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "test",
+        "transcript_path": "/tmp/test",
+        "permission_mode": "default",
+        "cwd": "/tmp",
+        "tool_name": "Write",
+        "tool_use_id": "123",
+        "tool_input": {
+            "file_path": file_path,
+            "content": content
+        }
+    })
+    .to_string()
+}
+
+fn edit_hook(file_path: &str, old_string: &str, new_string: &str) -> String {
+    serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "test",
+        "transcript_path": "/tmp/test",
+        "permission_mode": "default",
+        "cwd": "/tmp",
+        "tool_name": "Edit",
+        "tool_use_id": "123",
+        "tool_input": {
+            "file_path": file_path,
+            "old_string": old_string,
+            "new_string": new_string
+        }
+    })
+    .to_string()
+}
+
+fn stuttering_rule() -> &'static str {
+    r#"
+version: 1
+rules:
+  - name: stuttering-types
+    description: Avoid repeating module context in Rust type names
+    message: "{{ $suggestion }}"
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.rs"
+        content:
+          - kind: StutteringTypeName
+            language: rust
+            redundant_suffixes: ["Manager", "Service", "Handler"]
+            module_aliases:
+              db: ["Database"]
+            allow:
+              - "storage::StorageEngine"
+            suggestion: "Rename `{{ $type }}` to `{{ $replacement }}`; {{ $reason }}."
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.rs"
+        new_content:
+          - kind: StutteringTypeName
+            language: rust
+            redundant_suffixes: ["Manager", "Service", "Handler"]
+            module_aliases:
+              db: ["Database"]
+            allow:
+              - "storage::StorageEngine"
+            suggestion: "Rename `{{ $type }}` to `{{ $replacement }}`; {{ $reason }}."
+"#
+}
+
+#[test]
+fn test_stuttering_type_names_detect_inline_modules() {
+    let dir = setup_config(stuttering_rule());
+    let input = write_hook(
+        "src/lib.rs",
+        r#"
+mod storage {
+    pub struct CasStorage;
+    pub enum DiskStorage {}
+    pub struct StorageEngine;
+}
+
+mod cache {
+    pub type KeyCache = String;
+}
+
+mod auth {
+    pub struct JwtManager;
+}
+
+mod db {
+    pub struct Database;
+}
+"#,
+    );
+
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected interrupt for stuttering type names, got: {output}"
+    );
+    assert!(output.contains("Rename `CasStorage` to `Cas`"));
+    assert!(output.contains("Rename `DiskStorage` to `Disk`"));
+    assert!(output.contains("Rename `KeyCache` to `Key`"));
+    assert!(output.contains("Rename `JwtManager` to `Jwt`"));
+    assert!(output.contains("module `db` already provides `Database`"));
+    assert!(
+        !output.contains("Rename `StorageEngine`"),
+        "allow-list should suppress intentional repetitions, got: {output}"
+    );
+}
+
+#[test]
+fn test_stuttering_type_names_use_file_module_context() {
+    let dir = setup_config(stuttering_rule());
+    let input = write_hook("src/storage.rs", "pub struct CasStorage;\n");
+
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected interrupt for file module stutter, got: {output}"
+    );
+    assert!(output.contains("Rename `CasStorage` to `Cas`"));
+}
+
+#[test]
+fn test_stuttering_type_names_check_command_reports_lines() {
+    let dir = setup_config(stuttering_rule());
+    let src = dir.path().join("src");
+    fs::create_dir(&src).expect("create src");
+    fs::write(src.join("storage.rs"), "pub struct CasStorage;\n").expect("write source");
+
+    let (exit_code, stdout, stderr) = run_nudge_in_dir(&dir, &["check", "src/storage.rs"]);
+
+    assert_ne!(exit_code, 0, "check should fail for violations");
+    assert!(stderr.is_empty(), "expected no stderr, got: {stderr}");
+    assert!(
+        stdout.contains("src/storage.rs:1 [stuttering-types]"),
+        "expected file/line/rule output, got: {stdout}"
+    );
+    assert!(stdout.contains("Rename `CasStorage` to `Cas`"));
+}
+
+#[test]
+fn test_stuttering_type_names_edit_uses_replacement_content() {
+    let dir = setup_config(stuttering_rule());
+    let input = edit_hook("src/auth.rs", "pub struct Jwt;", "pub struct JwtManager;");
+
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected interrupt for edit replacement, got: {output}"
+    );
+    assert!(output.contains("Rename `JwtManager` to `Jwt`"));
+}
+
+#[test]
+fn test_stuttering_type_names_pass_clear_names_and_allowed_repetitions() {
+    let dir = setup_config(stuttering_rule());
+    let input = write_hook(
+        "src/storage.rs",
+        r#"
+pub struct Cas;
+pub struct Disk;
+pub struct StorageEngine;
+"#,
+    );
+
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0");
+    assert!(
+        output.is_empty(),
+        "expected passthrough for clear or allowed names, got: {output}"
+    );
+}


### PR DESCRIPTION
## Why this change

Resolves #3.

Rust style guidance says types should not repeat context already supplied by their module path, but Nudge's existing Regex and SyntaxTree matchers could not compare a type declaration against its containing module or file path. That left examples like `storage::CasStorage`, `cache::KeyCache`, `auth::JwtManager`, and `db::Database` unenforceable without brittle ad hoc scripts.

## What changed

Added a Rust-only `kind: StutteringTypeName` content matcher. It parses Rust with tree-sitter, walks inline `mod` blocks, derives module context from paths like `src/storage.rs`, and emits matches on struct, enum, trait, type alias, and union identifiers.

The matcher flags module-context repetition and configured redundant suffixes such as `Manager`, `Service`, and `Handler`. It exposes message captures including `{{ $type }}`, `{{ $module }}`, `{{ $term }}`, `{{ $replacement }}`, and `{{ $reason }}`, plus an `allow` list for intentional names like `storage::StorageEngine`.

Hook evaluation and `nudge check` now pass file path context into content matchers so file-derived modules work in both live hooks and CI/lint mode. I also documented the new matcher in README, `AGENTS.md`, and `nudge claude docs` / `nudge codex docs`.

## Testing steps performed

`cargo test -p nudge stuttering -- --nocapture`

```text
running 7 tests
test rules::schema::stuttering::tests::file_module_stack_ignores_non_module_roots ... ok
test rules::schema::stuttering::tests::file_module_stack_uses_path_after_src ... ok
test rules::schema::content::tests::test_content_matcher_stuttering_type_name_rejects_non_rust ... ok
test rules::schema::content::tests::test_content_matcher_stuttering_type_name_deserialize ... ok
test rules::schema::stuttering::tests::allow_list_suppresses_exact_qualified_name ... ok
test rules::schema::stuttering::tests::detects_file_module_suffix ... ok
test rules::schema::stuttering::tests::detects_inline_module_alias_exact ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 64 filtered out

running 5 tests
test stuttering_types::test_stuttering_type_names_pass_clear_names_and_allowed_repetitions ... ok
test stuttering_types::test_stuttering_type_names_use_file_module_context ... ok
test stuttering_types::test_stuttering_type_names_edit_uses_replacement_content ... ok
test stuttering_types::test_stuttering_type_names_check_command_reports_lines ... ok
test stuttering_types::test_stuttering_type_names_detect_inline_modules ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 72 filtered out
```

`cargo test -p nudge`

```text
running 71 tests
test result: ok. 71 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

running 1 test
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

running 77 tests
test result: ok. 77 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

Doc-tests nudge
running 1 test
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`cargo run -q -p nudge -- claude docs >/tmp/nudge-claude-docs.txt`

```text
exit 0
```

## Notes

No runtime setup or migration is required. Projects opt into this by adding `kind: StutteringTypeName` to Write/Edit file rules.
