### PR TITLE
Add deterministic WhatComment matcher

### DIFF
--- a/.nudge.yaml
+++ b/.nudge.yaml
@@ -132,6 +132,24 @@ rules:
                   (#eq? @method "unwrap"))
                 arguments: (arguments))
 
+  # Catch comments that explain what obvious code does instead of why it exists.
+  - name: no-what-comments
+    description: Comments should explain why, not restate obvious code
+    message: "Remove this comment or explain why the code exists, then retry."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.rs"
+        content:
+          - kind: WhatComment
+            language: rust
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.rs"
+        new_content:
+          - kind: WhatComment
+            language: rust
+
   # Redirect docs.rs fetches to local cargo registry.
   # Demonstrates the WebFetch matcher with URL capture groups.
   - name: prefer-local-docs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ nudge check         - Check project files against rules (CI/linter mode)
 - `src/cmd/check.rs` - Check command: validate project files against rules for CI
 - `src/rules.rs` - Rule loading from config files
 - `src/rules/schema.rs` - Rule schema facade and hook matcher types
-- `src/rules/schema/` - Focused matcher implementations for content, glob paths, project state, tree-sitter syntax, and URLs
+- `src/rules/schema/` - Focused matcher implementations for content, comments, glob paths, project state, tree-sitter syntax, and URLs
 - `src/snippet.rs` - Code snippet rendering for rule violations (uses `annotate-snippets`)
 
 ### How Nudge Communicates

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ These are the rules Nudge uses on its own codebase (yes, we dogfood):
 | Qualified paths      | Import and use shorter names instead of long paths          |
 | Pretty assertions    | Use `pretty_assertions` in tests for better diff output     |
 | No `.unwrap()`       | Use `.expect("...")` with a descriptive message             |
+| Why comments         | Remove comments that restate obvious code                   |
 
 Other Attune codebases of course have other rules.
 
@@ -89,6 +90,22 @@ rules:
 ```
 
 Substitutions work for Claude Code and Codex CLI. Nudge returns the provider's full updated tool input with only `command` changed, and adds `hookSpecificOutput.additionalContext` so the model sees what was rewritten.
+
+For comments that explain what the next line already says, use `kind: WhatComment`. It is a deterministic heuristic for short adjacent line comments, with built-in passes for comments that explain reasoning, safety, concurrency, performance, compatibility, and similar constraints:
+
+```yaml
+version: 1
+rules:
+  - name: no-what-comments
+    message: "Remove this comment or explain why the code exists, then retry."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.rs"
+        content:
+          - kind: WhatComment
+            language: rust
+```
 
 For the full rule syntax and copy-pasteable examples, run `nudge claude docs` or `nudge codex docs`.
 

--- a/packages/nudge/src/cmd/check.rs
+++ b/packages/nudge/src/cmd/check.rs
@@ -201,7 +201,6 @@ fn collect_files(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
         for path in paths {
             let path_str = path.to_string_lossy();
 
-            // Check if it's a glob pattern
             if path_str.contains('*') || path_str.contains('?') || path_str.contains('[') {
                 let pattern = Pattern::new(&path_str)
                     .with_context(|| format!("invalid glob pattern: {path_str}"))?;

--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -246,6 +246,33 @@ const DOCS: &str = cstr!("\
   <dim>Note: If code fails to parse (incomplete or invalid syntax), the matcher</dim>
   <dim>passes silently. This is intentional because code being written is often incomplete.</dim>
 
+<bold>What Comment Matching</bold>
+
+  Use <cyan>kind: WhatComment</cyan> to catch short adjacent line comments that restate
+  obvious code instead of explaining why the code exists.
+
+  <white>Basic Syntax:</white>
+    <yellow>content:</yellow>
+      <yellow>- kind: WhatComment</yellow>
+        <yellow>language: rust</yellow>              <dim># Required</dim>
+        <yellow>suggestion: \"...\"</yellow>           <dim># Optional: same as Regex</dim>
+
+  <white>How It Works:</white>
+    - Looks only at one- or two-line comments immediately followed by code
+    - Compares meaningful comment words with tokens/concepts from the next statement
+    - Flags obvious cases like \"Set x to 5\", \"Call process\", or \"Loop through items\"
+    - Passes doc comments, TODO/FIXME labels, and comments with why/safety/performance signals
+
+  <white>Captures:</white>
+    <green>{{ $comment }}</green>        Comment text without the marker
+    <green>{{ $code }}</green>           The adjacent code window being compared
+    <green>{{ $matched_tokens }}</green> Tokens that made the comment look redundant
+
+  <white>When to Use:</white>
+    <green>WhatComment</green>  Enforce \"comments explain why, not what\" without an LLM or network call
+    <green>SyntaxTree</green>   Precise structural rules for one language
+    <green>Regex</green>        Exact text patterns that are cheap and obvious
+
 <bold>External Program Matching</bold>
 
   Use <cyan>kind: External</cyan> to delegate matching to an external program (linter, formatter,
@@ -370,6 +397,22 @@ const DOCS: &str = cstr!("\
                   <yellow>body: (block</yellow>
                     <yellow>(use_declaration</yellow>
                       <yellow>argument: (scoped_identifier) @path)))</yellow>
+
+  <cyan>Block comments that explain what instead of why</cyan>
+
+    <dim># Flags comments like `// Set x to 5` before `let x = 5;`, while</dim>
+    <dim># preserving comments that explain safety, concurrency, performance, etc.</dim>
+
+    <yellow>- name: no-what-comments</yellow>
+      <yellow>description: Comments should explain why, not restate obvious code</yellow>
+      <yellow>message: \"Remove this comment or explain why the code exists, then retry.\"</yellow>
+      <yellow>on:</yellow>
+        <yellow>- hook: PreToolUse</yellow>
+          <yellow>tool: Write</yellow>
+          <yellow>file: \"**/*.rs\"</yellow>
+          <yellow>content:</yellow>
+            <yellow>- kind: WhatComment</yellow>
+              <yellow>language: rust</yellow>
 
   <cyan>Enforce markdown table formatting (External)</cyan>
 

--- a/packages/nudge/src/rules/schema.rs
+++ b/packages/nudge/src/rules/schema.rs
@@ -20,6 +20,7 @@ mod path;
 mod project_state;
 mod syntax;
 mod url;
+mod what_comment;
 
 /// A rule configuration file.
 #[derive(Debug, Clone, Deserialize)]

--- a/packages/nudge/src/rules/schema/content.rs
+++ b/packages/nudge/src/rules/schema/content.rs
@@ -14,7 +14,7 @@ use crate::{
     template::{self, Captures},
 };
 
-use super::{Language, TreeSitterQuery, syntax::union_of_captures};
+use super::{Language, TreeSitterQuery, syntax::union_of_captures, what_comment};
 
 /// The method used to match hook content.
 ///
@@ -70,6 +70,16 @@ pub enum ContentMatcher {
         /// The command to run, as a list of arguments.
         command: Vec<String>,
     },
+
+    /// Match comments that restate obvious code instead of explaining why.
+    WhatComment {
+        /// The language grammar/comment style to use.
+        language: Language,
+
+        /// Optional suggestion template, same as Regex.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        suggestion: Option<String>,
+    },
 }
 
 impl<'de> Deserialize<'de> for ContentMatcher {
@@ -121,9 +131,18 @@ impl<'de> Deserialize<'de> for ContentMatcher {
                 }
                 Ok(ContentMatcher::External { command })
             }
+            "WhatComment" => {
+                let language = raw
+                    .language
+                    .ok_or_else(|| serde::de::Error::missing_field("language"))?;
+                Ok(ContentMatcher::WhatComment {
+                    language,
+                    suggestion: raw.suggestion,
+                })
+            }
             other => Err(serde::de::Error::unknown_variant(
                 other,
-                &["Regex", "SyntaxTree", "External"],
+                &["Regex", "SyntaxTree", "External", "WhatComment"],
             )),
         }
     }
@@ -141,6 +160,10 @@ impl ContentMatcher {
                 .next()
                 .is_some(),
             ContentMatcher::External { command } => run_external_command(command, s).is_some(),
+            ContentMatcher::WhatComment { language, .. } => what_comment::matches(*language, s)
+                .into_iter()
+                .next()
+                .is_some(),
         }
     }
 
@@ -161,6 +184,10 @@ impl ContentMatcher {
                     Vec::new()
                 }
             }
+            ContentMatcher::WhatComment { language, .. } => what_comment::matches(*language, s)
+                .into_iter()
+                .map(|m| m.span)
+                .collect(),
         }
     }
 
@@ -195,6 +222,14 @@ impl ContentMatcher {
                 } else {
                     Vec::new()
                 }
+            }
+            ContentMatcher::WhatComment {
+                language,
+                suggestion,
+            } => {
+                let mut matches = what_comment::matches(*language, s);
+                apply_suggestion(&mut matches, suggestion);
+                matches
             }
         }
     }
@@ -609,5 +644,38 @@ mod tests {
         };
         assert!(!matcher.is_match("haystack with needle inside"));
         assert!(matcher.is_match("haystack without the search term"));
+    }
+
+    #[test]
+    fn test_what_comment_deserialize() {
+        let yaml = r#"
+            kind: WhatComment
+            language: rust
+        "#;
+        let matcher =
+            serde_yaml::from_str::<ContentMatcher>(yaml).expect("valid what-comment matcher yaml");
+        assert!(matches!(matcher, ContentMatcher::WhatComment { .. }));
+    }
+
+    #[test]
+    fn test_what_comment_captures_comment_and_code() {
+        let matcher = ContentMatcher::WhatComment {
+            language: Language::Rust,
+            suggestion: None,
+        };
+        let matches = matcher.matches_with_context(
+            "// Rename the temp file to the target path\n\
+             tokio::fs::rename(temp_path, target).await?;\n",
+        );
+
+        pretty_assert_eq!(matches.len(), 1);
+        pretty_assert_eq!(
+            matches[0].captures.get("comment"),
+            Some(&"Rename the temp file to the target path".to_string())
+        );
+        pretty_assert_eq!(
+            matches[0].captures.get("code"),
+            Some(&"tokio::fs::rename(temp_path, target).await?;".to_string())
+        );
     }
 }

--- a/packages/nudge/src/rules/schema/what_comment.rs
+++ b/packages/nudge/src/rules/schema/what_comment.rs
@@ -1,0 +1,686 @@
+use std::{collections::HashSet, sync::LazyLock};
+
+use crate::{
+    snippet::{Match, Span},
+    template::Captures,
+};
+
+use super::Language;
+
+const MAX_COMMENT_LINES: usize = 2;
+const MAX_COMMENT_TOKENS: usize = 14;
+const MAX_CODE_LINES: usize = 5;
+
+#[derive(Clone, Copy, Debug)]
+struct SourceLine<'a> {
+    start: usize,
+    end: usize,
+    text: &'a str,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct LineComment<'a> {
+    marker_start: usize,
+    end: usize,
+    text: &'a str,
+}
+
+#[derive(Debug)]
+struct CommentGroup {
+    span: Span,
+    text: String,
+    line_count: usize,
+    has_metadata_label: bool,
+}
+
+pub(super) fn matches(language: Language, source: &str) -> Vec<Match> {
+    let lines = source_lines(source);
+    let mut matches = Vec::new();
+    let mut index = 0;
+
+    while index < lines.len() {
+        let Some((group, next_index)) = comment_group(language, &lines, index) else {
+            index += 1;
+            continue;
+        };
+
+        index = next_index;
+
+        if group.line_count > MAX_COMMENT_LINES
+            || group.has_metadata_label
+            || next_index >= lines.len()
+            || lines[next_index].text.trim().is_empty()
+            || line_comment(language, lines[next_index]).is_some()
+        {
+            continue;
+        }
+
+        let code = code_window(language, &lines, next_index);
+        if let Some(matched_tokens) = obvious_restatement(&group.text, &code) {
+            let mut captures = Captures::new();
+            captures.insert("comment".to_string(), group.text.clone());
+            captures.insert("code".to_string(), code.trim().to_string());
+            captures.insert("matched_tokens".to_string(), matched_tokens.join(", "));
+            matches.push(Match {
+                span: group.span,
+                captures,
+            });
+        }
+    }
+
+    matches
+}
+
+fn source_lines(source: &str) -> Vec<SourceLine<'_>> {
+    let mut lines = Vec::new();
+    let mut start = 0;
+
+    for segment in source.split_inclusive('\n') {
+        let without_lf = segment.strip_suffix('\n').unwrap_or(segment);
+        let text = without_lf.strip_suffix('\r').unwrap_or(without_lf);
+        let end = start + text.len();
+        lines.push(SourceLine { start, end, text });
+        start += segment.len();
+    }
+
+    if !source.is_empty() && !source.ends_with('\n') && lines.is_empty() {
+        lines.push(SourceLine {
+            start: 0,
+            end: source.len(),
+            text: source,
+        });
+    }
+
+    lines
+}
+
+fn comment_group(
+    language: Language,
+    lines: &[SourceLine<'_>],
+    start_index: usize,
+) -> Option<(CommentGroup, usize)> {
+    let first = line_comment(language, lines[start_index])?;
+    let mut parts = Vec::from([first.text.trim().to_string()]);
+    let mut end = first.end;
+    let mut line_count = 1;
+    let mut contains_metadata_label = has_metadata_label(first.text);
+    let mut index = start_index + 1;
+
+    while index < lines.len() {
+        let Some(comment) = line_comment(language, lines[index]) else {
+            break;
+        };
+
+        parts.push(comment.text.trim().to_string());
+        end = comment.end;
+        line_count += 1;
+        contains_metadata_label |= has_metadata_label(comment.text);
+        index += 1;
+    }
+
+    Some((
+        CommentGroup {
+            span: Span {
+                start: first.marker_start,
+                end,
+            },
+            text: parts.join(" ").trim().to_string(),
+            line_count,
+            has_metadata_label: contains_metadata_label,
+        },
+        index,
+    ))
+}
+
+fn line_comment<'a>(language: Language, line: SourceLine<'a>) -> Option<LineComment<'a>> {
+    let trimmed = line.text.trim_start();
+    let leading = line.text.len() - trimmed.len();
+    let prefix = line_comment_prefix(language);
+
+    if !trimmed.starts_with(prefix) || is_doc_comment(language, trimmed) {
+        return None;
+    }
+
+    let text = trimmed[prefix.len()..].trim_start();
+    Some(LineComment {
+        marker_start: line.start + leading,
+        end: line.end,
+        text,
+    })
+}
+
+fn line_comment_prefix(language: Language) -> &'static str {
+    match language {
+        Language::Python => "#",
+        Language::Haskell => "--",
+        Language::Rust
+        | Language::TypeScript
+        | Language::JavaScript
+        | Language::Go
+        | Language::Java
+        | Language::CSharp
+        | Language::Kotlin => "//",
+    }
+}
+
+fn is_doc_comment(language: Language, trimmed: &str) -> bool {
+    match language {
+        Language::Rust => {
+            trimmed.starts_with("///")
+                || trimmed.starts_with("//!")
+                || trimmed.starts_with("/**")
+                || trimmed.starts_with("/*!")
+        }
+        Language::Java | Language::JavaScript | Language::TypeScript | Language::Go => {
+            trimmed.starts_with("/**")
+        }
+        Language::Kotlin | Language::CSharp => {
+            trimmed.starts_with("///") || trimmed.starts_with("/**")
+        }
+        Language::Python => {
+            trimmed.starts_with("#!")
+                || trimmed.starts_with("# type:")
+                || trimmed.starts_with("# noqa")
+                || trimmed.starts_with("# pylint:")
+                || trimmed.starts_with("# fmt:")
+        }
+        Language::Haskell => trimmed.starts_with("-- |") || trimmed.starts_with("-- ^"),
+    }
+}
+
+fn code_window(language: Language, lines: &[SourceLine<'_>], start_index: usize) -> String {
+    let first = lines[start_index].text.trim();
+    let mut code = first.to_string();
+
+    if !opens_block(language, first) {
+        return code;
+    }
+
+    for line in lines.iter().skip(start_index + 1).take(MAX_CODE_LINES - 1) {
+        let trimmed = line.text.trim();
+        if trimmed.is_empty() || line_comment(language, *line).is_some() {
+            break;
+        }
+
+        code.push('\n');
+        code.push_str(trimmed);
+
+        if closes_block(language, trimmed) {
+            break;
+        }
+    }
+
+    code
+}
+
+fn opens_block(language: Language, code: &str) -> bool {
+    let trimmed = code.trim();
+    match language {
+        Language::Python => trimmed.ends_with(':'),
+        Language::Haskell => false,
+        _ => {
+            let opens = trimmed.matches('{').count();
+            let closes = trimmed.matches('}').count();
+            opens > closes
+        }
+    }
+}
+
+fn closes_block(language: Language, code: &str) -> bool {
+    match language {
+        Language::Python => false,
+        Language::Haskell => false,
+        _ => code.trim().contains('}'),
+    }
+}
+
+fn obvious_restatement(comment: &str, code: &str) -> Option<Vec<String>> {
+    if has_why_signal(comment) {
+        return None;
+    }
+
+    let comment_tokens = meaningful_tokens(comment);
+    let comment_set = token_set(&comment_tokens);
+    if comment_set.len() < 2 || comment_set.len() > MAX_COMMENT_TOKENS {
+        return None;
+    }
+
+    let code_set = code_token_set(code);
+    if code_set.is_empty() || !is_actionish(&comment_tokens) {
+        return None;
+    }
+
+    let mut matched = comment_set
+        .intersection(&code_set)
+        .cloned()
+        .collect::<Vec<_>>();
+    matched.sort();
+
+    let overlap = matched.len();
+    let ratio = overlap as f32 / comment_set.len() as f32;
+    let first = comment_tokens
+        .first()
+        .map(String::as_str)
+        .unwrap_or_default();
+    let first_action_matches = strong_action_verbs().contains(first) && code_set.contains(first);
+
+    if (overlap >= 3 && ratio >= 0.50)
+        || (overlap >= 2 && ratio >= 0.67)
+        || (comment_set.len() <= 3 && overlap >= 1 && first_action_matches)
+    {
+        Some(matched)
+    } else {
+        None
+    }
+}
+
+fn has_metadata_label(comment: &str) -> bool {
+    let normalized = comment.trim_start().to_ascii_lowercase();
+    let labels = [
+        "todo",
+        "fixme",
+        "safety",
+        "note",
+        "hack",
+        "warning",
+        "warn",
+        "invariant",
+        "perf",
+        "security",
+        "compat",
+        "legacy",
+    ];
+
+    labels.iter().any(|label| {
+        normalized == *label
+            || normalized
+                .strip_prefix(label)
+                .is_some_and(|rest| rest.starts_with(':') || rest.starts_with('('))
+    })
+}
+
+fn has_why_signal(comment: &str) -> bool {
+    let lower = comment.to_ascii_lowercase();
+    let phrases = [
+        "because",
+        "so that",
+        "in order to",
+        "to avoid",
+        "to prevent",
+        "to ensure",
+        "must not",
+        "must never",
+        "do not",
+        "don't",
+        "cannot",
+        "can't",
+        "never ",
+        "without ",
+    ];
+
+    if phrases.iter().any(|phrase| lower.contains(phrase)) {
+        return true;
+    }
+
+    let tokens = token_set(&meaningful_tokens(comment));
+    why_tokens().iter().any(|token| tokens.contains(*token))
+}
+
+fn meaningful_tokens(text: &str) -> Vec<String> {
+    raw_words(text)
+        .into_iter()
+        .flat_map(|word| token_variants(&word))
+        .filter(|token| !stop_words().contains(token.as_str()))
+        .collect()
+}
+
+fn raw_words(text: &str) -> Vec<String> {
+    let mut words = Vec::new();
+    let mut current = String::new();
+
+    for ch in text.chars() {
+        if ch.is_alphanumeric() {
+            current.push(ch);
+        } else {
+            push_split_word(&mut words, &current);
+            current.clear();
+        }
+    }
+
+    push_split_word(&mut words, &current);
+    words
+}
+
+fn push_split_word(words: &mut Vec<String>, raw: &str) {
+    if raw.is_empty() {
+        return;
+    }
+
+    let mut start = 0;
+    let chars = raw.char_indices().collect::<Vec<_>>();
+    for window in chars.windows(2) {
+        let (_, ch) = window[0];
+        let (next_index, next) = window[1];
+        let split = (ch.is_lowercase() && next.is_uppercase())
+            || (ch.is_alphabetic() && next.is_ascii_digit())
+            || (ch.is_ascii_digit() && next.is_alphabetic());
+
+        if split {
+            words.push(raw[start..next_index].to_ascii_lowercase());
+            start = next_index;
+        }
+    }
+
+    words.push(raw[start..].to_ascii_lowercase());
+}
+
+fn token_variants(word: &str) -> Vec<String> {
+    let normalized = normalize_token(word);
+    let mut variants = Vec::from([normalized.clone()]);
+
+    if let Some(stripped) = normalized.strip_suffix("ies") {
+        variants.push(format!("{stripped}y"));
+    } else if let Some(stripped) = normalized.strip_suffix("ing")
+        && stripped.len() > 2
+    {
+        variants.push(stripped.to_string());
+        variants.push(format!("{stripped}e"));
+    } else if let Some(stripped) = normalized.strip_suffix("ed")
+        && stripped.len() > 2
+    {
+        variants.push(stripped.to_string());
+    } else if let Some(stripped) = normalized.strip_suffix("es")
+        && stripped.len() > 2
+    {
+        variants.push(stripped.to_string());
+    } else if let Some(stripped) = normalized.strip_suffix('s')
+        && stripped.len() > 2
+    {
+        variants.push(stripped.to_string());
+    }
+
+    variants.sort();
+    variants.dedup();
+    variants
+}
+
+fn normalize_token(word: &str) -> String {
+    match word {
+        "func" => "function".to_string(),
+        "fn" => "function".to_string(),
+        "const" | "let" | "var" => "set".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn token_set(tokens: &[String]) -> HashSet<String> {
+    tokens.iter().cloned().collect()
+}
+
+fn code_token_set(code: &str) -> HashSet<String> {
+    let mut tokens = meaningful_tokens(code);
+    let lower = code.to_ascii_lowercase();
+
+    if looks_like_assignment(&lower) {
+        tokens.extend(["set".to_string(), "assign".to_string()]);
+    }
+
+    if looks_like_loop(&lower) {
+        tokens.extend([
+            "loop".to_string(),
+            "iterate".to_string(),
+            "iteration".to_string(),
+        ]);
+    }
+
+    if looks_like_condition(&lower) {
+        tokens.extend([
+            "if".to_string(),
+            "condition".to_string(),
+            "conditional".to_string(),
+        ]);
+    }
+
+    if looks_like_call(&lower) {
+        tokens.extend(["call".to_string(), "function".to_string()]);
+    }
+
+    token_set(&tokens)
+}
+
+fn looks_like_assignment(code: &str) -> bool {
+    code.contains(" = ")
+        || code.contains(":=")
+        || code.contains("+=")
+        || code.contains("-=")
+        || code.contains("*=")
+        || code.contains("/=")
+        || code.trim_start().starts_with("let ")
+        || code.trim_start().starts_with("const ")
+        || code.trim_start().starts_with("var ")
+}
+
+fn looks_like_loop(code: &str) -> bool {
+    let trimmed = code.trim_start();
+    trimmed.starts_with("for ")
+        || trimmed.starts_with("while ")
+        || trimmed.starts_with("loop ")
+        || trimmed.starts_with("for(")
+        || trimmed.starts_with("while(")
+}
+
+fn looks_like_condition(code: &str) -> bool {
+    let trimmed = code.trim_start();
+    trimmed.starts_with("if ")
+        || trimmed.starts_with("if(")
+        || trimmed.starts_with("match ")
+        || trimmed.starts_with("switch ")
+}
+
+fn looks_like_call(code: &str) -> bool {
+    code.contains('(') && !looks_like_loop(code) && !looks_like_condition(code)
+}
+
+fn is_actionish(tokens: &[String]) -> bool {
+    let Some(first) = tokens.first().map(String::as_str) else {
+        return false;
+    };
+
+    action_verbs().contains(first)
+        || tokens
+            .iter()
+            .any(|token| control_words().contains(token.as_str()))
+}
+
+fn stop_words() -> &'static HashSet<&'static str> {
+    static STOP_WORDS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+        HashSet::from([
+            "a", "an", "and", "are", "as", "at", "be", "by", "each", "for", "from", "in", "into",
+            "is", "it", "its", "of", "on", "one", "or", "the", "then", "these", "this", "those",
+            "through", "to", "true", "with",
+        ])
+    });
+    &STOP_WORDS
+}
+
+fn action_verbs() -> &'static HashSet<&'static str> {
+    static ACTION_VERBS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+        HashSet::from([
+            "add",
+            "append",
+            "assign",
+            "build",
+            "call",
+            "calculate",
+            "check",
+            "close",
+            "compute",
+            "convert",
+            "create",
+            "delete",
+            "deserialize",
+            "dispatch",
+            "fetch",
+            "filter",
+            "format",
+            "get",
+            "handle",
+            "hash",
+            "if",
+            "init",
+            "initialize",
+            "insert",
+            "iterate",
+            "load",
+            "log",
+            "loop",
+            "open",
+            "parse",
+            "print",
+            "process",
+            "push",
+            "read",
+            "remove",
+            "rename",
+            "render",
+            "return",
+            "save",
+            "send",
+            "serialize",
+            "set",
+            "sort",
+            "update",
+            "use",
+            "validate",
+            "write",
+        ])
+    });
+    &ACTION_VERBS
+}
+
+fn strong_action_verbs() -> &'static HashSet<&'static str> {
+    static STRONG_ACTION_VERBS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+        HashSet::from([
+            "assign", "call", "check", "delete", "get", "if", "iterate", "loop", "process",
+            "remove", "rename", "return", "set", "update",
+        ])
+    });
+    &STRONG_ACTION_VERBS
+}
+
+fn control_words() -> &'static HashSet<&'static str> {
+    static CONTROL_WORDS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+        HashSet::from([
+            "call",
+            "condition",
+            "conditional",
+            "each",
+            "function",
+            "if",
+            "iterate",
+            "loop",
+            "match",
+            "switch",
+            "while",
+        ])
+    });
+    &CONTROL_WORDS
+}
+
+fn why_tokens() -> &'static HashSet<&'static str> {
+    static WHY_TOKENS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+        HashSet::from([
+            "atomic",
+            "avoid",
+            "backwards",
+            "borrow",
+            "cache",
+            "compatible",
+            "compatibility",
+            "concurrent",
+            "concurrency",
+            "constraint",
+            "database",
+            "deadlock",
+            "deterministic",
+            "expensive",
+            "fast",
+            "guarantee",
+            "idempotent",
+            "invariant",
+            "latency",
+            "legacy",
+            "limit",
+            "lock",
+            "memory",
+            "migration",
+            "migrations",
+            "mutex",
+            "overflow",
+            "panic",
+            "partial",
+            "performance",
+            "plaintext",
+            "pool",
+            "prevent",
+            "race",
+            "regression",
+            "safety",
+            "security",
+            "serial",
+            "slow",
+            "stable",
+            "thread",
+            "unsafe",
+            "workaround",
+        ])
+    });
+    &WHY_TOKENS
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq as pretty_assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn matches_obvious_call_comment() {
+        let source = "// Rename the temp file to the target path\n\
+                      tokio::fs::rename(temp_path, target).await?;\n";
+
+        let matches = matches(Language::Rust, source);
+
+        pretty_assert_eq!(matches.len(), 1);
+        pretty_assert_eq!(
+            matches[0].captures.get("comment"),
+            Some(&"Rename the temp file to the target path".to_string())
+        );
+    }
+
+    #[test]
+    fn preserves_why_comment() {
+        let source = "// Use atomic rename to prevent partial reads during concurrent access\n\
+                      tokio::fs::rename(temp_path, target).await?;\n";
+
+        assert!(matches(Language::Rust, source).is_empty());
+    }
+
+    #[test]
+    fn requires_adjacent_code() {
+        let source = "// Rename the temp file to the target path\n\
+                      \n\
+                      tokio::fs::rename(temp_path, target).await?;\n";
+
+        assert!(matches(Language::Rust, source).is_empty());
+    }
+
+    #[test]
+    fn supports_hash_comments() {
+        let source = "# Set x to 5\nx = 5\n";
+
+        let matches = matches(Language::Python, source);
+
+        pretty_assert_eq!(matches.len(), 1);
+    }
+}

--- a/packages/nudge/tests/it/bash.rs
+++ b/packages/nudge/tests/it/bash.rs
@@ -250,7 +250,6 @@ rules:
                 pattern: "^main$"
 "#;
 
-    // Create git repo on main branch
     let dir = setup_git_repo("main", config);
 
     // Should match: git push on main branch
@@ -291,7 +290,6 @@ rules:
                 pattern: "^main$"
 "#;
 
-    // Create git repo on feature branch
     let dir = setup_git_repo("feature-branch", config);
 
     // Should NOT match: git push on feature branch (not main)
@@ -396,7 +394,6 @@ rules:
                 pattern: "^(main|master)$"
 "#;
 
-    // Create git repo on main branch
     let dir = setup_git_repo("main", config);
 
     // Should match: git push on main branch

--- a/packages/nudge/tests/it/main.rs
+++ b/packages/nudge/tests/it/main.rs
@@ -19,6 +19,7 @@ mod setup;
 mod syntax_tree;
 mod user_prompt;
 mod webfetch;
+mod what_comments;
 
 use std::io::Write as _;
 use std::path::PathBuf;
@@ -173,7 +174,6 @@ fn run_agent_hook(agent: &str, input: &str) -> (i32, String) {
         .spawn()
         .expect("failed to spawn nudge");
 
-    // Write input to stdin
     {
         let stdin = child.stdin.as_mut().expect("failed to get stdin");
         stdin

--- a/packages/nudge/tests/it/what_comments.rs
+++ b/packages/nudge/tests/it/what_comments.rs
@@ -1,0 +1,225 @@
+//! Integration tests for the WhatComment matcher.
+//!
+//! These tests exercise the hook and `nudge check` paths so obvious "what"
+//! comments are caught without blocking comments that explain reasoning.
+
+use std::fs;
+use std::io::Write as _;
+use std::process::{Command, Stdio};
+
+use crate::{edit_hook, nudge_binary, write_hook};
+use pretty_assertions::assert_eq as pretty_assert_eq;
+use tempfile::TempDir;
+
+fn setup_config(rules_yaml: &str) -> TempDir {
+    let dir = TempDir::new().expect("create temp dir");
+    fs::write(dir.path().join(".nudge.yaml"), rules_yaml).expect("write config");
+    dir
+}
+
+fn write_rule() -> &'static str {
+    r#"
+version: 1
+rules:
+  - name: no-what-comments
+    description: Comments should explain why, not restate obvious code
+    message: "Comment restates the next code: {{ $comment }}. Remove it or explain why, then retry."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.rs"
+        content:
+          - kind: WhatComment
+            language: rust
+"#
+}
+
+fn edit_rule() -> &'static str {
+    r#"
+version: 1
+rules:
+  - name: no-what-comments
+    description: Comments should explain why, not restate obvious code
+    message: "Comment restates the next code: {{ $comment }}. Remove it or explain why, then retry."
+    on:
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.rs"
+        new_content:
+          - kind: WhatComment
+            language: rust
+"#
+}
+
+fn run_hook_in_dir(dir: &TempDir, input: &str) -> (i32, String) {
+    let mut child = Command::new(nudge_binary())
+        .args(["claude", "hook"])
+        .current_dir(dir.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn nudge");
+
+    {
+        let stdin = child.stdin.as_mut().expect("failed to get stdin");
+        stdin
+            .write_all(input.as_bytes())
+            .expect("failed to write to stdin");
+    }
+
+    let output = child.wait_with_output().expect("failed to wait for nudge");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = if !stdout.trim().is_empty() {
+        stdout.trim().to_string()
+    } else {
+        stderr.trim().to_string()
+    };
+
+    (output.status.code().unwrap_or(-1), combined)
+}
+
+fn assert_denied(exit_code: i32, output: &str, comment: &str) {
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected interrupt, got: {output}"
+    );
+    assert!(
+        output.contains(comment),
+        "expected output to mention {comment:?}, got: {output}"
+    );
+}
+
+fn assert_passed(exit_code: i32, output: &str) {
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(output.is_empty(), "expected passthrough, got: {output}");
+}
+
+#[test]
+fn detects_obvious_what_comments_on_write() {
+    let dir = setup_config(write_rule());
+
+    let cases = [
+        (
+            "rename call",
+            "// Rename the temp file to the target path\n\
+             tokio::fs::rename(temp_path, target).await?;\n",
+            "Rename the temp file to the target path",
+        ),
+        (
+            "loop body",
+            "// Loop through items and process each one\n\
+             for item in items { process(item); }\n",
+            "Loop through items and process each one",
+        ),
+        (
+            "assignment",
+            "// Set x to 5\n\
+             let x = 5;\n",
+            "Set x to 5",
+        ),
+        (
+            "function call",
+            "// Call the process function\n\
+             process(item);\n",
+            "Call the process function",
+        ),
+    ];
+
+    for (_name, content, comment) in cases {
+        let input = write_hook("src/lib.rs", content);
+        let (exit_code, output) = run_hook_in_dir(&dir, &input);
+        assert_denied(exit_code, &output, comment);
+    }
+}
+
+#[test]
+fn detects_obvious_what_comments_on_edit() {
+    let dir = setup_config(edit_rule());
+    let input = edit_hook("src/lib.rs", "", "// Set retries to 3\nlet retries = 3;\n");
+
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    assert_denied(exit_code, &output, "Set retries to 3");
+}
+
+#[test]
+fn preserves_comments_that_explain_why() {
+    let dir = setup_config(write_rule());
+
+    let cases = [
+        "// Use atomic rename to prevent partial reads during concurrent access\n\
+         tokio::fs::rename(temp_path, target).await?;\n",
+        "// Process in serial to avoid overwhelming the database connection pool\n\
+         for item in items { process(item); }\n",
+        "// SAFETY: ptr is non-null because allocator returned Ok above\n\
+         unsafe { ptr.write(value); }\n",
+        "// Keep this branch for backwards-compatible config migrations\n\
+         if legacy_config.is_some() { migrate(); }\n",
+    ];
+
+    for content in cases {
+        let input = write_hook("src/lib.rs", content);
+        let (exit_code, output) = run_hook_in_dir(&dir, &input);
+        assert_passed(exit_code, &output);
+    }
+}
+
+#[test]
+fn preserves_non_adjacent_and_doc_comments() {
+    let dir = setup_config(write_rule());
+
+    let cases = [
+        "/// Rename the temp file to the target path\n\
+         pub fn rename_temp() {}\n",
+        "// Rename the temp file to the target path\n\
+         \n\
+         tokio::fs::rename(temp_path, target).await?;\n",
+        "// TODO: Set retries from config\n\
+         let retries = 3;\n",
+    ];
+
+    for content in cases {
+        let input = write_hook("src/lib.rs", content);
+        let (exit_code, output) = run_hook_in_dir(&dir, &input);
+        assert_passed(exit_code, &output);
+    }
+}
+
+#[test]
+fn check_reports_the_comment_line() {
+    let dir = setup_config(write_rule());
+    let source_dir = dir.path().join("src");
+    fs::create_dir(&source_dir).expect("create src dir");
+    fs::write(
+        source_dir.join("lib.rs"),
+        "fn rename() {\n    // Rename the temp file to the target path\n    tokio::fs::rename(temp_path, target).await?;\n}\n",
+    )
+    .expect("write source file");
+
+    let output = Command::new(nudge_binary())
+        .args(["check", "src/lib.rs"])
+        .current_dir(dir.path())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run nudge check");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    pretty_assert_eq!(
+        output.status.code().unwrap_or(-1),
+        1,
+        "expected check failure, stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("src/lib.rs:2 [no-what-comments]"),
+        "expected issue on comment line, got stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Rename the temp file to the target path"),
+        "expected captured comment in check output, got stdout: {stdout}"
+    );
+}


### PR DESCRIPTION
## Why this change

- Issue #4 asks Nudge to catch comments that explain what obvious code already says, such as `// Set x to 5` before `let x = 5;`, while preserving comments that explain non-obvious reasoning.
- I chose a deterministic `kind: WhatComment` content matcher instead of an LLM-backed analyzer so hook execution and `nudge check` remain local, fast, reproducible, and testable without API keys or network calls.
- The matcher is intentionally conservative: it only considers short adjacent line comments, compares meaningful comment words against tokens and simple code concepts from the next statement, and skips doc comments, TODO/FIXME-style labels, and comments with reasoning, safety, concurrency, performance, compatibility, or constraint signals.
- The rule surface works anywhere existing `content` / `new_content` matchers work, including PreToolUse Write, PreToolUse Edit, and `nudge check`; it exposes `{{ $comment }}`, `{{ $code }}`, and `{{ $matched_tokens }}` for messages and suggestions.
- The repository now dogfoods the new rule in `.nudge.yaml`, and the redundant comments it surfaced in tests/check code were removed.

Fixes #4.

## Testing steps performed

```text
$ cargo test -p nudge
running 70 tests
...
test result: ok. 70 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

running 1 test
...
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 77 tests
...
test what_comments::check_reports_the_comment_line ... ok
test what_comments::detects_obvious_what_comments_on_edit ... ok
test what_comments::preserves_non_adjacent_and_doc_comments ... ok
test what_comments::preserves_comments_that_explain_why ... ok
test what_comments::detects_obvious_what_comments_on_write ... ok
...
test result: ok. 77 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.76s

running 1 test
...
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

```text
$ cargo clippy -p nudge --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
```

```text
$ cargo run -p nudge -- check
✓ Checked 60 files against 7 rules
  - .nudge.yaml: 7 rules
```

```text
$ git diff --check
# no output
```