### PR TITLE
Add Rust functional mutation matcher

### DIFF
--- a/.nudge.yaml
+++ b/.nudge.yaml
@@ -53,6 +53,26 @@ rules:
             query: |
               (let_declaration type: (_) @type)
 
+  # Catch simple mutation-heavy Rust loops that have clear iterator
+  # equivalents. The matcher intentionally skips complex loop bodies,
+  # preallocated Vecs, unsafe contexts, and control-flow-heavy expressions.
+  - name: prefer-functional-mutation
+    description: Prefer iterator adapters over simple mutable Rust loops
+    message: "{{ $suggestion }} Then retry."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.rs"
+        content:
+          - kind: RustFunctionalMutation
+            patterns: [vec_push, find, fold]
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.rs"
+        new_content:
+          - kind: RustFunctionalMutation
+            patterns: [vec_push, find, fold]
+
   # Catch unnecessarily fully qualified paths in code (not imports).
   # Pattern: paths with 2+ `::` separators followed by ::, (, or <
   - name: no-qualified-paths

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ nudge check         - Check project files against rules (CI/linter mode)
 - `src/rules.rs` - Rule loading from config files
 - `src/rules/schema.rs` - Rule schema facade and hook matcher types
 - `src/rules/schema/` - Focused matcher implementations for content, glob paths, project state, tree-sitter syntax, and URLs
+- `src/rules/schema/rust_functional_mutation.rs` - Rust-specific matcher for conservative loop-to-iterator mutation patterns
 - `src/snippet.rs` - Code snippet rendering for rule violations (uses `annotate-snippets`)
 
 ### How Nudge Communicates

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ These are the rules Nudge uses on its own codebase (yes, we dogfood):
 | Qualified paths      | Import and use shorter names instead of long paths          |
 | Pretty assertions    | Use `pretty_assertions` in tests for better diff output     |
 | No `.unwrap()`       | Use `.expect("...")` with a descriptive message             |
+| Functional iteration | Prefer iterator adapters over simple mutable Rust loops     |
 
 Other Attune codebases of course have other rules.
 
@@ -89,6 +90,23 @@ rules:
 ```
 
 Substitutions work for Claude Code and Codex CLI. Nudge returns the provider's full updated tool input with only `command` changed, and adds `hookSpecificOutput.additionalContext` so the model sees what was rewritten.
+
+Rust projects can also use the built-in `RustFunctionalMutation` matcher for
+low-noise loop rewrites such as `Vec::new()` plus `push`, `None` plus `break`,
+and accumulator reassignment that maps cleanly to `collect`, `find`, or `fold`:
+
+```yaml
+rules:
+  - name: prefer-functional-mutation
+    message: "{{ $suggestion }} Then retry."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.rs"
+        content:
+          - kind: RustFunctionalMutation
+            patterns: [vec_push, find, fold]
+```
 
 For the full rule syntax and copy-pasteable examples, run `nudge claude docs` or `nudge codex docs`.
 

--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -246,6 +246,34 @@ const DOCS: &str = cstr!("\
   <dim>Note: If code fails to parse (incomplete or invalid syntax), the matcher</dim>
   <dim>passes silently. This is intentional because code being written is often incomplete.</dim>
 
+<bold>Rust Functional Mutation Matching</bold>
+
+  Use <cyan>kind: RustFunctionalMutation</cyan> for simple Rust loops where immutable iterator
+  style is clearer than building state with <cyan>let mut</cyan>. It catches only adjacent
+  <green>let mut</green> plus <green>for</green> patterns with exact, low-noise shapes.
+
+  <white>Detected patterns:</white>
+    <green>vec_push</green>  <yellow>let mut values = Vec::new(); for item in items { values.push(...) }</yellow>
+    <green>find</green>      <yellow>let mut found = None; ... found = Some(item); break;</yellow>
+    <green>fold</green>      <yellow>let mut total = init; for item in items { total = combine(total, item); }</yellow>
+
+  <white>Basic Syntax:</white>
+    <yellow>content:</yellow>
+      <yellow>- kind: RustFunctionalMutation</yellow>
+        <yellow>patterns: [vec_push, find, fold]</yellow> <dim># Optional; defaults to all</dim>
+
+  <white>Captures:</white>
+    <green>{{ $suggestion }}</green>  Generated guidance for the matched pattern
+    <green>{{ $kind }}</green>        One of vec_push, vec_filter_map, find, find_map, fold
+    <green>{{ $binding }}</green>     Mutable binding name
+    <green>{{ $item }}</green>        Loop item binding
+    <green>{{ $iterator }}</green>    For-loop input expression
+
+  <white>False-positive controls:</white>
+    The matcher skips unsafe contexts, complex loop bodies, loops with extra side effects,
+    preallocated vectors such as <green>Vec::with_capacity(...)</green>, and control-flow-heavy
+    expressions such as <green>?</green>, <green>return</green>, <green>break</green>, or <green>await</green>.
+
 <bold>External Program Matching</bold>
 
   Use <cyan>kind: External</cyan> to delegate matching to an external program (linter, formatter,
@@ -274,6 +302,7 @@ const DOCS: &str = cstr!("\
     <green>External</green>     Leverage existing linters (markdownlint, prettier --check, etc.)
     <green>Regex</green>        Simple patterns you can express in regex
     <green>SyntaxTree</green>   Structural patterns in supported languages
+    <green>RustFunctionalMutation</green>  Rust iterator-style loop rewrites
 
   <dim>Note: External commands add latency. Use sparingly for checks that are</dim>
   <dim>difficult or impossible to express with Regex or SyntaxTree matchers.</dim>
@@ -389,6 +418,28 @@ const DOCS: &str = cstr!("\
           <yellow>content:</yellow>
             <yellow>- kind: External</yellow>
               <yellow>command: [\"npx\", \"markdownlint\", \"--stdin\", \"-c\", \"{\\\"MD060\\\":{\\\"style\\\":\\\"aligned\\\"}}\"]</yellow>
+
+  <cyan>Prefer iterator style for simple Rust mutation loops</cyan>
+
+    <dim># Detects Vec push collection, Option search with break, and fold-like</dim>
+    <dim># accumulator reassignment. The matcher intentionally skips complex loops.</dim>
+
+    <yellow>- name: prefer-functional-mutation</yellow>
+      <yellow>description: Prefer iterator adapters over simple mutable loops</yellow>
+      <yellow>message: \"{{ $suggestion }} Then retry.\"</yellow>
+      <yellow>on:</yellow>
+        <yellow>- hook: PreToolUse</yellow>
+          <yellow>tool: Write</yellow>
+          <yellow>file: \"**/*.rs\"</yellow>
+          <yellow>content:</yellow>
+            <yellow>- kind: RustFunctionalMutation</yellow>
+              <yellow>patterns: [vec_push, find, fold]</yellow>
+        <yellow>- hook: PreToolUse</yellow>
+          <yellow>tool: Edit</yellow>
+          <yellow>file: \"**/*.rs\"</yellow>
+          <yellow>new_content:</yellow>
+            <yellow>- kind: RustFunctionalMutation</yellow>
+              <yellow>patterns: [vec_push, find, fold]</yellow>
 
   <cyan>Redirect docs.rs to local source (WebFetch)</cyan>
 

--- a/packages/nudge/src/rules/schema.rs
+++ b/packages/nudge/src/rules/schema.rs
@@ -18,6 +18,7 @@ pub use url::UrlMatcher;
 mod content;
 mod path;
 mod project_state;
+mod rust_functional_mutation;
 mod syntax;
 mod url;
 

--- a/packages/nudge/src/rules/schema/content.rs
+++ b/packages/nudge/src/rules/schema/content.rs
@@ -14,7 +14,14 @@ use crate::{
     template::{self, Captures},
 };
 
-use super::{Language, TreeSitterQuery, syntax::union_of_captures};
+use super::{
+    Language, TreeSitterQuery,
+    rust_functional_mutation::{
+        RustFunctionalMutationPattern, default_rust_functional_mutation_patterns,
+        rust_functional_mutation_matches,
+    },
+    syntax::union_of_captures,
+};
 
 /// The method used to match hook content.
 ///
@@ -70,6 +77,22 @@ pub enum ContentMatcher {
         /// The command to run, as a list of arguments.
         command: Vec<String>,
     },
+
+    /// Match simple Rust mutation patterns that have clear iterator
+    /// equivalents.
+    ///
+    /// This matcher is intentionally conservative. It only reports adjacent
+    /// `let mut` plus `for` loops with exact loop-body shapes that map cleanly
+    /// to `map`/`filter_map`/`collect`, `find`/`find_map`, or `fold`.
+    RustFunctionalMutation {
+        /// Which mutation patterns to detect. Defaults to all supported
+        /// patterns.
+        patterns: Vec<RustFunctionalMutationPattern>,
+
+        /// Optional suggestion template, same as Regex and SyntaxTree.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        suggestion: Option<String>,
+    },
 }
 
 impl<'de> Deserialize<'de> for ContentMatcher {
@@ -84,6 +107,7 @@ impl<'de> Deserialize<'de> for ContentMatcher {
             language: Option<Language>,
             query: Option<String>,
             command: Option<Vec<String>>,
+            patterns: Option<Vec<RustFunctionalMutationPattern>>,
             suggestion: Option<String>,
             replace: Option<String>,
         }
@@ -121,9 +145,21 @@ impl<'de> Deserialize<'de> for ContentMatcher {
                 }
                 Ok(ContentMatcher::External { command })
             }
+            "RustFunctionalMutation" => {
+                let patterns = raw
+                    .patterns
+                    .unwrap_or_else(default_rust_functional_mutation_patterns);
+                if patterns.is_empty() {
+                    return Err(serde::de::Error::custom("patterns cannot be empty"));
+                }
+                Ok(ContentMatcher::RustFunctionalMutation {
+                    patterns,
+                    suggestion: raw.suggestion,
+                })
+            }
             other => Err(serde::de::Error::unknown_variant(
                 other,
-                &["Regex", "SyntaxTree", "External"],
+                &["Regex", "SyntaxTree", "External", "RustFunctionalMutation"],
             )),
         }
     }
@@ -141,6 +177,12 @@ impl ContentMatcher {
                 .next()
                 .is_some(),
             ContentMatcher::External { command } => run_external_command(command, s).is_some(),
+            ContentMatcher::RustFunctionalMutation { patterns, .. } => {
+                rust_functional_mutation_matches(patterns, s)
+                    .into_iter()
+                    .next()
+                    .is_some()
+            }
         }
     }
 
@@ -160,6 +202,12 @@ impl ContentMatcher {
                 } else {
                     Vec::new()
                 }
+            }
+            ContentMatcher::RustFunctionalMutation { patterns, .. } => {
+                rust_functional_mutation_matches(patterns, s)
+                    .into_iter()
+                    .map(|m| m.span)
+                    .collect()
             }
         }
     }
@@ -195,6 +243,14 @@ impl ContentMatcher {
                 } else {
                     Vec::new()
                 }
+            }
+            ContentMatcher::RustFunctionalMutation {
+                patterns,
+                suggestion,
+            } => {
+                let mut matches = rust_functional_mutation_matches(patterns, s);
+                apply_suggestion(&mut matches, suggestion);
+                matches
             }
         }
     }
@@ -609,5 +665,29 @@ mod tests {
         };
         assert!(!matcher.is_match("haystack with needle inside"));
         assert!(matcher.is_match("haystack without the search term"));
+    }
+
+    #[test]
+    fn test_rust_functional_mutation_deserialize() {
+        let yaml = r#"
+            kind: RustFunctionalMutation
+            patterns: [vec_push, find]
+        "#;
+        let matcher =
+            serde_yaml::from_str::<ContentMatcher>(yaml).expect("valid Rust matcher yaml");
+        assert!(matches!(
+            matcher,
+            ContentMatcher::RustFunctionalMutation { .. }
+        ));
+    }
+
+    #[test]
+    fn test_rust_functional_mutation_deserialize_rejects_empty_patterns() {
+        let yaml = r#"
+            kind: RustFunctionalMutation
+            patterns: []
+        "#;
+        let result = serde_yaml::from_str::<ContentMatcher>(yaml);
+        assert!(result.is_err());
     }
 }

--- a/packages/nudge/src/rules/schema/rust_functional_mutation.rs
+++ b/packages/nudge/src/rules/schema/rust_functional_mutation.rs
@@ -1,0 +1,798 @@
+use serde::{Deserialize, Serialize};
+use tree_sitter::Node;
+
+use crate::{
+    snippet::{Match, Span},
+    template::Captures,
+};
+
+use super::syntax::Language;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RustFunctionalMutationPattern {
+    VecPush,
+    Find,
+    Fold,
+}
+
+pub fn default_rust_functional_mutation_patterns() -> Vec<RustFunctionalMutationPattern> {
+    vec![
+        RustFunctionalMutationPattern::VecPush,
+        RustFunctionalMutationPattern::Find,
+        RustFunctionalMutationPattern::Fold,
+    ]
+}
+
+pub fn rust_functional_mutation_matches(
+    patterns: &[RustFunctionalMutationPattern],
+    source: &str,
+) -> Vec<Match> {
+    let Some(tree) = Language::Rust.parse(source) else {
+        return Vec::new();
+    };
+
+    let mut matches = Vec::new();
+    visit_blocks(tree.root_node(), source, patterns, &mut matches);
+    matches
+}
+
+fn visit_blocks(
+    node: Node<'_>,
+    source: &str,
+    patterns: &[RustFunctionalMutationPattern],
+    matches: &mut Vec<Match>,
+) {
+    if node.kind() == "block" {
+        analyze_block(node, source, patterns, matches);
+    }
+
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        visit_blocks(child, source, patterns, matches);
+    }
+}
+
+fn analyze_block(
+    block: Node<'_>,
+    source: &str,
+    patterns: &[RustFunctionalMutationPattern],
+    matches: &mut Vec<Match>,
+) {
+    let statements = block_statements(block);
+
+    for pair in statements.windows(2) {
+        let Some(binding) = mutable_let(pair[0], source) else {
+            continue;
+        };
+        let Some(for_loop) = for_loop(pair[1], source) else {
+            continue;
+        };
+
+        if has_unsafe_ancestor(binding.0.node) || has_unsafe_ancestor(for_loop.0.node) {
+            continue;
+        }
+
+        if pattern_enabled(patterns, RustFunctionalMutationPattern::VecPush)
+            && let Some(m) = detect_vec_push(&binding, &for_loop, source)
+        {
+            matches.push(m);
+            continue;
+        }
+
+        if pattern_enabled(patterns, RustFunctionalMutationPattern::Find)
+            && let Some(m) = detect_find(&binding, &for_loop, source)
+        {
+            matches.push(m);
+            continue;
+        }
+
+        if pattern_enabled(patterns, RustFunctionalMutationPattern::Fold)
+            && let Some(m) = detect_fold(&binding, &for_loop, source)
+        {
+            matches.push(m);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MutableLet<'tree> {
+    node: Node<'tree>,
+    init: Node<'tree>,
+}
+
+#[derive(Debug, Clone)]
+struct Binding {
+    name: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ForLoop<'tree> {
+    node: Node<'tree>,
+    body: Node<'tree>,
+}
+
+#[derive(Debug, Clone)]
+struct LoopItem {
+    name: String,
+    iter: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PushCall<'tree> {
+    argument: Node<'tree>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Assignment<'tree> {
+    right: Node<'tree>,
+    compound: bool,
+}
+
+fn mutable_let<'tree>(node: Node<'tree>, source: &str) -> Option<(MutableLet<'tree>, Binding)> {
+    if node.kind() != "let_declaration" || !has_direct_child_kind(node, "mutable_specifier") {
+        return None;
+    }
+
+    let pattern = node.child_by_field_name("pattern")?;
+    if pattern.kind() != "identifier" {
+        return None;
+    }
+
+    let init = node.child_by_field_name("value")?;
+    let name = node_text(pattern, source).to_string();
+    Some((MutableLet { node, init }, Binding { name }))
+}
+
+fn for_loop<'tree>(node: Node<'tree>, source: &str) -> Option<(ForLoop<'tree>, LoopItem)> {
+    let node = unwrap_expression_statement(node);
+    if node.kind() != "for_expression" {
+        return None;
+    }
+
+    let pattern = node.child_by_field_name("pattern")?;
+    if pattern.kind() != "identifier" {
+        return None;
+    }
+
+    let value = node.child_by_field_name("value")?;
+    let body = node.child_by_field_name("body")?;
+    Some((
+        ForLoop { node, body },
+        LoopItem {
+            name: node_text(pattern, source).to_string(),
+            iter: node_text(value, source).trim().to_string(),
+        },
+    ))
+}
+
+fn detect_vec_push(
+    (binding, binding_name): &(MutableLet<'_>, Binding),
+    (for_loop, loop_item): &(ForLoop<'_>, LoopItem),
+    source: &str,
+) -> Option<Match> {
+    if !is_empty_vec_init(binding.init, source) {
+        return None;
+    }
+
+    let statements = block_statements(for_loop.body);
+    let [statement] = statements.as_slice() else {
+        return None;
+    };
+
+    if let Some(push) = push_call(*statement, &binding_name.name, source) {
+        if !node_contains_identifier(push.argument, &loop_item.name, source)
+            || contains_awkward_control_flow(push.argument)
+        {
+            return None;
+        }
+
+        return Some(build_match(
+            binding.node,
+            for_loop.node,
+            [
+                ("kind", "vec_push".to_string()),
+                ("binding", binding_name.name.clone()),
+                ("item", loop_item.name.clone()),
+                ("iterator", loop_item.iter.clone()),
+                (
+                    "suggestion",
+                    vec_push_suggestion(binding_name, loop_item, push, source),
+                ),
+            ],
+        ));
+    }
+
+    let if_expression = unwrap_expression_statement(*statement);
+    if if_expression.kind() != "if_expression"
+        || if_expression.child_by_field_name("alternative").is_some()
+    {
+        return None;
+    }
+
+    let condition = if_expression.child_by_field_name("condition")?;
+    let consequence = if_expression.child_by_field_name("consequence")?;
+    let option_expr = option_expr_from_some_let(condition, source)?;
+    if contains_awkward_control_flow(option_expr.value) {
+        return None;
+    }
+
+    let consequence_statements = block_statements(consequence);
+    let [push_statement] = consequence_statements.as_slice() else {
+        return None;
+    };
+    let push = push_call(*push_statement, &binding_name.name, source)?;
+    if node_text(push.argument, source).trim() != option_expr.bound_name {
+        return None;
+    }
+    if !node_contains_identifier(option_expr.value, &loop_item.name, source) {
+        return None;
+    }
+
+    Some(build_match(
+        binding.node,
+        for_loop.node,
+        [
+            ("kind", "vec_filter_map".to_string()),
+            ("binding", binding_name.name.clone()),
+            ("item", loop_item.name.clone()),
+            ("iterator", loop_item.iter.clone()),
+            (
+                "suggestion",
+                filter_map_suggestion(binding_name, loop_item, option_expr.value, source),
+            ),
+        ],
+    ))
+}
+
+fn detect_find(
+    (binding, binding_name): &(MutableLet<'_>, Binding),
+    (for_loop, loop_item): &(ForLoop<'_>, LoopItem),
+    source: &str,
+) -> Option<Match> {
+    if !is_none_init(binding.init, source) {
+        return None;
+    }
+
+    let statements = block_statements(for_loop.body);
+    let [statement] = statements.as_slice() else {
+        return None;
+    };
+
+    let if_expression = unwrap_expression_statement(*statement);
+    if if_expression.kind() != "if_expression"
+        || if_expression.child_by_field_name("alternative").is_some()
+    {
+        return None;
+    }
+
+    let condition = if_expression.child_by_field_name("condition")?;
+    let consequence = if_expression.child_by_field_name("consequence")?;
+    let consequence_statements = block_statements(consequence);
+    let [assignment_statement, break_statement] = consequence_statements.as_slice() else {
+        return None;
+    };
+
+    let assignment = assignment(*assignment_statement, &binding_name.name, source)?;
+    if assignment.compound {
+        return None;
+    }
+
+    let some_arg = some_call_arg(assignment.right, source)?;
+    if !is_plain_break(*break_statement, source) {
+        return None;
+    }
+    if !node_contains_identifier(condition, &loop_item.name, source)
+        && !node_contains_identifier(some_arg, &loop_item.name, source)
+    {
+        return None;
+    }
+
+    let kind = if node_text(some_arg, source).trim() == loop_item.name {
+        "find"
+    } else {
+        "find_map"
+    };
+
+    Some(build_match(
+        binding.node,
+        for_loop.node,
+        [
+            ("kind", kind.to_string()),
+            ("binding", binding_name.name.clone()),
+            ("item", loop_item.name.clone()),
+            ("iterator", loop_item.iter.clone()),
+            (
+                "suggestion",
+                find_suggestion(binding_name, loop_item, some_arg, source),
+            ),
+        ],
+    ))
+}
+
+fn detect_fold(
+    (binding, binding_name): &(MutableLet<'_>, Binding),
+    (for_loop, loop_item): &(ForLoop<'_>, LoopItem),
+    source: &str,
+) -> Option<Match> {
+    let statements = block_statements(for_loop.body);
+    let [statement] = statements.as_slice() else {
+        return None;
+    };
+
+    let assignment = assignment(*statement, &binding_name.name, source)?;
+    if contains_awkward_control_flow(assignment.right)
+        || node_contains_kind(assignment.right, "macro_invocation")
+    {
+        return None;
+    }
+
+    let carries_accumulator = assignment.compound
+        || node_contains_identifier(assignment.right, &binding_name.name, source);
+    if !carries_accumulator || !node_contains_identifier(assignment.right, &loop_item.name, source)
+    {
+        return None;
+    }
+
+    Some(build_match(
+        binding.node,
+        for_loop.node,
+        [
+            ("kind", "fold".to_string()),
+            ("binding", binding_name.name.clone()),
+            ("item", loop_item.name.clone()),
+            ("iterator", loop_item.iter.clone()),
+            ("init", node_text(binding.init, source).trim().to_string()),
+            (
+                "suggestion",
+                fold_suggestion(binding, binding_name, loop_item, source),
+            ),
+        ],
+    ))
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SomeLet<'tree> {
+    bound_name: &'tree str,
+    value: Node<'tree>,
+}
+
+fn option_expr_from_some_let<'tree>(
+    condition: Node<'tree>,
+    source: &'tree str,
+) -> Option<SomeLet<'tree>> {
+    if condition.kind() != "let_condition" {
+        return None;
+    }
+
+    let pattern = condition.child_by_field_name("pattern")?;
+    let value = condition.child_by_field_name("value")?;
+    if pattern.kind() != "tuple_struct_pattern" {
+        return None;
+    }
+
+    let type_node = pattern.child_by_field_name("type")?;
+    if node_text(type_node, source) != "Some" {
+        return None;
+    }
+
+    let identifiers = named_children(pattern)
+        .into_iter()
+        .filter(|child| child.kind() == "identifier")
+        .filter(|child| node_text(*child, source) != "Some")
+        .collect::<Vec<_>>();
+    let [bound] = identifiers.as_slice() else {
+        return None;
+    };
+
+    Some(SomeLet {
+        bound_name: node_text(*bound, source),
+        value,
+    })
+}
+
+fn push_call<'tree>(
+    statement: Node<'tree>,
+    binding_name: &str,
+    source: &str,
+) -> Option<PushCall<'tree>> {
+    let call = unwrap_expression_statement(statement);
+    if call.kind() != "call_expression" {
+        return None;
+    }
+
+    let function = call.child_by_field_name("function")?;
+    if function.kind() != "field_expression" {
+        return None;
+    }
+
+    let receiver = function.child_by_field_name("value")?;
+    let field = function.child_by_field_name("field")?;
+    if receiver.kind() != "identifier"
+        || node_text(receiver, source) != binding_name
+        || node_text(field, source) != "push"
+    {
+        return None;
+    }
+
+    let arguments = call.child_by_field_name("arguments")?;
+    let args = named_children(arguments);
+    let [argument] = args.as_slice() else {
+        return None;
+    };
+
+    Some(PushCall {
+        argument: *argument,
+    })
+}
+
+fn assignment<'tree>(
+    statement: Node<'tree>,
+    binding_name: &str,
+    source: &str,
+) -> Option<Assignment<'tree>> {
+    let expression = unwrap_expression_statement(statement);
+    if expression.kind() != "assignment_expression"
+        && expression.kind() != "compound_assignment_expr"
+    {
+        return None;
+    }
+
+    let left = expression.child_by_field_name("left")?;
+    if left.kind() != "identifier" || node_text(left, source) != binding_name {
+        return None;
+    }
+
+    let right = expression.child_by_field_name("right")?;
+    Some(Assignment {
+        right,
+        compound: expression.kind() == "compound_assignment_expr",
+    })
+}
+
+fn some_call_arg<'tree>(node: Node<'tree>, source: &str) -> Option<Node<'tree>> {
+    if node.kind() != "call_expression" {
+        return None;
+    }
+
+    let function = node.child_by_field_name("function")?;
+    if function.kind() != "identifier" || node_text(function, source) != "Some" {
+        return None;
+    }
+
+    let arguments = node.child_by_field_name("arguments")?;
+    let args = named_children(arguments);
+    let [arg] = args.as_slice() else {
+        return None;
+    };
+
+    Some(*arg)
+}
+
+fn is_plain_break(statement: Node<'_>, source: &str) -> bool {
+    let expression = unwrap_expression_statement(statement);
+    expression.kind() == "break_expression" && node_text(expression, source).trim() == "break"
+}
+
+fn is_empty_vec_init(node: Node<'_>, source: &str) -> bool {
+    if node.kind() == "macro_invocation" {
+        let macro_name = node.child_by_field_name("macro");
+        let token_tree = named_children(node)
+            .into_iter()
+            .find(|child| child.kind() == "token_tree");
+        return macro_name
+            .map(|macro_name| node_text(macro_name, source) == "vec")
+            .unwrap_or(false)
+            && token_tree
+                .map(|token_tree| node_text(token_tree, source).trim() == "[]")
+                .unwrap_or(false);
+    }
+
+    if node.kind() != "call_expression" {
+        return false;
+    }
+
+    let Some(arguments) = node.child_by_field_name("arguments") else {
+        return false;
+    };
+    if !named_children(arguments).is_empty() {
+        return false;
+    }
+
+    let Some(function) = node.child_by_field_name("function") else {
+        return false;
+    };
+    if function.kind() != "scoped_identifier" {
+        return false;
+    }
+
+    let Some(name) = function.child_by_field_name("name") else {
+        return false;
+    };
+    if node_text(name, source) != "new" {
+        return false;
+    }
+
+    let Some(path) = function.child_by_field_name("path") else {
+        return false;
+    };
+    type_path_ends_with_vec(path, source)
+}
+
+fn type_path_ends_with_vec(node: Node<'_>, source: &str) -> bool {
+    match node.kind() {
+        "identifier" | "type_identifier" => node_text(node, source) == "Vec",
+        "generic_type" => node
+            .child_by_field_name("type")
+            .map(|node| type_path_ends_with_vec(node, source))
+            .unwrap_or(false),
+        "scoped_identifier" | "scoped_type_identifier" => node
+            .child_by_field_name("name")
+            .map(|node| type_path_ends_with_vec(node, source))
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
+fn is_none_init(node: Node<'_>, source: &str) -> bool {
+    match node.kind() {
+        "identifier" => node_text(node, source) == "None",
+        "scoped_identifier" => node
+            .child_by_field_name("name")
+            .map(|name| node_text(name, source) == "None")
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
+fn block_statements(block: Node<'_>) -> Vec<Node<'_>> {
+    named_children(block)
+        .into_iter()
+        .filter(|node| !matches!(node.kind(), "line_comment" | "block_comment"))
+        .collect()
+}
+
+fn named_children(node: Node<'_>) -> Vec<Node<'_>> {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor).collect()
+}
+
+fn unwrap_expression_statement(node: Node<'_>) -> Node<'_> {
+    if node.kind() != "expression_statement" {
+        return node;
+    }
+
+    let children = named_children(node);
+    let [child] = children.as_slice() else {
+        return node;
+    };
+    *child
+}
+
+fn has_direct_child_kind(node: Node<'_>, kind: &str) -> bool {
+    let mut cursor = node.walk();
+    node.children(&mut cursor).any(|child| child.kind() == kind)
+}
+
+fn has_unsafe_ancestor(node: Node<'_>) -> bool {
+    let mut current = Some(node);
+    while let Some(node) = current {
+        if node.kind() == "unsafe_block" {
+            return true;
+        }
+        current = node.parent();
+    }
+    false
+}
+
+fn contains_awkward_control_flow(node: Node<'_>) -> bool {
+    [
+        "await_expression",
+        "break_expression",
+        "continue_expression",
+        "return_expression",
+        "try_expression",
+        "unsafe_block",
+    ]
+    .into_iter()
+    .any(|kind| node_contains_kind(node, kind))
+}
+
+fn node_contains_kind(node: Node<'_>, kind: &str) -> bool {
+    if node.kind() == kind {
+        return true;
+    }
+
+    named_children(node)
+        .into_iter()
+        .any(|child| node_contains_kind(child, kind))
+}
+
+fn node_contains_identifier(node: Node<'_>, name: &str, source: &str) -> bool {
+    if node.kind() == "identifier" && node_text(node, source) == name {
+        return true;
+    }
+
+    named_children(node)
+        .into_iter()
+        .any(|child| node_contains_identifier(child, name, source))
+}
+
+fn pattern_enabled(
+    patterns: &[RustFunctionalMutationPattern],
+    pattern: RustFunctionalMutationPattern,
+) -> bool {
+    patterns.contains(&pattern)
+}
+
+fn build_match(
+    start_node: Node<'_>,
+    end_node: Node<'_>,
+    captures: impl IntoIterator<Item = (&'static str, String)>,
+) -> Match {
+    Match {
+        span: Span::from(start_node.start_byte()..end_node.end_byte()),
+        captures: Captures::from_iter(
+            captures
+                .into_iter()
+                .map(|(key, value)| (key.to_string(), value)),
+        ),
+    }
+}
+
+fn vec_push_suggestion(
+    binding: &Binding,
+    loop_item: &LoopItem,
+    push: PushCall<'_>,
+    source: &str,
+) -> String {
+    let iter = iterator_chain(&loop_item.iter);
+    let argument = node_text(push.argument, source).trim();
+    let replacement = if argument == loop_item.name {
+        format!("let {} = {}.collect::<Vec<_>>();", binding.name, iter)
+    } else {
+        format!(
+            "let {} = {}.map(|{}| {}).collect::<Vec<_>>();",
+            binding.name, iter, loop_item.name, argument
+        )
+    };
+
+    format!(
+        "Build `{}` with iterator adapters instead of `let mut` plus `push`: `{}`",
+        binding.name, replacement
+    )
+}
+
+fn filter_map_suggestion(
+    binding: &Binding,
+    loop_item: &LoopItem,
+    option_expr: Node<'_>,
+    source: &str,
+) -> String {
+    let iter = iterator_chain(&loop_item.iter);
+    let option_expr = node_text(option_expr, source).trim();
+    let replacement = format!(
+        "let {} = {}.filter_map(|{}| {}).collect::<Vec<_>>();",
+        binding.name, iter, loop_item.name, option_expr
+    );
+
+    format!(
+        "Use `filter_map` and collect directly instead of mutating `{}`: `{}`",
+        binding.name, replacement
+    )
+}
+
+fn find_suggestion(
+    binding: &Binding,
+    loop_item: &LoopItem,
+    some_arg: Node<'_>,
+    source: &str,
+) -> String {
+    let iter = iterator_chain(&loop_item.iter);
+    let arg = node_text(some_arg, source).trim();
+    if arg == loop_item.name {
+        format!(
+            "Use `{iter}.find(|{}| ...)` to produce `{}` without `mut` and `break`.",
+            loop_item.name, binding.name
+        )
+    } else {
+        format!(
+            "Use `{iter}.find_map(|{}| ...)` to produce `{}` without `mut` and `break`.",
+            loop_item.name, binding.name
+        )
+    }
+}
+
+fn fold_suggestion(
+    binding: &MutableLet<'_>,
+    binding_name: &Binding,
+    loop_item: &LoopItem,
+    source: &str,
+) -> String {
+    let iter = iterator_chain(&loop_item.iter);
+    let init = node_text(binding.init, source).trim();
+    format!(
+        "Use `{iter}.fold({init}, |{}, {}| ...)` instead of reassigning `{}` inside the loop.",
+        binding_name.name, loop_item.name, binding_name.name
+    )
+}
+
+fn iterator_chain(iterable: &str) -> String {
+    let iterable = iterable.trim();
+    if iterable.ends_with(".iter()")
+        || iterable.ends_with(".iter_mut()")
+        || iterable.ends_with(".into_iter()")
+    {
+        iterable.to_string()
+    } else {
+        format!("{iterable}.into_iter()")
+    }
+}
+
+fn node_text<'source>(node: Node<'_>, source: &'source str) -> &'source str {
+    node.utf8_text(source.as_bytes()).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq as pretty_assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn detects_all_supported_patterns() {
+        let source = r#"
+fn f(items: Vec<Item>) -> Vec<Value> {
+    let mut values = Vec::new();
+    for item in items {
+        values.push(process(item));
+    }
+
+    let mut found = None;
+    for item in more_items {
+        if item.ready() {
+            found = Some(item);
+            break;
+        }
+    }
+
+    let mut total = 0;
+    for value in values {
+        total = combine(total, value);
+    }
+
+    values
+}
+"#;
+
+        let matches =
+            rust_functional_mutation_matches(&default_rust_functional_mutation_patterns(), source);
+
+        pretty_assert_eq!(matches.len(), 3);
+        pretty_assert_eq!(
+            matches[0].captures.get("kind"),
+            Some(&"vec_push".to_string())
+        );
+        pretty_assert_eq!(matches[1].captures.get("kind"), Some(&"find".to_string()));
+        pretty_assert_eq!(matches[2].captures.get("kind"), Some(&"fold".to_string()));
+    }
+
+    #[test]
+    fn skips_side_effectful_collection_loop() {
+        let source = r#"
+fn f(items: Vec<Item>) -> Vec<Value> {
+    let mut values = Vec::new();
+    for item in items {
+        metrics.count_item();
+        values.push(process(item));
+    }
+    values
+}
+"#;
+
+        let matches =
+            rust_functional_mutation_matches(&default_rust_functional_mutation_patterns(), source);
+
+        assert!(matches.is_empty());
+    }
+}

--- a/packages/nudge/tests/it/main.rs
+++ b/packages/nudge/tests/it/main.rs
@@ -15,6 +15,7 @@ mod inline_imports;
 mod message_content;
 mod multiple_rules;
 mod non_rust_files;
+mod rust_functional_mutation;
 mod setup;
 mod syntax_tree;
 mod user_prompt;

--- a/packages/nudge/tests/it/rust_functional_mutation.rs
+++ b/packages/nudge/tests/it/rust_functional_mutation.rs
@@ -1,0 +1,308 @@
+//! Integration tests for RustFunctionalMutation matcher.
+//!
+//! These tests exercise the full hook path for the Rust-specific matcher that
+//! catches simple mutation-heavy loops with clear iterator equivalents.
+
+use std::fs;
+use std::io::Write as _;
+use std::process::{Command, Stdio};
+
+use pretty_assertions::assert_eq as pretty_assert_eq;
+use tempfile::TempDir;
+
+use crate::nudge_binary;
+
+fn setup_config() -> TempDir {
+    let dir = TempDir::new().expect("create temp dir");
+    let config_path = dir.path().join(".nudge.yaml");
+    fs::write(
+        &config_path,
+        r#"
+version: 1
+rules:
+  - name: prefer-functional-mutation
+    description: Prefer iterator adapters over simple mutable loop accumulation
+    message: "{{ $suggestion }}"
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.rs"
+        content:
+          - kind: RustFunctionalMutation
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.rs"
+        new_content:
+          - kind: RustFunctionalMutation
+"#,
+    )
+    .expect("write config");
+    dir
+}
+
+fn run_hook_in_dir(dir: &TempDir, input: &str) -> (i32, String) {
+    let mut child = Command::new(nudge_binary())
+        .args(["claude", "hook"])
+        .current_dir(dir.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn nudge");
+
+    {
+        let stdin = child.stdin.as_mut().expect("failed to get stdin");
+        stdin
+            .write_all(input.as_bytes())
+            .expect("failed to write to stdin");
+    }
+
+    let output = child.wait_with_output().expect("failed to wait for nudge");
+
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    let combined = if !stdout.trim().is_empty() {
+        stdout.trim().to_string()
+    } else {
+        stderr.trim().to_string()
+    };
+
+    (exit_code, combined)
+}
+
+fn write_hook(file_path: &str, content: &str) -> String {
+    serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "test",
+        "transcript_path": "/tmp/test",
+        "permission_mode": "default",
+        "cwd": "/tmp",
+        "tool_name": "Write",
+        "tool_use_id": "123",
+        "tool_input": {
+            "file_path": file_path,
+            "content": content
+        }
+    })
+    .to_string()
+}
+
+#[track_caller]
+fn assert_interrupt(output: &str) {
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected interrupt, got: {output}"
+    );
+}
+
+#[track_caller]
+fn assert_passthrough(output: &str) {
+    assert!(
+        output.is_empty(),
+        "expected passthrough with no output, got: {output}"
+    );
+}
+
+#[test]
+fn detects_vec_push_collection_loop() {
+    let dir = setup_config();
+    let input = write_hook(
+        "test.rs",
+        r#"
+fn build(items: Vec<Item>) -> Vec<Value> {
+    let mut results = Vec::new();
+    for item in items {
+        results.push(process(item));
+    }
+    results
+}
+"#,
+    );
+
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected hook success, output: {output}");
+    assert_interrupt(&output);
+    assert!(
+        output.contains("map") && output.contains("collect::<Vec<_>>()"),
+        "expected map/collect suggestion, got: {output}"
+    );
+}
+
+#[test]
+fn detects_filter_map_loop() {
+    let dir = setup_config();
+    let input = write_hook(
+        "test.rs",
+        r#"
+fn build(items: Vec<Item>) -> Vec<Value> {
+    let mut results = Vec::new();
+    for item in items {
+        if let Some(value) = process(item) {
+            results.push(value);
+        }
+    }
+    results
+}
+"#,
+    );
+
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected hook success, output: {output}");
+    assert_interrupt(&output);
+    assert!(
+        output.contains("filter_map") && output.contains("collect::<Vec<_>>()"),
+        "expected filter_map suggestion, got: {output}"
+    );
+}
+
+#[test]
+fn detects_find_loop() {
+    let dir = setup_config();
+    let input = write_hook(
+        "test.rs",
+        r#"
+fn find_match(items: Vec<Item>) -> Option<Item> {
+    let mut found = None;
+    for item in items {
+        if item.is_ready() {
+            found = Some(item);
+            break;
+        }
+    }
+    found
+}
+"#,
+    );
+
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected hook success, output: {output}");
+    assert_interrupt(&output);
+    assert!(
+        output.contains("find") || output.contains("find_map"),
+        "expected find suggestion, got: {output}"
+    );
+}
+
+#[test]
+fn detects_fold_loop() {
+    let dir = setup_config();
+    let input = write_hook(
+        "test.rs",
+        r#"
+fn sum(items: Vec<i64>) -> i64 {
+    let mut total = 0;
+    for item in items {
+        total = combine(total, item);
+    }
+    total
+}
+"#,
+    );
+
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected hook success, output: {output}");
+    assert_interrupt(&output);
+    assert!(
+        output.contains("fold"),
+        "expected fold suggestion, got: {output}"
+    );
+}
+
+#[test]
+fn skips_vec_with_capacity_for_performance_sensitive_collection() {
+    let dir = setup_config();
+    let input = write_hook(
+        "test.rs",
+        r#"
+fn build(items: &[Item]) -> Vec<Value> {
+    let mut results = Vec::with_capacity(items.len());
+    for item in items {
+        results.push(process(item));
+    }
+    results
+}
+"#,
+    );
+
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected hook success, output: {output}");
+    assert_passthrough(&output);
+}
+
+#[test]
+fn skips_loops_with_extra_side_effects() {
+    let dir = setup_config();
+    let input = write_hook(
+        "test.rs",
+        r#"
+fn build(items: Vec<Item>) -> Vec<Value> {
+    let mut results = Vec::new();
+    for item in items {
+        metrics.count_item();
+        results.push(process(item));
+    }
+    results
+}
+"#,
+    );
+
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected hook success, output: {output}");
+    assert_passthrough(&output);
+}
+
+#[test]
+fn skips_io_style_mutation() {
+    let dir = setup_config();
+    let input = write_hook(
+        "test.rs",
+        r#"
+use std::io::{Result, Write};
+
+fn write_all(items: Vec<Item>) -> Result<Vec<u8>> {
+    let mut writer = Vec::new();
+    for item in items {
+        writeln!(writer, "{}", item)?;
+    }
+    Ok(writer)
+}
+"#,
+    );
+
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected hook success, output: {output}");
+    assert_passthrough(&output);
+}
+
+#[test]
+fn skips_unsafe_or_ffi_contexts() {
+    let dir = setup_config();
+    let input = write_hook(
+        "test.rs",
+        r#"
+fn collect_raw(items: Vec<Item>) -> Vec<Value> {
+    unsafe {
+        let mut results = Vec::new();
+        for item in items {
+            results.push(from_raw(item));
+        }
+        results
+    }
+}
+"#,
+    );
+
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected hook success, output: {output}");
+    assert_passthrough(&output);
+}


### PR DESCRIPTION
## Why this change

Issue #2 asks whether Nudge can enforce the simple, high-confidence cases where Rust loop mutation should be written as iterator-style code. Regex or raw tree-sitter queries are too brittle for this because the useful behavior depends on the relationship between an adjacent `let mut`, a `for` loop, and the loop body.

This PR adds a first-class `RustFunctionalMutation` content matcher. It detects conservative forms of:

- `let mut values = Vec::new(); for item in items { values.push(...) }` as `map`/`filter_map` plus `collect::<Vec<_>>()`
- `let mut found = None; ... found = Some(item); break;` as `find`/`find_map`
- `let mut total = init; for item in items { total = combine(total, item); }` as `fold`

The matcher parses Rust with tree-sitter and deliberately skips noisy cases: unsafe contexts, complex loop bodies, loops with extra side effects, `Vec::with_capacity(...)`, non-simple loop patterns, and control-flow-heavy expressions such as `?`, `return`, `break`, or `await`. Matches include captures such as `{{ $suggestion }}`, `{{ $kind }}`, `{{ $binding }}`, `{{ $item }}`, and `{{ $iterator }}` so rule messages can be direct and useful.

The PR also dogfoods the new matcher in `.nudge.yaml`, documents it in the README and `nudge docs`, and adds end-to-end hook tests with positive and negative cases.

Resolves #2.

## Testing steps performed

```text
cargo test -p nudge rust_functional_mutation -- --nocapture
...
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 64 filtered out; finished in 0.00s
...
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 72 filtered out; finished in 0.01s
```

```text
cargo run -q -p nudge -- validate .nudge.yaml
# Printed parsed rules including prefer-functional-mutation with RustFunctionalMutation patterns vec_push, find, fold.
```

```text
cargo run -q -p nudge -- check packages/nudge/src/rules/schema/rust_functional_mutation.rs packages/nudge/src/rules/schema/content.rs packages/nudge/tests/it/rust_functional_mutation.rs
✓ Checked 3 files against 7 rules
  - .nudge.yaml: 7 rules
```

```text
git diff --check
# no output
```

```text
cargo clippy -p nudge --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.65s
```

```text
cargo test -p nudge
...
test result: ok. 68 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
...
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
...
test result: ok. 80 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.81s
...
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

## Configuration changes after merge

Nudge's own `.nudge.yaml` now includes `prefer-functional-mutation` for Rust Write/Edit hooks. No migration is required for existing user configs; `RustFunctionalMutation` is an additive matcher. Projects can opt in with `kind: RustFunctionalMutation` and optionally narrow `patterns: [vec_push, find, fold]`.