### PR TITLE
[codex] Resolve issue 6 with semantic prompt reminders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ nudge check         - Check project files against rules (CI/linter mode)
 - `src/hook/evaluate.rs` - Provider-neutral rule evaluation
 - `src/hook/response.rs` - Provider-specific response rendering
 - `src/hook/apply_patch.rs` - Codex apply_patch normalization
+- `src/hook/state.rs` - Local opt-in interaction state for context-aware prompt reminders
 - `src/cmd/claude/hook.rs` - Hook command: deserializes input, evaluates rules, emits response
 - `src/cmd/claude/setup.rs` - Setup command: configures hooks in settings.local.json
 - `src/cmd/claude/docs.rs` - Docs command: prints rule writing guide
@@ -79,6 +80,7 @@ nudge check         - Check project files against rules (CI/linter mode)
 - `src/rules.rs` - Rule loading from config files
 - `src/rules/schema.rs` - Rule schema facade and hook matcher types
 - `src/rules/schema/` - Focused matcher implementations for content, glob paths, project state, tree-sitter syntax, and URLs
+- `src/rules/schema/prompt.rs` - UserPromptSubmit intent, cooldown, and file-change gate schema helpers
 - `src/snippet.rs` - Code snippet rendering for rule violations (uses `annotate-snippets`)
 
 ### How Nudge Communicates

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ When something matches a rule you've defined:
 
 - **Interrupt** (PreToolUse rules): Nudge catches the issue *before* it's written and explains what to fix
 - **Substitute** (PreToolUse Bash rules): Nudge rewrites simple deterministic commands, lets the tool proceed, and tells the model what changed
-- **Continue** (UserPromptSubmit rules): Nudge injects context into the conversation to guide the agent
+- **Continue** (UserPromptSubmit rules): Nudge injects context into the conversation to guide the agent, including semantic prompt reminders after relevant local file changes
 - **Passthrough**: No rules matched, everything proceeds normally
 
 ## Example Rules
@@ -89,6 +89,30 @@ rules:
 ```
 
 Substitutions work for Claude Code and Codex CLI. Nudge returns the provider's full updated tool input with only `command` changed, and adds `hookSpecificOutput.additionalContext` so the model sees what was rewritten.
+
+For context that should appear only after a project-specific workflow, use a stateful `UserPromptSubmit` matcher. This example reminds the agent how to test local Hurry changes after source files were touched, while avoiding unrelated "run the tests" prompts:
+
+```yaml
+version: 1
+rules:
+  - name: hurry-local-test-reminder
+    description: Use dev entrypoints when testing Hurry changes
+    message: "Use `hurry-dev` after `make install-dev`."
+    on:
+      - hook: UserPromptSubmit
+        intent:
+          examples:
+            - "let's test this"
+            - "try running it"
+            - "does this work"
+        after_file_change:
+          - file: "packages/hurry/src/**"
+            within: "1h"
+        once_per_change: true
+        cooldown: "1h"
+```
+
+`intent.examples` are matched locally with deterministic token normalization. Nudge does not call an LLM or make network requests. `after_file_change` is opt-in: Nudge stores only matching file paths, timestamps, and reminder frequency state in a local JSON file. It does not store prompt text. Set `NUDGE_STATE_DIR` to override the storage directory, or delete the state file from Nudge's local data directory to clear it.
 
 For the full rule syntax and copy-pasteable examples, run `nudge claude docs` or `nudge codex docs`.
 
@@ -207,6 +231,10 @@ You can test a specific rule with the `test` subcommand:
 ```bash
 nudge test --rule no-inline-imports --tool Write --file test.rs \
   --content $'fn main() {\n    use std::io;\n}'
+
+nudge test --rule hurry-local-test-reminder \
+  --changed-file packages/hurry/src/daemon.rs \
+  --prompt "try executing it"
 ```
 
 Or pipe raw hook JSON to nudge directly:

--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -66,6 +66,19 @@ const DOCS: &str = cstr!("\
               <yellow>pattern: \"your-regex\"</yellow>
               <yellow>suggestion: \"optional\"</yellow>
 
+        <yellow>- hook: UserPromptSubmit</yellow>    <dim># Inject context after matching user prompts</dim>
+          <yellow>prompt:</yellow>                   <dim># Optional regex patterns</dim>
+            <yellow>- kind: Regex</yellow>
+              <yellow>pattern: \"your-regex\"</yellow>
+          <yellow>intent:</yellow>                   <dim># Optional local semantic matcher</dim>
+            <yellow>examples: [\"try running it\", \"does this work\"]</yellow>
+            <yellow>threshold: 0.60</yellow>
+          <yellow>after_file_change:</yellow>        <dim># Optional local state gate</dim>
+            <yellow>- file: \"src/**\"</yellow>
+              <yellow>within: \"1h\"</yellow>
+          <yellow>once_per_change: true</yellow>     <dim># Optional frequency control</dim>
+          <yellow>cooldown: \"1h\"</yellow>
+
 <bold>Hook Types</bold>
 
   <green>PreToolUse</green>        Triggers before provider-supported Write/Edit/WebFetch/Bash
@@ -73,7 +86,9 @@ const DOCS: &str = cstr!("\
                     rewrite the command and allow it to proceed.
 
   <green>UserPromptSubmit</green>  Triggers when user submits a prompt. Always <cyan>continues</cyan>
-                    (injects context into the conversation).
+                    (injects context into the conversation). Supports regex
+                    prompt matching, local example-based intent matching, and
+                    opt-in local file-change gates.
 
 <bold>Tool Types (PreToolUse only)</bold>
 
@@ -174,6 +189,42 @@ const DOCS: &str = cstr!("\
   <dim>CI note: nudge check ignores substitute rules. Check mode scans repository</dim>
   <dim>files against file-based block rules; substitutions need a live Bash hook</dim>
   <dim>payload and a provider that can receive updatedInput.</dim>
+
+<bold>Prompt Intent and Local Interaction State</bold>
+
+  UserPromptSubmit rules can combine regex prompt matching with <cyan>intent:</cyan>,
+  <cyan>after_file_change:</cyan>, <cyan>once_per_change:</cyan>, and <cyan>cooldown:</cyan>.
+  This is useful for project workflow reminders that should fire after relevant
+  edits, such as \"try running it\" after changing a local daemon.
+
+  <white>Basic Syntax:</white>
+    <yellow>- name: hurry-local-test-reminder</yellow>
+      <yellow>description: Use dev entrypoints when testing Hurry changes</yellow>
+      <yellow>message: \"Use `hurry-dev` after `make install-dev`.\"</yellow>
+      <yellow>on:</yellow>
+        <yellow>- hook: UserPromptSubmit</yellow>
+          <yellow>intent:</yellow>
+            <yellow>examples:</yellow>
+              <yellow>- \"let's test this\"</yellow>
+              <yellow>- \"try running it\"</yellow>
+              <yellow>- \"does this work\"</yellow>
+          <yellow>after_file_change:</yellow>
+            <yellow>- file: \"packages/hurry/src/**\"</yellow>
+              <yellow>within: \"1h\"</yellow>
+          <yellow>once_per_change: true</yellow>
+          <yellow>cooldown: \"1h\"</yellow>
+
+  <white>How It Works:</white>
+    1. <cyan>intent.examples</cyan> are matched with deterministic local token normalization.
+    2. <cyan>after_file_change</cyan> records only matching file paths and timestamps.
+    3. <cyan>once_per_change</cyan> suppresses repeats until another matching file changes.
+    4. <cyan>cooldown</cyan> suppresses reminders until it elapses; a newer
+       matching file change is allowed when <cyan>once_per_change</cyan> is true.
+
+  <white>Privacy:</white>
+    Nudge does not store prompt text and does not call an LLM or make network
+    requests. Stateful prompt rules are opt-in. State is a local JSON file in
+    Nudge's local data directory; set <cyan>NUDGE_STATE_DIR</cyan> to override it.
 
 <bold>How Messages Are Displayed</bold>
 
@@ -336,6 +387,24 @@ const DOCS: &str = cstr!("\
             <yellow>- kind: Regex</yellow>
               <yellow>pattern: \"(?i)start.*(server|dev)|run.*local\"</yellow>
 
+  <cyan>Inject workflow context after relevant edits (UserPromptSubmit)</cyan>
+
+    <yellow>- name: hurry-local-test-reminder</yellow>
+      <yellow>description: Use dev entrypoints when testing Hurry changes</yellow>
+      <yellow>message: \"Use `hurry-dev` after `make install-dev`.\"</yellow>
+      <yellow>on:</yellow>
+        <yellow>- hook: UserPromptSubmit</yellow>
+          <yellow>intent:</yellow>
+            <yellow>examples:</yellow>
+              <yellow>- \"let's test this\"</yellow>
+              <yellow>- \"try running it\"</yellow>
+              <yellow>- \"does this work\"</yellow>
+          <yellow>after_file_change:</yellow>
+            <yellow>- file: \"packages/hurry/src/**\"</yellow>
+              <yellow>within: \"1h\"</yellow>
+          <yellow>once_per_change: true</yellow>
+          <yellow>cooldown: \"1h\"</yellow>
+
   <cyan>Suggest .expect() instead of .unwrap() (with suggestions)</cyan>
 
     <yellow>- name: no-unwrap</yellow>
@@ -462,6 +531,9 @@ const DOCS: &str = cstr!("\
 
   Test a specific rule <dim>(run with `--help` for options)</dim>
   <cyan>nudge test</cyan>
+
+  Simulate a prior file change for stateful UserPromptSubmit rules
+  <cyan>nudge test --rule hurry-local-test-reminder --changed-file packages/hurry/src/daemon.rs --prompt \"try executing it\"</cyan>
 
 <bold>Rule Writing is Iterative</bold>
 

--- a/packages/nudge/src/cmd/claude/hook.rs
+++ b/packages/nudge/src/cmd/claude/hook.rs
@@ -6,7 +6,11 @@ use clap::Args;
 use color_eyre::{Result, eyre::Context};
 use nudge::{
     agent::{AgentKind, claude},
-    hook::{evaluate::evaluate_hooks, response},
+    hook::{
+        evaluate::{evaluate_hooks, evaluate_hooks_with_state},
+        response,
+        state::{InteractionState, rules_need_interaction_state},
+    },
     rules,
 };
 use tracing::instrument;
@@ -21,5 +25,14 @@ pub fn main(_config: Config) -> Result<()> {
     let hooks = claude::parse_hook(raw).context("parse Claude hook event")?;
 
     let rules = rules::load_all().context("load rules")?;
-    response::emit(AgentKind::Claude, evaluate_hooks(&hooks, &rules))
+    let outcome = if rules_need_interaction_state(&rules) {
+        let mut state = InteractionState::load().context("load interaction state")?;
+        let outcome = evaluate_hooks_with_state(&hooks, &rules, &mut state);
+        state.save().context("save interaction state")?;
+        outcome
+    } else {
+        evaluate_hooks(&hooks, &rules)
+    };
+
+    response::emit(AgentKind::Claude, outcome)
 }

--- a/packages/nudge/src/cmd/codex/hook.rs
+++ b/packages/nudge/src/cmd/codex/hook.rs
@@ -6,7 +6,11 @@ use clap::Args;
 use color_eyre::{Result, eyre::Context};
 use nudge::{
     agent::{AgentKind, codex},
-    hook::{evaluate::evaluate_hooks, response},
+    hook::{
+        evaluate::{evaluate_hooks, evaluate_hooks_with_state},
+        response,
+        state::{InteractionState, rules_need_interaction_state},
+    },
     rules,
 };
 use tracing::instrument;
@@ -21,5 +25,14 @@ pub fn main(_config: Config) -> Result<()> {
     let hooks = codex::parse_hook(raw).context("parse Codex hook event")?;
 
     let rules = rules::load_all().context("load rules")?;
-    response::emit(AgentKind::Codex, evaluate_hooks(&hooks, &rules))
+    let outcome = if rules_need_interaction_state(&rules) {
+        let mut state = InteractionState::load().context("load interaction state")?;
+        let outcome = evaluate_hooks_with_state(&hooks, &rules, &mut state);
+        state.save().context("save interaction state")?;
+        outcome
+    } else {
+        evaluate_hooks(&hooks, &rules)
+    };
+
+    response::emit(AgentKind::Codex, outcome)
 }

--- a/packages/nudge/src/cmd/test.rs
+++ b/packages/nudge/src/cmd/test.rs
@@ -1,7 +1,7 @@
 //! Test rules against sample input.
 
-use std::fs;
 use std::path::PathBuf;
+use std::{env, fs};
 
 use clap::Args;
 use color_eyre::eyre::{Context, Result, bail, eyre};
@@ -9,7 +9,12 @@ use serde_json::json;
 
 use nudge::{
     agent::claude,
-    hook::{NudgeHook, evaluate::evaluate_hooks, response::HookOutcome},
+    hook::{
+        NudgeHook,
+        evaluate::{evaluate_hooks, evaluate_hooks_with_state},
+        response::HookOutcome,
+        state::{InteractionState, now_seconds},
+    },
     rules,
 };
 
@@ -42,6 +47,10 @@ pub struct Config {
     /// User prompt to test against (for UserPromptSubmit rules).
     #[arg(long)]
     pub prompt: Option<String>,
+
+    /// Simulate a prior file change before testing a UserPromptSubmit rule.
+    #[arg(long, requires = "prompt")]
+    pub changed_file: Vec<PathBuf>,
 }
 
 pub fn main(config: Config) -> Result<()> {
@@ -56,7 +65,17 @@ pub fn main(config: Config) -> Result<()> {
     println!("Rule: {}", config.rule);
     println!();
 
-    match evaluate_hooks(&hooks, &[rule]) {
+    let outcome = if config.changed_file.is_empty() {
+        evaluate_hooks(&hooks, &[rule])
+    } else {
+        let now = now_seconds();
+        let mut state = InteractionState::default();
+        let file_hooks = build_changed_file_hooks(&config)?;
+        state.record_file_changes(&file_hooks, std::slice::from_ref(&rule), now);
+        evaluate_hooks_with_state(&hooks, &[rule], &mut state)
+    };
+
+    match outcome {
         HookOutcome::Passthrough => {
             println!("Result: Passthrough");
             println!("The rule did not match the provided input.");
@@ -89,6 +108,33 @@ pub fn main(config: Config) -> Result<()> {
     Ok(())
 }
 
+fn build_changed_file_hooks(config: &Config) -> Result<Vec<NudgeHook>> {
+    let cwd = env::current_dir()
+        .context("get current directory")?
+        .to_string_lossy()
+        .to_string();
+    let mut hooks = Vec::new();
+
+    for file_path in &config.changed_file {
+        let payload = json!({
+            "hook_event_name": "PreToolUse",
+            "session_id": "test",
+            "transcript_path": "/tmp/test",
+            "permission_mode": "default",
+            "cwd": cwd,
+            "tool_name": "Write",
+            "tool_use_id": "test-changed-file",
+            "tool_input": {
+                "file_path": file_path,
+                "content": ""
+            }
+        });
+        hooks.extend(claude::parse_hook(payload).context("failed to build changed file hook")?);
+    }
+
+    Ok(hooks)
+}
+
 /// Build a Hook from the CLI arguments.
 fn build_hooks(config: &Config) -> Result<Vec<NudgeHook>> {
     // Determine what kind of hook to build based on arguments
@@ -115,13 +161,17 @@ fn build_user_prompt_hook(config: &Config) -> Result<Vec<NudgeHook>> {
         .prompt
         .as_ref()
         .expect("prompt required for UserPromptSubmit hook");
+    let cwd = env::current_dir()
+        .context("get current directory")?
+        .to_string_lossy()
+        .to_string();
 
     let payload = json!({
         "hook_event_name": "UserPromptSubmit",
         "session_id": "test",
         "transcript_path": "/tmp/test",
         "permission_mode": "default",
-        "cwd": "/tmp",
+        "cwd": cwd,
         "prompt": prompt
     });
 
@@ -129,6 +179,10 @@ fn build_user_prompt_hook(config: &Config) -> Result<Vec<NudgeHook>> {
 }
 
 fn build_tool_use_hook(config: &Config) -> Result<Vec<NudgeHook>> {
+    let cwd = env::current_dir()
+        .context("get current directory")?
+        .to_string_lossy()
+        .to_string();
     let tool = config.tool.as_deref().unwrap_or("Write");
     let file_path = config
         .file
@@ -179,7 +233,7 @@ fn build_tool_use_hook(config: &Config) -> Result<Vec<NudgeHook>> {
         "session_id": "test",
         "transcript_path": "/tmp/test",
         "permission_mode": "default",
-        "cwd": "/tmp",
+        "cwd": cwd,
         "tool_name": tool,
         "tool_use_id": "test-123",
         "tool_input": tool_input

--- a/packages/nudge/src/hook.rs
+++ b/packages/nudge/src/hook.rs
@@ -9,6 +9,7 @@ use crate::agent::AgentKind;
 pub mod apply_patch;
 pub mod evaluate;
 pub mod response;
+pub mod state;
 
 /// A Nudge hook event after provider-specific payloads have been normalized.
 #[derive(Debug, Clone, PartialEq)]

--- a/packages/nudge/src/hook/evaluate.rs
+++ b/packages/nudge/src/hook/evaluate.rs
@@ -7,7 +7,9 @@ use serde_json::Value;
 use crate::{
     hook::{
         BashInput, EditInput, NudgeHook, PreToolUse, ToolUse, UserPromptSubmit, WebFetchInput,
-        WriteInput, response::HookOutcome,
+        WriteInput,
+        response::HookOutcome,
+        state::{FileChangeContext, InteractionState, now_seconds},
     },
     rules::{
         ContentMatcher, PreToolUseBashMatcher, PreToolUseEditMatcher, PreToolUseWebFetchMatcher,
@@ -21,9 +23,30 @@ use crate::{
 /// A raw provider hook can normalize into multiple Nudge events. This happens
 /// for Codex `apply_patch`, where one tool call can touch several files.
 pub fn evaluate_hooks(hooks: &[NudgeHook], rules: &[Rule]) -> HookOutcome {
+    let mut state = InteractionState::default();
+    evaluate_hooks_with_state(hooks, rules, &mut state)
+}
+
+/// Evaluate a normalized hook batch against loaded rules and local interaction
+/// state.
+pub fn evaluate_hooks_with_state(
+    hooks: &[NudgeHook],
+    rules: &[Rule],
+    state: &mut InteractionState,
+) -> HookOutcome {
+    evaluate_hooks_at(hooks, rules, state, now_seconds())
+}
+
+fn evaluate_hooks_at(
+    hooks: &[NudgeHook],
+    rules: &[Rule],
+    state: &mut InteractionState,
+    now: u64,
+) -> HookOutcome {
     let mut pretooluse_matches = Vec::new();
     let mut pretooluse_update = None;
     let mut user_prompt_matches = Vec::new();
+    let mut user_prompt_updates = Vec::new();
 
     for hook in hooks {
         match hook {
@@ -33,7 +56,9 @@ pub fn evaluate_hooks(hooks: &[NudgeHook], rules: &[Rule]) -> HookOutcome {
                 pretooluse_matches.extend(evaluate_pretooluse(&payload, rules));
             }
             NudgeHook::UserPromptSubmit(payload) => {
-                user_prompt_matches.extend(evaluate_userpromptsubmit(payload, rules));
+                let (matches, updates) = evaluate_userpromptsubmit(payload, rules, state, now);
+                user_prompt_matches.extend(matches);
+                user_prompt_updates.extend(updates);
             }
             NudgeHook::PermissionRequest(_) | NudgeHook::Other => {}
         }
@@ -52,10 +77,22 @@ pub fn evaluate_hooks(hooks: &[NudgeHook], rules: &[Rule]) -> HookOutcome {
     }
 
     if !user_prompt_matches.is_empty() {
+        for update in user_prompt_updates {
+            state.mark_reminder_shown(
+                &update.cwd,
+                &update.rule_name,
+                now,
+                update.change_id,
+                update.change_timestamp,
+            );
+        }
+
         return HookOutcome::AddContext {
             context: user_prompt_matches.join("\n\n"),
         };
     }
+
+    state.record_file_changes(hooks, rules, now);
 
     if let Some(update) = pretooluse_update {
         return HookOutcome::UpdatePreToolUse {
@@ -66,6 +103,20 @@ pub fn evaluate_hooks(hooks: &[NudgeHook], rules: &[Rule]) -> HookOutcome {
     }
 
     HookOutcome::Passthrough
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UserPromptStateUpdate {
+    cwd: std::path::PathBuf,
+    rule_name: String,
+    change_id: Option<u64>,
+    change_timestamp: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UserPromptRuleMatch {
+    matches: Vec<Match>,
+    state_update: Option<UserPromptStateUpdate>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -173,21 +224,34 @@ fn evaluate_pretooluse(payload: &PreToolUse, rules: &[Rule]) -> Vec<String> {
     vec![source_for_tool(&payload.tool).annotate(annotations)]
 }
 
-fn evaluate_userpromptsubmit(payload: &UserPromptSubmit, rules: &[Rule]) -> Vec<String> {
-    let annotations = rules
-        .iter()
-        .flat_map(|rule| {
-            rule.hooks_userpromptsubmit()
-                .flat_map(|matcher| evaluate_user_prompt(payload, matcher))
-                .pipe_matches(rule)
-        })
-        .collect_vec();
-
-    if annotations.is_empty() {
-        return Vec::new();
+fn evaluate_userpromptsubmit(
+    payload: &UserPromptSubmit,
+    rules: &[Rule],
+    state: &InteractionState,
+    now: u64,
+) -> (Vec<String>, Vec<UserPromptStateUpdate>) {
+    let mut updates = Vec::new();
+    let mut annotations = Vec::new();
+    for rule in rules {
+        for matcher in rule.hooks_userpromptsubmit() {
+            let Some(rule_match) = evaluate_user_prompt(payload, matcher, rule, state, now) else {
+                continue;
+            };
+            if let Some(update) = rule_match.state_update {
+                updates.push(update);
+            }
+            annotations.extend(rule.annotate_matches(rule_match.matches));
+        }
     }
 
-    vec![Source::from(&payload.prompt).annotate(annotations)]
+    if annotations.is_empty() {
+        return (Vec::new(), Vec::new());
+    }
+
+    (
+        vec![Source::from(&payload.prompt).annotate(annotations)],
+        updates,
+    )
 }
 
 trait PipeMatches: Iterator<Item = Match> + Sized {
@@ -261,8 +325,112 @@ fn bash_project_state_matches(payload: &PreToolUse, matcher: &PreToolUseBashMatc
         .all(|state_matcher| state_matcher.is_match(&payload.context.cwd))
 }
 
-fn evaluate_user_prompt(input: &UserPromptSubmit, matcher: &UserPromptSubmitMatcher) -> Vec<Match> {
-    evaluate_all_matched(&input.prompt, &matcher.prompt)
+fn evaluate_user_prompt(
+    input: &UserPromptSubmit,
+    matcher: &UserPromptSubmitMatcher,
+    rule: &Rule,
+    state: &InteractionState,
+    now: u64,
+) -> Option<UserPromptRuleMatch> {
+    let mut matches = Vec::new();
+
+    if !matcher.prompt.is_empty() {
+        let prompt_matches = evaluate_all_matched(&input.prompt, &matcher.prompt);
+        if prompt_matches.is_empty() {
+            return None;
+        }
+        matches.extend(prompt_matches);
+    }
+
+    if let Some(intent) = &matcher.intent {
+        let intent_matches = intent.matches_with_context(&input.prompt);
+        if intent_matches.is_empty() {
+            return None;
+        }
+        matches.extend(intent_matches);
+    }
+
+    if matcher.prompt.is_empty() && matcher.intent.is_none() {
+        return None;
+    }
+
+    let change = if matcher.after_file_change.is_empty() {
+        None
+    } else {
+        Some(state.latest_matching_file_change(
+            &input.context.cwd,
+            &matcher.after_file_change,
+            now,
+        )?)
+    };
+
+    if reminder_is_suppressed(input, matcher, rule, state, now, change.as_ref()) {
+        return None;
+    }
+
+    if let Some(change) = &change {
+        for prompt_match in &mut matches {
+            prompt_match
+                .captures
+                .insert("changed_file".to_string(), change.path.clone());
+            prompt_match
+                .captures
+                .insert("changed_at".to_string(), change.timestamp.to_string());
+        }
+    }
+
+    let state_update = matcher
+        .uses_interaction_state()
+        .then(|| UserPromptStateUpdate {
+            cwd: input.context.cwd.clone(),
+            rule_name: rule.name.clone(),
+            change_id: change.as_ref().map(|change| change.id),
+            change_timestamp: change.map(|change| change.timestamp),
+        });
+
+    Some(UserPromptRuleMatch {
+        matches,
+        state_update,
+    })
+}
+
+fn reminder_is_suppressed(
+    input: &UserPromptSubmit,
+    matcher: &UserPromptSubmitMatcher,
+    rule: &Rule,
+    state: &InteractionState,
+    now: u64,
+    change: Option<&FileChangeContext>,
+) -> bool {
+    let Some(reminder) = state.reminder(&input.context.cwd, &rule.name) else {
+        return false;
+    };
+
+    if matcher.once_per_change {
+        let Some(change) = change else {
+            return true;
+        };
+        let already_seen = if let Some(last_change_id) = reminder.last_change_id {
+            change.id <= last_change_id
+        } else {
+            reminder
+                .last_change_timestamp
+                .is_some_and(|last_change| change.timestamp <= last_change)
+        };
+        if already_seen {
+            return true;
+        }
+
+        return false;
+    }
+
+    if let Some(cooldown) = matcher.cooldown
+        && now.saturating_sub(reminder.last_shown_at) < cooldown.as_secs()
+    {
+        return true;
+    }
+
+    false
 }
 
 fn source_for_tool(tool: &ToolUse) -> Source {

--- a/packages/nudge/src/hook/state.rs
+++ b/packages/nudge/src/hook/state.rs
@@ -72,7 +72,8 @@ impl InteractionState {
         fs::write(&path, content).with_context(|| format!("write {}", path.display()))
     }
 
-    /// Record allowed file changes that match at least one stateful prompt rule.
+    /// Record allowed file changes that match at least one stateful prompt
+    /// rule.
     pub fn record_file_changes(&mut self, hooks: &[NudgeHook], rules: &[Rule], now: u64) {
         let file_gates = rules
             .iter()
@@ -107,7 +108,8 @@ impl InteractionState {
         }
     }
 
-    /// Find the newest local file change that satisfies any of the supplied gates.
+    /// Find the newest local file change that satisfies any of the supplied
+    /// gates.
     pub fn latest_matching_file_change(
         &self,
         cwd: &Path,

--- a/packages/nudge/src/hook/state.rs
+++ b/packages/nudge/src/hook/state.rs
@@ -1,0 +1,335 @@
+//! Local interaction state for context-aware prompt reminders.
+
+use std::{
+    collections::BTreeMap,
+    env, fs,
+    io::ErrorKind,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use color_eyre::{
+    Result,
+    eyre::{Context, OptionExt},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    hook::{NudgeHook, PreToolUse, ToolUse},
+    rules::{FileChangeMatcher, Rule, project_dirs},
+};
+
+const STATE_FILE_NAME: &str = "interaction-state.json";
+const STATE_VERSION: u8 = 1;
+const MAX_FILE_CHANGES_PER_PROJECT: usize = 512;
+const MAX_FILE_CHANGE_AGE_SECONDS: u64 = 7 * 24 * 60 * 60;
+
+/// Local state used by stateful `UserPromptSubmit` matchers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InteractionState {
+    version: u8,
+
+    #[serde(default)]
+    projects: BTreeMap<String, ProjectInteractionState>,
+}
+
+impl Default for InteractionState {
+    fn default() -> Self {
+        Self {
+            version: STATE_VERSION,
+            projects: BTreeMap::new(),
+        }
+    }
+}
+
+impl InteractionState {
+    /// Load interaction state from the local machine.
+    pub fn load() -> Result<Self> {
+        let Some(path) = state_file_path()? else {
+            return Ok(Self::default());
+        };
+
+        let content = match fs::read_to_string(&path) {
+            Ok(content) => content,
+            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(Self::default()),
+            Err(error) => return Err(error).with_context(|| format!("read {}", path.display())),
+        };
+
+        serde_json::from_str(&content).with_context(|| format!("parse {}", path.display()))
+    }
+
+    /// Save interaction state to the local machine.
+    pub fn save(&self) -> Result<()> {
+        let Some(path) = state_file_path()? else {
+            return Ok(());
+        };
+
+        let parent = path
+            .parent()
+            .ok_or_eyre("interaction state path has no parent directory")?;
+        fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+        let content = serde_json::to_string_pretty(self).context("serialize interaction state")?;
+        fs::write(&path, content).with_context(|| format!("write {}", path.display()))
+    }
+
+    /// Record allowed file changes that match at least one stateful prompt rule.
+    pub fn record_file_changes(&mut self, hooks: &[NudgeHook], rules: &[Rule], now: u64) {
+        let file_gates = rules
+            .iter()
+            .flat_map(Rule::hooks_userpromptsubmit)
+            .flat_map(|matcher| matcher.after_file_change.iter())
+            .collect::<Vec<_>>();
+        if file_gates.is_empty() {
+            return;
+        }
+
+        for hook in hooks {
+            let NudgeHook::PreToolUse(payload) = hook else {
+                continue;
+            };
+            let Some(path) = changed_file_path(payload) else {
+                continue;
+            };
+            let path = project_relative_path(&payload.context.cwd, path);
+            if !file_gates.iter().any(|gate| gate.file.is_match(&path)) {
+                continue;
+            }
+
+            let project = self.project_mut(&payload.context.cwd);
+            let id = project.next_change_id;
+            project.next_change_id = project.next_change_id.saturating_add(1);
+            project.file_changes.push(FileChangeRecord {
+                id,
+                path,
+                timestamp: now,
+            });
+            project.prune_file_changes(now);
+        }
+    }
+
+    /// Find the newest local file change that satisfies any of the supplied gates.
+    pub fn latest_matching_file_change(
+        &self,
+        cwd: &Path,
+        gates: &[FileChangeMatcher],
+        now: u64,
+    ) -> Option<FileChangeContext> {
+        if gates.is_empty() {
+            return None;
+        }
+
+        let project = self.projects.get(&project_key(cwd));
+        project.and_then(|project| {
+            project.file_changes.iter().rev().find_map(|change| {
+                let age = now.saturating_sub(change.timestamp);
+                if gates
+                    .iter()
+                    .any(|gate| gate.matches_change(&change.path, age))
+                {
+                    Some(FileChangeContext {
+                        id: change.id,
+                        path: change.path.clone(),
+                        timestamp: change.timestamp,
+                    })
+                } else {
+                    None
+                }
+            })
+        })
+    }
+
+    /// Return reminder frequency state for a rule in the current project.
+    pub fn reminder(&self, cwd: &Path, rule_name: &str) -> Option<&ReminderRecord> {
+        self.projects
+            .get(&project_key(cwd))
+            .and_then(|project| project.reminders.get(rule_name))
+    }
+
+    /// Mark that a prompt reminder has been shown.
+    pub fn mark_reminder_shown(
+        &mut self,
+        cwd: &Path,
+        rule_name: &str,
+        now: u64,
+        change_id: Option<u64>,
+        change_timestamp: Option<u64>,
+    ) {
+        let project = self.project_mut(cwd);
+        project.reminders.insert(
+            rule_name.to_string(),
+            ReminderRecord {
+                last_shown_at: now,
+                last_change_id: change_id,
+                last_change_timestamp: change_timestamp,
+            },
+        );
+    }
+
+    fn project_mut(&mut self, cwd: &Path) -> &mut ProjectInteractionState {
+        self.projects.entry(project_key(cwd)).or_default()
+    }
+}
+
+/// File-change context captured for prompt template interpolation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileChangeContext {
+    pub id: u64,
+    pub path: String,
+    pub timestamp: u64,
+}
+
+/// Frequency state for one reminder rule.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReminderRecord {
+    pub last_shown_at: u64,
+
+    #[serde(default)]
+    pub last_change_id: Option<u64>,
+
+    #[serde(default)]
+    pub last_change_timestamp: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct ProjectInteractionState {
+    #[serde(default)]
+    next_change_id: u64,
+
+    #[serde(default)]
+    file_changes: Vec<FileChangeRecord>,
+
+    #[serde(default)]
+    reminders: BTreeMap<String, ReminderRecord>,
+}
+
+impl ProjectInteractionState {
+    fn prune_file_changes(&mut self, now: u64) {
+        self.file_changes
+            .retain(|change| now.saturating_sub(change.timestamp) <= MAX_FILE_CHANGE_AGE_SECONDS);
+
+        let excess = self
+            .file_changes
+            .len()
+            .saturating_sub(MAX_FILE_CHANGES_PER_PROJECT);
+        if excess > 0 {
+            self.file_changes.drain(0..excess);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct FileChangeRecord {
+    #[serde(default)]
+    id: u64,
+
+    path: String,
+    timestamp: u64,
+}
+
+/// Whether any loaded rules need local interaction state.
+pub fn rules_need_interaction_state(rules: &[Rule]) -> bool {
+    rules.iter().any(Rule::uses_interaction_state)
+}
+
+/// Current Unix timestamp in seconds.
+pub fn now_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default()
+}
+
+fn changed_file_path(payload: &PreToolUse) -> Option<&Path> {
+    match &payload.tool {
+        ToolUse::Write(input) => Some(&input.file_path),
+        ToolUse::Edit(input) => Some(&input.file_path),
+        ToolUse::Delete(input) => Some(&input.file_path),
+        ToolUse::WebFetch(_) | ToolUse::Bash(_) | ToolUse::Other { .. } => None,
+    }
+}
+
+fn project_relative_path(cwd: &Path, path: &Path) -> String {
+    let relative = if path.is_absolute() {
+        path.strip_prefix(cwd).unwrap_or(path)
+    } else {
+        path
+    };
+    relative.to_string_lossy().replace('\\', "/")
+}
+
+fn project_key(cwd: &Path) -> String {
+    cwd.canonicalize()
+        .unwrap_or_else(|_| cwd.to_path_buf())
+        .to_string_lossy()
+        .to_string()
+}
+
+fn state_file_path() -> Result<Option<PathBuf>> {
+    if let Ok(dir) = env::var("NUDGE_STATE_DIR") {
+        return Ok(Some(PathBuf::from(dir).join(STATE_FILE_NAME)));
+    }
+
+    Ok(project_dirs().map(|dirs| dirs.data_local_dir().join(STATE_FILE_NAME)))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    use crate::{
+        agent::claude,
+        hook::state::{InteractionState, now_seconds},
+        rules::RuleConfig,
+    };
+
+    use super::*;
+
+    fn rules(yaml: &str) -> Vec<Rule> {
+        serde_yaml::from_str::<RuleConfig>(yaml)
+            .expect("rules parse")
+            .rules
+    }
+
+    #[test]
+    fn records_only_opted_in_matching_file_changes() {
+        let temp = TempDir::new().expect("temp dir");
+        let hooks = claude::parse_hook(json!({
+            "hook_event_name": "PreToolUse",
+            "cwd": temp.path(),
+            "tool_name": "Write",
+            "tool_input": { "file_path": "packages/hurry/src/main.rs", "content": "" }
+        }))
+        .expect("parse hook");
+        let rules = rules(
+            r#"
+version: 1
+rules:
+  - name: hurry-test
+    on:
+      - hook: UserPromptSubmit
+        intent:
+          examples: ["try running it"]
+        after_file_change:
+          - file: "packages/hurry/src/**"
+"#,
+        );
+
+        let now = now_seconds();
+        let mut state = InteractionState::default();
+        state.record_file_changes(&hooks, &rules, now);
+
+        let change = state
+            .latest_matching_file_change(
+                temp.path(),
+                &rules[0]
+                    .hooks_userpromptsubmit()
+                    .next()
+                    .expect("matcher")
+                    .after_file_change,
+                now,
+            )
+            .expect("recorded change");
+        assert_eq!(change.path, "packages/hurry/src/main.rs");
+    }
+}

--- a/packages/nudge/src/rules/schema.rs
+++ b/packages/nudge/src/rules/schema.rs
@@ -343,7 +343,8 @@ pub struct UserPromptSubmitMatcher {
     /// Example-based semantic intent matcher for the user prompt.
     ///
     /// This is local and deterministic: Nudge compares normalized prompt tokens
-    /// to author-provided examples. It never calls an external model or service.
+    /// to author-provided examples. It never calls an external model or
+    /// service.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub intent: Option<PromptIntentMatcher>,
 

--- a/packages/nudge/src/rules/schema.rs
+++ b/packages/nudge/src/rules/schema.rs
@@ -12,12 +12,14 @@ use crate::{
 pub use content::{ContentMatcher, RegexMatcher};
 pub use path::GlobMatcher;
 pub use project_state::ProjectStateMatcher;
+pub use prompt::{DurationSeconds, FileChangeMatcher, PromptIntentMatcher};
 pub use syntax::{Language, TreeSitterQuery};
 pub use url::UrlMatcher;
 
 mod content;
 mod path;
 mod project_state;
+mod prompt;
 mod syntax;
 mod url;
 
@@ -102,6 +104,12 @@ impl Rule {
         self.on
             .iter()
             .filter_map(fmap_match!(Hook::UserPromptSubmit))
+    }
+
+    /// Whether this rule needs local interaction state.
+    pub fn uses_interaction_state(&self) -> bool {
+        self.hooks_userpromptsubmit()
+            .any(UserPromptSubmitMatcher::uses_interaction_state)
     }
 
     /// Annotate matching spans with the message from the rule.
@@ -331,6 +339,35 @@ pub struct UserPromptSubmitMatcher {
     /// patterns, the rule is triggered.
     #[serde(default)]
     pub prompt: Vec<ContentMatcher>,
+
+    /// Example-based semantic intent matcher for the user prompt.
+    ///
+    /// This is local and deterministic: Nudge compares normalized prompt tokens
+    /// to author-provided examples. It never calls an external model or service.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub intent: Option<PromptIntentMatcher>,
+
+    /// Only match after a recent project file change.
+    ///
+    /// File changes are recorded locally only for rules that opt into this
+    /// field, and only matching file paths and timestamps are stored.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub after_file_change: Vec<FileChangeMatcher>,
+
+    /// Suppress this prompt reminder until the cooldown has elapsed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cooldown: Option<DurationSeconds>,
+
+    /// Suppress repeats until another matching file change occurs.
+    #[serde(default)]
+    pub once_per_change: bool,
+}
+
+impl UserPromptSubmitMatcher {
+    /// Whether this matcher needs local interaction state.
+    pub fn uses_interaction_state(&self) -> bool {
+        !self.after_file_change.is_empty() || self.cooldown.is_some()
+    }
 }
 
 #[cfg(test)]
@@ -372,5 +409,27 @@ mod tests {
             serde_yaml::from_str::<PreToolUseBashMatcher>(yaml).expect("valid bash matcher yaml");
         pretty_assert_eq!(matcher.command.len(), 1);
         pretty_assert_eq!(matcher.project_state.len(), 1);
+    }
+
+    #[test]
+    fn test_user_prompt_semantic_matcher_deserialize() {
+        let yaml = r#"
+            hook: UserPromptSubmit
+            intent:
+              examples:
+                - "let's test this"
+                - "try running it"
+            after_file_change:
+              - file: "packages/hurry/src/**"
+                within: "30m"
+            once_per_change: true
+            cooldown: "1h"
+        "#;
+        let matcher = serde_yaml::from_str::<UserPromptSubmitMatcher>(yaml)
+            .expect("valid user prompt matcher yaml");
+        assert!(matcher.intent.is_some());
+        pretty_assert_eq!(matcher.after_file_change.len(), 1);
+        assert!(matcher.once_per_change);
+        assert!(matcher.uses_interaction_state());
     }
 }

--- a/packages/nudge/src/rules/schema/prompt.rs
+++ b/packages/nudge/src/rules/schema/prompt.rs
@@ -1,0 +1,254 @@
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Deserializer, Serialize};
+
+use crate::{
+    snippet::{Match, Span},
+    template::Captures,
+};
+
+use super::GlobMatcher;
+
+/// Duration in seconds, parsed from friendly strings like `30m`, `1h`, or `2d`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub struct DurationSeconds(u64);
+
+impl DurationSeconds {
+    pub fn as_secs(self) -> u64 {
+        self.0
+    }
+}
+
+impl Default for DurationSeconds {
+    fn default() -> Self {
+        Self(60 * 60)
+    }
+}
+
+impl<'de> Deserialize<'de> for DurationSeconds {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Raw {
+            Seconds(u64),
+            Text(String),
+        }
+
+        match Raw::deserialize(deserializer)? {
+            Raw::Seconds(seconds) => Ok(DurationSeconds(seconds)),
+            Raw::Text(text) => parse_duration(&text).map_err(serde::de::Error::custom),
+        }
+    }
+}
+
+fn parse_duration(text: &str) -> Result<DurationSeconds, String> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Err("duration cannot be empty".to_string());
+    }
+
+    let (digits, suffix) = trimmed.split_at(
+        trimmed
+            .find(|c: char| !c.is_ascii_digit())
+            .unwrap_or(trimmed.len()),
+    );
+    if digits.is_empty() {
+        return Err(format!("duration must start with a number: {text}"));
+    }
+
+    let value = digits
+        .parse::<u64>()
+        .map_err(|error| format!("invalid duration number {digits}: {error}"))?;
+    let multiplier = match suffix.trim() {
+        "" | "s" | "sec" | "secs" | "second" | "seconds" => 1,
+        "m" | "min" | "mins" | "minute" | "minutes" => 60,
+        "h" | "hr" | "hrs" | "hour" | "hours" => 60 * 60,
+        "d" | "day" | "days" => 24 * 60 * 60,
+        other => return Err(format!("unsupported duration suffix: {other}")),
+    };
+
+    value
+        .checked_mul(multiplier)
+        .map(DurationSeconds)
+        .ok_or_else(|| format!("duration is too large: {text}"))
+}
+
+/// A local file-change gate for prompt context injection.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct FileChangeMatcher {
+    /// Glob pattern for changed files.
+    #[serde(default)]
+    pub file: GlobMatcher,
+
+    /// How recently the file change must have been observed.
+    #[serde(default)]
+    pub within: DurationSeconds,
+}
+
+impl FileChangeMatcher {
+    pub fn matches_change(&self, path: &str, age_seconds: u64) -> bool {
+        self.file.is_match(path) && age_seconds <= self.within.as_secs()
+    }
+}
+
+/// Example-based semantic intent matcher for `UserPromptSubmit`.
+#[derive(Debug, Clone, Serialize)]
+pub struct PromptIntentMatcher {
+    examples: Vec<String>,
+    threshold: f32,
+}
+
+impl PromptIntentMatcher {
+    const DEFAULT_THRESHOLD: f32 = 0.60;
+
+    pub fn matches_with_context(&self, prompt: &str) -> Vec<Match> {
+        let prompt_tokens = normalized_tokens(prompt);
+        let Some((example, score)) = self
+            .examples
+            .iter()
+            .map(|example| {
+                (
+                    example,
+                    semantic_score(&prompt_tokens, &normalized_tokens(example)),
+                )
+            })
+            .max_by(|(_, left), (_, right)| left.total_cmp(right))
+        else {
+            return Vec::new();
+        };
+
+        if score < self.threshold {
+            return Vec::new();
+        }
+
+        let mut captures = Captures::new();
+        captures.insert("intent_example".to_string(), example.clone());
+        captures.insert("intent_score".to_string(), format!("{score:.2}"));
+
+        vec![Match {
+            span: Span::from(0..prompt.len()),
+            captures,
+        }]
+    }
+}
+
+impl<'de> Deserialize<'de> for PromptIntentMatcher {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Raw {
+            examples: Vec<String>,
+            threshold: Option<f32>,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        if raw.examples.is_empty() {
+            return Err(serde::de::Error::custom("intent examples cannot be empty"));
+        }
+
+        let threshold = raw.threshold.unwrap_or(Self::DEFAULT_THRESHOLD);
+        if !(0.0..=1.0).contains(&threshold) {
+            return Err(serde::de::Error::custom(
+                "intent threshold must be between 0.0 and 1.0",
+            ));
+        }
+
+        Ok(PromptIntentMatcher {
+            examples: raw.examples,
+            threshold,
+        })
+    }
+}
+
+fn semantic_score(left: &BTreeSet<String>, right: &BTreeSet<String>) -> f32 {
+    if left.is_empty() || right.is_empty() {
+        return 0.0;
+    }
+
+    let intersection = left.intersection(right).count() as f32;
+    let union = left.union(right).count() as f32;
+    intersection / union
+}
+
+fn normalized_tokens(text: &str) -> BTreeSet<String> {
+    text.split(|c: char| !c.is_ascii_alphanumeric())
+        .filter_map(canonical_token)
+        .collect()
+}
+
+fn canonical_token(token: &str) -> Option<String> {
+    let token = token.to_ascii_lowercase();
+    match token.as_str() {
+        "" | "a" | "an" | "and" | "are" | "can" | "could" | "do" | "does" | "for" | "how" | "i"
+        | "if" | "is" | "let" | "lets" | "now" | "of" | "on" | "please" | "s" | "see"
+        | "should" | "the" | "to" | "we" | "will" | "would" | "you" => None,
+
+        "check" | "checking" | "execute" | "executing" | "pass" | "passes" | "passing" | "ran"
+        | "run" | "running" | "runs" | "smoke" | "test" | "tested" | "testing" | "try"
+        | "trying" | "validate" | "validating" | "verify" | "verifying" | "work" | "working"
+        | "works" => Some("test".to_string()),
+
+        "change" | "changes" | "current" | "implementation" | "it" | "local" | "locally"
+        | "that" | "this" => Some("current".to_string()),
+
+        other => Some(other.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq as pretty_assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn parses_duration_strings() {
+        pretty_assert_eq!(
+            serde_yaml::from_str::<DurationSeconds>("30m")
+                .expect("duration")
+                .as_secs(),
+            30 * 60
+        );
+        pretty_assert_eq!(
+            serde_yaml::from_str::<DurationSeconds>("1h")
+                .expect("duration")
+                .as_secs(),
+            60 * 60
+        );
+    }
+
+    #[test]
+    fn prompt_intent_matches_semantic_variants() {
+        let matcher = serde_yaml::from_str::<PromptIntentMatcher>(
+            r#"
+examples:
+  - "let's test this"
+  - "try running it"
+  - "does this work"
+"#,
+        )
+        .expect("intent matcher");
+
+        assert!(!matcher.matches_with_context("try executing it").is_empty());
+        assert!(
+            !matcher
+                .matches_with_context("can we verify this now")
+                .is_empty()
+        );
+        assert!(
+            matcher
+                .matches_with_context("run the unit tests")
+                .is_empty()
+        );
+        assert!(
+            matcher
+                .matches_with_context("explain how this daemon is structured")
+                .is_empty()
+        );
+    }
+}

--- a/packages/nudge/tests/it/user_prompt.rs
+++ b/packages/nudge/tests/it/user_prompt.rs
@@ -1,6 +1,13 @@
 //! UserPromptSubmit Hook Tests
 
-use crate::{Expected, assert_expected, run_hook, user_prompt_hook};
+use std::{
+    fs,
+    io::Write as _,
+    process::{Command, Stdio},
+};
+
+use crate::{Expected, assert_expected, nudge_binary, run_hook, user_prompt_hook};
+use tempfile::TempDir;
 use xshell::Shell;
 
 #[test]
@@ -10,4 +17,215 @@ fn test_user_prompt_no_matching_rules() {
     let (exit_code, output) = run_hook(&sh, &input);
     // No UserPromptSubmit rules in the test config, so should passthrough
     assert_expected(exit_code, &output, Expected::Passthrough);
+}
+
+#[test]
+fn semantic_prompt_injects_after_matching_project_file_change() {
+    let temp = project_with_semantic_prompt_rule();
+    let input = user_prompt_hook_in_dir(temp.path(), "try executing it");
+
+    let (exit_code, output) = run_hook_in_project(&temp, &input);
+    assert_expected(exit_code, &output, Expected::Passthrough);
+
+    let input = write_hook_in_dir(
+        temp.path(),
+        "packages/hurry/src/daemon.rs",
+        "pub fn sync() {}\n",
+    );
+    let (exit_code, output) = run_hook_in_project(&temp, &input);
+    assert_expected(exit_code, &output, Expected::Passthrough);
+
+    let input = user_prompt_hook_in_dir(temp.path(), "try executing it");
+    let (exit_code, output) = run_hook_in_project(&temp, &input);
+    assert_expected(exit_code, &output, Expected::Continue);
+    assert!(
+        output.contains("Use `hurry-dev` after `make install-dev`."),
+        "expected local testing reminder, got: {output}"
+    );
+}
+
+#[test]
+fn semantic_prompt_requires_matching_file_change() {
+    let temp = project_with_semantic_prompt_rule();
+    let input = write_hook_in_dir(temp.path(), "README.md", "# docs\n");
+    let (exit_code, output) = run_hook_in_project(&temp, &input);
+    assert_expected(exit_code, &output, Expected::Passthrough);
+
+    let input = user_prompt_hook_in_dir(temp.path(), "let's test this");
+    let (exit_code, output) = run_hook_in_project(&temp, &input);
+    assert_expected(exit_code, &output, Expected::Passthrough);
+}
+
+#[test]
+fn semantic_prompt_rejects_unrelated_prompt_after_file_change() {
+    let temp = project_with_semantic_prompt_rule();
+    let input = write_hook_in_dir(
+        temp.path(),
+        "packages/hurry/src/daemon.rs",
+        "pub fn sync() {}\n",
+    );
+    let (exit_code, output) = run_hook_in_project(&temp, &input);
+    assert_expected(exit_code, &output, Expected::Passthrough);
+
+    let input = user_prompt_hook_in_dir(temp.path(), "explain how this daemon is structured");
+    let (exit_code, output) = run_hook_in_project(&temp, &input);
+    assert_expected(exit_code, &output, Expected::Passthrough);
+}
+
+#[test]
+fn semantic_prompt_once_per_change_suppresses_repeated_noise() {
+    let temp = project_with_semantic_prompt_rule();
+    let input = write_hook_in_dir(
+        temp.path(),
+        "packages/hurry/src/daemon.rs",
+        "pub fn sync() {}\n",
+    );
+    let (exit_code, output) = run_hook_in_project(&temp, &input);
+    assert_expected(exit_code, &output, Expected::Passthrough);
+
+    let input = user_prompt_hook_in_dir(temp.path(), "does this work?");
+    let (exit_code, output) = run_hook_in_project(&temp, &input);
+    assert_expected(exit_code, &output, Expected::Continue);
+
+    let input = user_prompt_hook_in_dir(temp.path(), "try running it");
+    let (exit_code, output) = run_hook_in_project(&temp, &input);
+    assert_expected(exit_code, &output, Expected::Passthrough);
+
+    let input = write_hook_in_dir(
+        temp.path(),
+        "packages/hurry/src/daemon.rs",
+        "pub fn sync_again() {}\n",
+    );
+    let (exit_code, output) = run_hook_in_project(&temp, &input);
+    assert_expected(exit_code, &output, Expected::Passthrough);
+
+    let input = user_prompt_hook_in_dir(temp.path(), "try running it");
+    let (exit_code, output) = run_hook_in_project(&temp, &input);
+    assert_expected(exit_code, &output, Expected::Continue);
+}
+
+#[test]
+fn test_command_can_simulate_changed_file_for_semantic_prompt_rule() {
+    let temp = project_with_semantic_prompt_rule();
+
+    let output = Command::new(nudge_binary())
+        .args([
+            "test",
+            "--rule",
+            "hurry-local-test-reminder",
+            "--prompt",
+            "try executing it",
+            "--changed-file",
+            "packages/hurry/src/daemon.rs",
+        ])
+        .current_dir(temp.path())
+        .env("HOME", temp.path().join("home"))
+        .env("XDG_CONFIG_HOME", temp.path().join("xdg-config"))
+        .env("NUDGE_STATE_DIR", temp.path().join("state"))
+        .output()
+        .expect("run nudge test");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "expected nudge test to pass, stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(stdout.contains("Result: Continue"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("Use `hurry-dev` after `make install-dev`."),
+        "stdout: {stdout}"
+    );
+}
+
+fn project_with_semantic_prompt_rule() -> TempDir {
+    let temp = TempDir::new().expect("create temp dir");
+    fs::create_dir_all(temp.path().join("packages/hurry/src")).expect("create source dir");
+    fs::write(
+        temp.path().join(".nudge.yaml"),
+        r#"
+version: 1
+rules:
+  - name: hurry-local-test-reminder
+    description: Use dev entrypoints when testing hurry changes
+    message: "Use `hurry-dev` after `make install-dev`."
+    on:
+      - hook: UserPromptSubmit
+        intent:
+          examples:
+            - "let's test this"
+            - "try running it"
+            - "does this work"
+        after_file_change:
+          - file: "packages/hurry/src/**"
+            within: "1h"
+        once_per_change: true
+        cooldown: "1h"
+"#,
+    )
+    .expect("write config");
+    temp
+}
+
+fn user_prompt_hook_in_dir(cwd: &std::path::Path, prompt: &str) -> String {
+    serde_json::json!({
+        "hook_event_name": "UserPromptSubmit",
+        "session_id": "test",
+        "transcript_path": "/tmp/test",
+        "permission_mode": "default",
+        "cwd": cwd,
+        "prompt": prompt
+    })
+    .to_string()
+}
+
+fn write_hook_in_dir(cwd: &std::path::Path, file_path: &str, content: &str) -> String {
+    serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "test",
+        "transcript_path": "/tmp/test",
+        "permission_mode": "default",
+        "cwd": cwd,
+        "tool_name": "Write",
+        "tool_use_id": "123",
+        "tool_input": {
+            "file_path": file_path,
+            "content": content
+        }
+    })
+    .to_string()
+}
+
+fn run_hook_in_project(dir: &TempDir, input: &str) -> (i32, String) {
+    let home = dir.path().join("home");
+    let state = dir.path().join("state");
+    let mut child = Command::new(nudge_binary())
+        .args(["claude", "hook"])
+        .current_dir(dir.path())
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", dir.path().join("xdg-config"))
+        .env("NUDGE_STATE_DIR", &state)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn nudge");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(input.as_bytes())
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("wait for nudge");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = if !stdout.trim().is_empty() {
+        stdout.trim().to_string()
+    } else {
+        stderr.trim().to_string()
+    };
+
+    (output.status.code().unwrap_or(-1), combined)
 }


### PR DESCRIPTION
Resolves #6.

**Why this change**
- `UserPromptSubmit` rules were limited to regex prompt matching, which made workflow reminders either too noisy or too narrow for prompts like "let's test this", "try running it", or "does this work".
- This adds a concrete local-first extension: example-based prompt intent matching, opt-in `after_file_change` gates, `once_per_change`, and `cooldown` controls.
- The real target behavior is now expressible directly: after source files matching a project-specific glob change, Nudge can inject the right testing reminder for semantic variants of "try running it" while ignoring unrelated prompts and unrelated file changes.
- Privacy boundaries are explicit: Nudge never calls an LLM or makes network requests for intent matching, and stateful prompt rules store only matching file paths, timestamps, and reminder frequency state locally.

**Configuration changes after merge**
- No migration is required for existing rules.
- New optional `UserPromptSubmit` fields are available: `intent.examples`, `intent.threshold`, `after_file_change`, `once_per_change`, and `cooldown`.
- Stateful prompt rules write a local JSON state file only when a loaded rule opts into state. Set `NUDGE_STATE_DIR` to override the storage directory.
- `nudge test` now supports `--changed-file <path>` with `--prompt` so rule authors can simulate prior local file changes when testing stateful prompt rules.

**Testing steps performed**
```text
$ cargo test -p nudge
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.86s
     Running unittests src/lib.rs (target/debug/deps/nudge-de919d37ae7d274f)

test result: ok. 68 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

     Running unittests src/main.rs (target/debug/deps/nudge-1aa3f0c0812a4a6f)

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/it/main.rs (target/debug/deps/it-a3069e9bcd7a65af)

test result: ok. 77 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.89s

   Doc-tests nudge

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

all doctests ran in 0.40s; merged doctests compilation took 0.20s
```

```text
$ target/debug/nudge codex docs | rg -n "Prompt Intent|try running it|changed-file|NUDGE_STATE_DIR"
59:            examples: ["try running it", "does this work"]
178:Prompt Intent and Local Interaction State
183:  edits, such as "try running it" after changing a local daemon.
194:              - "try running it"
212:    Nudge's local data directory; set NUDGE_STATE_DIR to override it.
385:              - "try running it"
521:  nudge test --rule hurry-local-test-reminder --changed-file packages/hurry/src/daemon.rs --prompt "try executing it"
```

**Surprising changes / Notes**
- `nudge test` generated hook payloads now use the command's current working directory instead of hard-coded `/tmp`, so stateful prompt tests and project-state evaluation line up with the project being tested.
- The semantic matcher is intentionally deterministic and local. It uses normalized token overlap with a small built-in synonym set rather than an external embedding service or remote model.