### PR TITLE
Add workflow completion gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,10 +48,10 @@ cargo run -p nudge -- check            # Check project files against rules (for 
 ### CLI Structure
 
 ```
-nudge claude hook   - Receives hook JSON on stdin, evaluates rules, outputs response
+nudge claude hook   - Receives hook JSON on stdin, evaluates rules/workflows, outputs response
 nudge claude setup  - Writes hook configuration to .claude/settings.local.json
 nudge claude docs   - Prints documentation for writing rules
-nudge codex hook    - Receives hook JSON on stdin, evaluates rules, outputs response
+nudge codex hook    - Receives hook JSON on stdin, evaluates rules/workflows, outputs response
 nudge codex setup   - Writes hook configuration to .codex/hooks.json
 nudge codex docs    - Prints documentation for writing rules
 nudge test          - Test a specific rule against sample input
@@ -67,33 +67,37 @@ nudge check         - Check project files against rules (CI/linter mode)
 - `src/hook/evaluate.rs` - Provider-neutral rule evaluation
 - `src/hook/response.rs` - Provider-specific response rendering
 - `src/hook/apply_patch.rs` - Codex apply_patch normalization
-- `src/cmd/claude/hook.rs` - Hook command: deserializes input, evaluates rules, emits response
+- `src/workflow.rs` - Opt-in workflow completion gates backed by per-session state
+- `src/cmd/claude/hook.rs` - Hook command: deserializes input, evaluates config, emits response
 - `src/cmd/claude/setup.rs` - Setup command: configures hooks in settings.local.json
 - `src/cmd/claude/docs.rs` - Docs command: prints rule writing guide
-- `src/cmd/codex/hook.rs` - Hook command: deserializes input, evaluates rules, emits response
+- `src/cmd/codex/hook.rs` - Hook command: deserializes input, evaluates config, emits response
 - `src/cmd/codex/setup.rs` - Setup command: configures hooks in hooks.json
 - `src/cmd/codex/docs.rs` - Docs command: prints rule writing guide
 - `src/cmd/test.rs` - Test command: test a rule against sample input
 - `src/cmd/validate.rs` - Validate command: parse and display rule configs
 - `src/cmd/check.rs` - Check command: validate project files against rules for CI
-- `src/rules.rs` - Rule loading from config files
+- `src/rules.rs` - Rule/workflow loading from config files
 - `src/rules/schema.rs` - Rule schema facade and hook matcher types
 - `src/rules/schema/` - Focused matcher implementations for content, glob paths, project state, tree-sitter syntax, and URLs
 - `src/snippet.rs` - Code snippet rendering for rule violations (uses `annotate-snippets`)
 
 ### How Nudge Communicates
 
-When Nudge has something to share, it responds in one of three ways:
+When Nudge has something to share, it responds in these ways:
 
 - **Passthrough**: Nothing to note. Carry on!
 - **Continue**: For UserPromptSubmit hooks, Nudge injects context as plain text
 - **Interrupt**: For PreToolUse hooks, Nudge blocks the operation and explains what to fix
 - **Substitute**: For deterministic PreToolUse Bash rules, Nudge rewrites the command and lets it proceed
+- **Workflow gate**: For active workflows, Nudge blocks Stop with a continuation prompt until the agent confirms done criteria
 
 The response type is determined by the hook type:
 - `PreToolUse` block rules **interrupt** (block provider-supported Write/Edit/WebFetch/Bash operations)
 - `PreToolUse` substitute rules **allow with updated input** (Claude Code and Codex CLI Bash commands)
 - `UserPromptSubmit` rules always **continue** (inject guidance into the conversation)
+- `UserPromptSubmit` workflow matches record the original prompt and done criteria in Nudge state
+- `Stop` workflows return `decision: "block"` until the final assistant message contains the workflow confirmation line
 - `PermissionRequest` is parsed but always **passes through** until Nudge has a permission-specific rule surface
 - `Delete` is normalized but not yet matchable from YAML rules
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ When something matches a rule you've defined:
 - **Interrupt** (PreToolUse rules): Nudge catches the issue *before* it's written and explains what to fix
 - **Substitute** (PreToolUse Bash rules): Nudge rewrites simple deterministic commands, lets the tool proceed, and tells the model what changed
 - **Continue** (UserPromptSubmit rules): Nudge injects context into the conversation to guide the agent
+- **Workflow gate** (Stop workflows): Nudge records the prompt and done criteria, then keeps the agent going until it confirms completion
 - **Passthrough**: No rules matched, everything proceeds normally
 
 ## Example Rules
@@ -89,6 +90,36 @@ rules:
 ```
 
 Substitutions work for Claude Code and Codex CLI. Nudge returns the provider's full updated tool input with only `command` changed, and adds `hookSpecificOutput.additionalContext` so the model sees what was rewritten.
+
+## Workflow Completion Gates
+
+Rules catch local mistakes. Workflows help Nudge ask "are we actually done?" at the end of a turn.
+
+Workflows are opt-in. Add a top-level `workflows:` list to `.nudge.yaml`. When a user prompt matches a workflow's `prompt` patterns, Nudge records that prompt and the configured `done` criteria for the session. On the `Stop` hook, Nudge blocks stopping with a continuation prompt until the assistant includes the exact confirmation line.
+
+```yaml
+version: 1
+workflows:
+  - name: issue-resolution
+    description: Finish issue work before stopping
+    prompt:
+      - kind: Regex
+        pattern: "(?i)issue #[0-9]+|pull request|\\bPR\\b"
+    done:
+      - "Add or update end-to-end tests for the requested behavior."
+      - "Implement the permanent fix."
+      - "Run the relevant tests and report exact proof."
+```
+
+For this workflow, Nudge asks the agent to include this line only after every criterion is complete:
+
+```text
+NUDGE_WORKFLOW_COMPLETE: issue-resolution
+```
+
+If the agent tries to stop without that line, Nudge returns a `decision: "block"` Stop response with the original prompt, the done criteria, and instructions to finish or verify the work. Once the confirmation appears, Nudge clears the session workflow state and lets the turn end.
+
+Workflow state is stored outside the repo in Nudge's per-user data directory. Set `NUDGE_STATE_DIR` when you want to isolate state for tests or automation.
 
 For the full rule syntax and copy-pasteable examples, run `nudge claude docs` or `nudge codex docs`.
 
@@ -174,7 +205,7 @@ nudge check "**/*.rs"
 nudge check || exit 1
 ```
 
-`nudge check` only evaluates file-based block rules for `PreToolUse` Write/Edit matchers. It ignores `action: substitute` rules because substitutions rewrite live Bash hook payloads and need a provider to receive `updatedInput`.
+`nudge check` only evaluates file-based block rules for `PreToolUse` Write/Edit matchers. It ignores `action: substitute` rules because substitutions rewrite live Bash hook payloads and need a provider to receive `updatedInput`. It also ignores workflows because workflows depend on live UserPromptSubmit and Stop hook state.
 
 Example output when violations are found:
 
@@ -239,6 +270,7 @@ echo '{
 
 # Exit 0 with JSON output = Interrupt or Substitute (rule matched)
 # Exit 0 with plain text = Continue (UserPromptSubmit context injected)
+# Exit 0 with {"decision":"block"} = Stop workflow continuation
 # Exit 0 with no output = Passthrough (nothing to note)
 ```
 

--- a/packages/nudge/src/agent/claude.rs
+++ b/packages/nudge/src/agent/claude.rs
@@ -9,7 +9,7 @@ use crate::{
     agent::AgentKind,
     hook::{
         BashInput, DeleteInput, EditInput, HookContext, NudgeHook, PermissionRequest, PreToolUse,
-        ToolUse, UserPromptSubmit, WebFetchInput, WriteInput,
+        Stop, ToolUse, UserPromptSubmit, WebFetchInput, WriteInput,
     },
 };
 
@@ -33,6 +33,14 @@ pub fn parse_hook(raw: Value) -> Result<Vec<NudgeHook>> {
         })]),
         "UserPromptSubmit" => Ok(vec![NudgeHook::UserPromptSubmit(UserPromptSubmit {
             prompt: string_field(&raw, "prompt")?.to_string(),
+            context,
+        })]),
+        "Stop" => Ok(vec![NudgeHook::Stop(Stop {
+            stop_hook_active: raw
+                .get("stop_hook_active")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            last_assistant_message: optional_string(&raw, "last_assistant_message"),
             context,
         })]),
         _ => Ok(vec![NudgeHook::Other]),
@@ -181,6 +189,21 @@ mod tests {
 
         assert!(
             matches!(hooks.as_slice(), [NudgeHook::UserPromptSubmit(payload)] if payload.prompt == "hello")
+        );
+    }
+
+    #[test]
+    fn stop_normalizes_to_stop_state() {
+        let hooks = parse_hook(json!({
+            "hook_event_name": "Stop",
+            "cwd": "/tmp",
+            "stop_hook_active": true,
+            "last_assistant_message": "done"
+        }))
+        .expect("parse hook");
+
+        assert!(
+            matches!(hooks.as_slice(), [NudgeHook::Stop(payload)] if payload.stop_hook_active && payload.last_assistant_message.as_deref() == Some("done"))
         );
     }
 

--- a/packages/nudge/src/agent/codex.rs
+++ b/packages/nudge/src/agent/codex.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use crate::{
     agent::AgentKind,
     hook::{
-        BashInput, HookContext, NudgeHook, PermissionRequest, PreToolUse, ToolUse,
+        BashInput, HookContext, NudgeHook, PermissionRequest, PreToolUse, Stop, ToolUse,
         UserPromptSubmit, apply_patch,
     },
 };
@@ -29,6 +29,14 @@ pub fn parse_hook(raw: Value) -> Result<Vec<NudgeHook>> {
         })]),
         "UserPromptSubmit" => Ok(vec![NudgeHook::UserPromptSubmit(UserPromptSubmit {
             prompt: string_field(&raw, "prompt")?.to_string(),
+            context,
+        })]),
+        "Stop" => Ok(vec![NudgeHook::Stop(Stop {
+            stop_hook_active: raw
+                .get("stop_hook_active")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            last_assistant_message: optional_string(&raw, "last_assistant_message"),
             context,
         })]),
         _ => Ok(vec![NudgeHook::Other]),
@@ -176,6 +184,21 @@ mod tests {
 
         assert!(
             matches!(hooks.as_slice(), [NudgeHook::UserPromptSubmit(payload)] if payload.prompt == "hello")
+        );
+    }
+
+    #[test]
+    fn stop_normalizes_to_stop_state() {
+        let hooks = parse_hook(json!({
+            "hook_event_name": "Stop",
+            "cwd": "/tmp",
+            "stop_hook_active": true,
+            "last_assistant_message": "done"
+        }))
+        .expect("parse hook");
+
+        assert!(
+            matches!(hooks.as_slice(), [NudgeHook::Stop(payload)] if payload.stop_hook_active && payload.last_assistant_message.as_deref() == Some("done"))
         );
     }
 

--- a/packages/nudge/src/cmd/check.rs
+++ b/packages/nudge/src/cmd/check.rs
@@ -13,7 +13,9 @@ use color_eyre::eyre::{Context, Result};
 use glob::Pattern;
 use ignore::WalkBuilder;
 
-use nudge::rules::{self, ContentMatcher, GlobMatcher, Hook, PreToolUseMatcher, Rule, RuleAction};
+use nudge::rules::{
+    self, ContentMatcher, GlobMatcher, Hook, LoadedConfig, PreToolUseMatcher, Rule, RuleAction,
+};
 
 #[derive(Args, Clone, Debug)]
 pub struct Config {
@@ -81,11 +83,14 @@ pub fn main(config: Config) -> Result<()> {
     }
 }
 
-fn collect_file_rules(rules_by_source: &[(PathBuf, Vec<Rule>)]) -> (Vec<FileRule<'_>>, usize) {
-    let total_rules = rules_by_source.iter().map(|(_, rules)| rules.len()).sum();
+fn collect_file_rules(rules_by_source: &[(PathBuf, LoadedConfig)]) -> (Vec<FileRule<'_>>, usize) {
+    let total_rules = rules_by_source
+        .iter()
+        .map(|(_, config)| config.rules.len())
+        .sum();
     let file_rules = rules_by_source
         .iter()
-        .flat_map(|(_, rules)| rules)
+        .flat_map(|(_, config)| &config.rules)
         .flat_map(file_rules_for_rule)
         .collect();
 
@@ -247,19 +252,23 @@ fn byte_offset_to_line(content: &str, offset: usize) -> usize {
 fn print_success(
     checked_files: usize,
     total_rules: usize,
-    rules_by_source: &[(PathBuf, Vec<Rule>)],
+    rules_by_source: &[(PathBuf, LoadedConfig)],
 ) {
     println!(
         "\u{2713} Checked {} files against {} rules",
         checked_files, total_rules
     );
-    for (source, rules) in rules_by_source {
-        if !rules.is_empty() {
+    for (source, config) in rules_by_source {
+        if !config.rules.is_empty() {
             println!(
                 "  - {}: {} {}",
                 source.display(),
-                rules.len(),
-                if rules.len() == 1 { "rule" } else { "rules" }
+                config.rules.len(),
+                if config.rules.len() == 1 {
+                    "rule"
+                } else {
+                    "rules"
+                }
             );
         }
     }

--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -13,7 +13,7 @@ pub fn main(_config: Config) -> Result<()> {
 }
 
 const DOCS: &str = cstr!("\
-<bold><blue>Nudge Rule Writing Guide</blue></bold>
+<bold><blue>Nudge Config Writing Guide</blue></bold>
 
 <bold>What is Nudge?</bold>
 
@@ -25,9 +25,9 @@ const DOCS: &str = cstr!("\
   a colleague tapping you on the shoulder. The messages are direct (sometimes
   blunt) because that's what cuts through when you're focused.
 
-<bold>Rule File Locations</bold>
+<bold>Config File Locations</bold>
 
-  Rules are loaded from these locations (all additive):
+  Rules and workflows are loaded from these locations (all additive):
 
     <cyan>$CONFIG_DIR/rules.yaml</cyan>        <dim>User-level rules</dim>
     <cyan>.nudge.yaml</cyan>                   <dim>Project root</dim>
@@ -66,6 +66,38 @@ const DOCS: &str = cstr!("\
               <yellow>pattern: \"your-regex\"</yellow>
               <yellow>suggestion: \"optional\"</yellow>
 
+<bold>Workflow Format</bold>
+
+  Workflows are opt-in completion gates. They activate on matching user prompts,
+  record the original prompt and done criteria for the session, and use Stop hooks
+  to keep the agent working until it confirms completion.
+
+  <yellow>version: 1</yellow>
+
+  <yellow>workflows:</yellow>
+    <yellow>- name: issue-resolution</yellow>
+      <yellow>description: Finish issue work before stopping</yellow> <dim># Optional</dim>
+      <yellow>prompt:</yellow>                       <dim># All patterns must match to activate</dim>
+        <yellow>- kind: Regex</yellow>
+          <yellow>pattern: \"(?i)issue #[0-9]+|pull request|\\\\bPR\\\\b\"</yellow>
+      <yellow>done:</yellow>
+        <yellow>- \"Add or update end-to-end tests.\"</yellow>
+        <yellow>- \"Implement the permanent fix.\"</yellow>
+        <yellow>- \"Run relevant tests and report exact proof.\"</yellow>
+
+  When active, Nudge tells the agent to include this exact line only after every
+  criterion is complete:
+
+    <green>NUDGE_WORKFLOW_COMPLETE: issue-resolution</green>
+
+  If Stop fires before that line appears, Nudge returns <cyan>decision: \"block\"</cyan>
+  with the original prompt, done criteria, and continuation instructions. Once the
+  confirmation line appears, Nudge clears the session workflow state and lets Stop
+  pass through.
+
+  Workflow state is stored in Nudge's per-user data directory. Set
+  <cyan>NUDGE_STATE_DIR</cyan> to isolate state for tests or automation.
+
 <bold>Hook Types</bold>
 
   <green>PreToolUse</green>        Triggers before provider-supported Write/Edit/WebFetch/Bash
@@ -74,6 +106,10 @@ const DOCS: &str = cstr!("\
 
   <green>UserPromptSubmit</green>  Triggers when user submits a prompt. Always <cyan>continues</cyan>
                     (injects context into the conversation).
+
+  <green>Stop</green>              Triggers when the agent tries to finish. Workflow gates can
+                    return <cyan>decision: \"block\"</cyan> to continue the turn until done
+                    criteria are confirmed.
 
 <bold>Tool Types (PreToolUse only)</bold>
 
@@ -103,6 +139,7 @@ const DOCS: &str = cstr!("\
   <green>PreToolUse Bash</green>              yes             partial, Codex hook coverage is incomplete for some shell paths
   <green>PermissionRequest</green>            parsed only     parsed only
   <green>UserPromptSubmit</green>             yes             yes
+  <green>Stop workflows</green>               yes             yes
 
   <dim>Delete and PermissionRequest are parsed so Nudge can name them precisely, but</dim>
   <dim>they do not have YAML matchers yet. Codex apply_patch is an adapter detail:</dim>

--- a/packages/nudge/src/cmd/claude/hook.rs
+++ b/packages/nudge/src/cmd/claude/hook.rs
@@ -6,7 +6,7 @@ use clap::Args;
 use color_eyre::{Result, eyre::Context};
 use nudge::{
     agent::{AgentKind, claude},
-    hook::{evaluate::evaluate_hooks, response},
+    hook::{evaluate::evaluate_config_hooks, response},
     rules,
 };
 use tracing::instrument;
@@ -20,6 +20,6 @@ pub fn main(_config: Config) -> Result<()> {
     let raw = serde_json::from_reader(stdin).context("read hook event")?;
     let hooks = claude::parse_hook(raw).context("parse Claude hook event")?;
 
-    let rules = rules::load_all().context("load rules")?;
-    response::emit(AgentKind::Claude, evaluate_hooks(&hooks, &rules))
+    let config = rules::load_all().context("load rules")?;
+    response::emit(AgentKind::Claude, evaluate_config_hooks(&hooks, &config)?)
 }

--- a/packages/nudge/src/cmd/claude/setup.rs
+++ b/packages/nudge/src/cmd/claude/setup.rs
@@ -32,9 +32,9 @@ pub struct Config {
 const CLAUDE_MD_SECTION: &str = r#"
 ## Nudge
 
-This project uses [Nudge](https://github.com/attunehq/nudge), a collaborative partner that helps you remember coding conventions. Nudge watches your `Write` and `Edit` operations and reminds you about patterns and preferences that matter here—so you can focus on the actual problem instead of tracking stylistic details.
+This project uses [Nudge](https://github.com/attunehq/nudge), a collaborative partner that helps you remember coding conventions. Nudge watches your `Write` and `Edit` operations and reminds you about patterns and preferences that matter here - so you can focus on the actual problem instead of tracking stylistic details.
 
-**Nudge is on your side.** When it sends you a message, it's not a reprimand—it's a colleague tapping you on the shoulder. The messages are direct (sometimes blunt) because that's what cuts through when you're focused. Trust the feedback and adjust; if a rule feels wrong, mention it so we can fix the rule.
+**Nudge is on your side.** When it sends you a message, it's not a reprimand - it's a colleague tapping you on the shoulder. The messages are direct (sometimes blunt) because that's what cuts through when you're focused. Trust the feedback and adjust; if a rule feels wrong, mention it so we can fix the rule.
 
 **Writing new rules:** If the user asks you to add or modify Nudge rules, run `nudge claude docs` to see the rule format, template variables, and guidelines for writing effective messages.
 "#;
@@ -110,7 +110,8 @@ pub fn main(config: Config) -> Result<()> {
     let nudge_matcher = HookMatcher::builder().hooks([nudge_hook]).build();
     let desired_hooks = [
         ("PreToolUse", nudge_pretooluse_matcher),
-        ("UserPromptSubmit", nudge_matcher),
+        ("UserPromptSubmit", nudge_matcher.clone()),
+        ("Stop", nudge_matcher),
     ];
     tracing::debug!(?desired_hooks, "generate desired hooks");
 
@@ -140,7 +141,6 @@ pub fn main(config: Config) -> Result<()> {
             .map(|(event, matcher)| (event, json!(matcher)));
         json_hooks::merge_hooks(hooks, desired_hooks)?;
         remove_managed_event_hook(hooks, "PostToolUse", &nudge_command);
-        remove_managed_event_hook(hooks, "Stop", &nudge_command);
     }
 
     let settings_json = serde_json::to_string_pretty(&settings).context("serialize settings")?;

--- a/packages/nudge/src/cmd/codex/hook.rs
+++ b/packages/nudge/src/cmd/codex/hook.rs
@@ -6,7 +6,7 @@ use clap::Args;
 use color_eyre::{Result, eyre::Context};
 use nudge::{
     agent::{AgentKind, codex},
-    hook::{evaluate::evaluate_hooks, response},
+    hook::{evaluate::evaluate_config_hooks, response},
     rules,
 };
 use tracing::instrument;
@@ -20,6 +20,6 @@ pub fn main(_config: Config) -> Result<()> {
     let raw = serde_json::from_reader(stdin).context("read hook event")?;
     let hooks = codex::parse_hook(raw).context("parse Codex hook event")?;
 
-    let rules = rules::load_all().context("load rules")?;
-    response::emit(AgentKind::Codex, evaluate_hooks(&hooks, &rules))
+    let config = rules::load_all().context("load rules")?;
+    response::emit(AgentKind::Codex, evaluate_config_hooks(&hooks, &config)?)
 }

--- a/packages/nudge/src/cmd/codex/setup.rs
+++ b/packages/nudge/src/cmd/codex/setup.rs
@@ -63,6 +63,12 @@ pub fn main(config: Config) -> Result<()> {
         (
             "UserPromptSubmit",
             json!({
+                "hooks": [nudge_hook.clone()]
+            }),
+        ),
+        (
+            "Stop",
+            json!({
                 "hooks": [nudge_hook]
             }),
         ),

--- a/packages/nudge/src/cmd/test.rs
+++ b/packages/nudge/src/cmd/test.rs
@@ -45,8 +45,9 @@ pub struct Config {
 }
 
 pub fn main(config: Config) -> Result<()> {
-    let rules = rules::load_all()?;
-    let rule = rules
+    let loaded_config = rules::load_all()?;
+    let rule = loaded_config
+        .rules
         .into_iter()
         .find(|r| r.name == config.rule)
         .ok_or_else(|| eyre!("Rule '{}' not found", config.rule))?;
@@ -83,6 +84,11 @@ pub fn main(config: Config) -> Result<()> {
             println!();
             println!("Matched content:");
             println!("{context}");
+        }
+        HookOutcome::ContinueStop { reason } => {
+            println!("Result: Continue Stop");
+            println!();
+            println!("{reason}");
         }
     }
 

--- a/packages/nudge/src/cmd/validate.rs
+++ b/packages/nudge/src/cmd/validate.rs
@@ -22,12 +22,12 @@ pub fn main(config: Config) -> Result<()> {
 
 /// Validate all discoverable config files.
 fn validate_all() -> Result<()> {
-    let rules = rules::load_all_attributed().context("load rules")?;
-    for (path, rules) in rules {
-        let yaml = serde_yaml::to_string(&rules).context("serialize rules")?;
+    let configs = rules::load_all_attributed().context("load rules")?;
+    for (path, config) in configs {
+        let yaml = serde_yaml::to_string(&config).context("serialize config")?;
         println!("Config file: {path:?}");
         println!("{yaml}");
-        print_codex_warnings(&rules);
+        print_codex_warnings(&config.rules);
         println!("------");
         println!();
     }
@@ -37,10 +37,10 @@ fn validate_all() -> Result<()> {
 
 /// Validate a single config file and print results.
 fn validate_file(path: &Path) -> Result<()> {
-    let rules = rules::load_from(path).context("parse rules file")?;
-    let yaml = serde_yaml::to_string(&rules).context("serialize rules")?;
+    let config = rules::load_from(path).context("parse rules file")?;
+    let yaml = serde_yaml::to_string(&config).context("serialize config")?;
     println!("{yaml}");
-    print_codex_warnings(&rules);
+    print_codex_warnings(&config.rules);
     Ok(())
 }
 

--- a/packages/nudge/src/hook.rs
+++ b/packages/nudge/src/hook.rs
@@ -22,6 +22,9 @@ pub enum NudgeHook {
     /// The user submitted a prompt.
     UserPromptSubmit(UserPromptSubmit),
 
+    /// The agent is trying to stop.
+    Stop(Stop),
+
     /// A hook event Nudge does not currently handle.
     Other,
 }
@@ -86,6 +89,19 @@ pub struct UserPromptSubmit {
 
     /// User prompt text.
     pub prompt: String,
+}
+
+/// Normalized `Stop` event.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Stop {
+    /// Shared hook context.
+    pub context: HookContext,
+
+    /// Whether this stop hook is already a continuation attempt.
+    pub stop_hook_active: bool,
+
+    /// Latest assistant message text, when the provider supplies it.
+    pub last_assistant_message: Option<String>,
 }
 
 /// Normalized tool use.

--- a/packages/nudge/src/hook/evaluate.rs
+++ b/packages/nudge/src/hook/evaluate.rs
@@ -1,5 +1,6 @@
 //! Rule evaluation for normalized hook events.
 
+use color_eyre::eyre::Result;
 use indoc::formatdoc;
 use itertools::Itertools;
 use serde_json::Value;
@@ -10,11 +11,41 @@ use crate::{
         WriteInput, response::HookOutcome,
     },
     rules::{
-        ContentMatcher, PreToolUseBashMatcher, PreToolUseEditMatcher, PreToolUseWebFetchMatcher,
-        PreToolUseWriteMatcher, Rule, RuleAction, UrlMatcher, UserPromptSubmitMatcher,
+        ContentMatcher, LoadedConfig, PreToolUseBashMatcher, PreToolUseEditMatcher,
+        PreToolUseWebFetchMatcher, PreToolUseWriteMatcher, Rule, RuleAction, UrlMatcher,
+        UserPromptSubmitMatcher,
     },
     snippet::{Annotation, Match, Source},
 };
+
+/// Evaluate a normalized hook batch against the full loaded config.
+pub fn evaluate_config_hooks(hooks: &[NudgeHook], config: &LoadedConfig) -> Result<HookOutcome> {
+    let rule_outcome = evaluate_hooks(hooks, &config.rules);
+    let workflow_outcome = crate::workflow::evaluate_hooks(hooks, &config.workflows)?;
+
+    Ok(combine_outcomes(rule_outcome, workflow_outcome))
+}
+
+fn combine_outcomes(rule_outcome: HookOutcome, workflow_outcome: HookOutcome) -> HookOutcome {
+    match (rule_outcome, workflow_outcome) {
+        (HookOutcome::Passthrough, workflow_outcome) => workflow_outcome,
+        (rule_outcome, HookOutcome::Passthrough) => rule_outcome,
+        (
+            HookOutcome::AddContext {
+                context: rule_context,
+            },
+            HookOutcome::AddContext {
+                context: workflow_context,
+            },
+        ) => HookOutcome::AddContext {
+            context: format!("{rule_context}\n\n{workflow_context}"),
+        },
+        (HookOutcome::AddContext { .. }, workflow_outcome @ HookOutcome::ContinueStop { .. }) => {
+            workflow_outcome
+        }
+        (rule_outcome, _) => rule_outcome,
+    }
+}
 
 /// Evaluate a normalized hook batch against loaded rules.
 ///
@@ -35,7 +66,7 @@ pub fn evaluate_hooks(hooks: &[NudgeHook], rules: &[Rule]) -> HookOutcome {
             NudgeHook::UserPromptSubmit(payload) => {
                 user_prompt_matches.extend(evaluate_userpromptsubmit(payload, rules));
             }
-            NudgeHook::PermissionRequest(_) | NudgeHook::Other => {}
+            NudgeHook::PermissionRequest(_) | NudgeHook::Stop(_) | NudgeHook::Other => {}
         }
     }
 

--- a/packages/nudge/src/hook/response.rs
+++ b/packages/nudge/src/hook/response.rs
@@ -35,6 +35,12 @@ pub enum HookOutcome {
         /// Context text.
         context: String,
     },
+
+    /// Prevent a `Stop` event from ending the turn.
+    ContinueStop {
+        /// Feedback sent to the agent as its continuation prompt.
+        reason: String,
+    },
 }
 
 /// Render and print a hook outcome.
@@ -52,6 +58,16 @@ pub fn render(_agent: AgentKind, outcome: HookOutcome) -> Result<RenderedHookOut
     match outcome {
         HookOutcome::Passthrough => Ok(RenderedHookOutcome::NoOutput),
         HookOutcome::AddContext { context } => Ok(RenderedHookOutcome::Stdout(context)),
+        HookOutcome::ContinueStop { reason } => {
+            let response = StopResponse {
+                decision: "block".to_string(),
+                reason,
+            };
+
+            Ok(RenderedHookOutcome::Stdout(
+                serde_json::to_string(&response).context("serialize stop response")?,
+            ))
+        }
         HookOutcome::DenyPreToolUse { message } => {
             let response = PreToolUseResponse {
                 system_message: Some("Nudge blocked operation due to rule violation.".to_string()),
@@ -120,6 +136,13 @@ struct PreToolUseOutput {
     updated_input: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     additional_context: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StopResponse {
+    decision: String,
+    reason: String,
 }
 
 #[cfg(test)]
@@ -234,6 +257,27 @@ mod tests {
         pretty_assert_eq!(
             rendered,
             RenderedHookOutcome::Stdout("remember this".to_string())
+        );
+    }
+
+    #[test]
+    fn stop_continuation_renders_block_decision() {
+        let rendered = render(
+            AgentKind::Codex,
+            HookOutcome::ContinueStop {
+                reason: "Run tests before stopping.".to_string(),
+            },
+        )
+        .expect("render");
+
+        let RenderedHookOutcome::Stdout(output) = rendered else {
+            panic!("expected stdout");
+        };
+        let json = serde_json::from_str::<Value>(&output).expect("valid json");
+        pretty_assert_eq!(json["decision"], Value::String("block".to_string()));
+        pretty_assert_eq!(
+            json["reason"],
+            Value::String("Run tests before stopping.".to_string())
         );
     }
 }

--- a/packages/nudge/src/lib.rs
+++ b/packages/nudge/src/lib.rs
@@ -6,6 +6,7 @@ pub mod hook;
 pub mod rules;
 pub mod snippet;
 pub mod template;
+pub mod workflow;
 
 /// Convenience macro for `filter_map`ing a pattern that contains a single item.
 /// Returns `Some(item)` if the item matches the pattern, `None` otherwise.

--- a/packages/nudge/src/rules.rs
+++ b/packages/nudge/src/rules.rs
@@ -16,6 +16,24 @@ pub use schema::*;
 
 mod schema;
 
+/// Fully parsed Nudge configuration from one or more files.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct LoadedConfig {
+    /// Rule hooks.
+    pub rules: Vec<Rule>,
+
+    /// Workflow completion gates.
+    pub workflows: Vec<Workflow>,
+}
+
+impl LoadedConfig {
+    fn merge(mut self, other: LoadedConfig) -> Self {
+        self.rules.extend(other.rules);
+        self.workflows.extend(other.workflows);
+        self
+    }
+}
+
 /// Get the project directories for the application.
 #[tracing::instrument]
 pub fn project_dirs() -> Option<ProjectDirs> {
@@ -29,11 +47,12 @@ pub fn project_dirs() -> Option<ProjectDirs> {
 /// 2. `.nudge.yaml` if it exists
 /// 3. `.nudge/` directory walked recursively, loading all `*.yaml` files
 #[tracing::instrument]
-pub fn load_all() -> Result<Vec<Rule>> {
+pub fn load_all() -> Result<LoadedConfig> {
     load_all_attributed()?
         .into_iter()
-        .flat_map(|(_, rules)| rules)
-        .collect::<Vec<_>>()
+        .fold(LoadedConfig::default(), |merged, (_, config)| {
+            merged.merge(config)
+        })
         .pipe(Ok)
 }
 
@@ -45,20 +64,20 @@ pub fn load_all() -> Result<Vec<Rule>> {
 /// 2. `.nudge.yaml` if it exists
 /// 3. `.nudge/` directory walked recursively, loading all `*.yaml` files
 #[tracing::instrument]
-pub fn load_all_attributed() -> Result<Vec<(PathBuf, Vec<Rule>)>> {
-    let mut rules = vec![];
+pub fn load_all_attributed() -> Result<Vec<(PathBuf, LoadedConfig)>> {
+    let mut configs = vec![];
 
     if let Some(dirs) = project_dirs() {
         let user_config = dirs.config_dir().join("rules.yaml");
-        let user_rules = load_from(&user_config)
+        let user_config_data = load_from(&user_config)
             .with_context(|| format!("load rules from user config: {user_config:?}"))?;
-        rules.push((user_config, user_rules));
+        configs.push((user_config, user_config_data));
     }
 
     let project_root_config = PathBuf::from(".nudge.yaml");
-    let project_root_rules = load_from(&project_root_config)
+    let project_root_config_data = load_from(&project_root_config)
         .with_context(|| format!("load rules from project root: {project_root_config:?}"))?;
-    rules.push((project_root_config, project_root_rules));
+    configs.push((project_root_config, project_root_config_data));
 
     let root = Path::new(".nudge");
     if root.is_dir() {
@@ -73,29 +92,29 @@ pub fn load_all_attributed() -> Result<Vec<(PathBuf, Vec<Rule>)>> {
 
             if entry.file_type().is_file() {
                 let config = entry.path().to_path_buf();
-                let config_rules = load_from(&config)
+                let config_data = load_from(&config)
                     .with_context(|| format!("load rules from file: {config:?}"))?;
-                rules.push((config, config_rules));
+                configs.push((config, config_data));
             }
         }
     }
 
-    Ok(rules)
+    Ok(configs)
 }
 
 /// Load rules from a single file.
 //
 // TODO: Support other file types.
 #[tracing::instrument]
-pub fn load_from(path: &Path) -> Result<Vec<Rule>> {
+pub fn load_from(path: &Path) -> Result<LoadedConfig> {
     if path.extension() != Some(OsStr::new("yaml")) {
         tracing::debug!("skipping non-yaml file");
-        return Ok(vec![]);
+        return Ok(LoadedConfig::default());
     }
 
     let content = match read_to_string(path) {
         Ok(content) => content,
-        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(vec![]),
+        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(LoadedConfig::default()),
         Err(e) => return Err(e).context(format!("read config file: {path:?}")),
     };
 
@@ -103,7 +122,10 @@ pub fn load_from(path: &Path) -> Result<Vec<Rule>> {
         .with_context(|| format!("parse config file: {path:?}"))
         .with_context(|| content.header("File content:"))
         .tap(|config| tracing::debug!(?config, "parsed config file"))
-        .map(|config| config.rules)
+        .map(|config| LoadedConfig {
+            rules: config.rules,
+            workflows: config.workflows,
+        })
 }
 
 #[cfg(test)]
@@ -112,8 +134,9 @@ mod tests {
 
     #[test]
     fn test_load_nonexistent_file() {
-        let rules =
+        let config =
             load_from(Path::new("nonexistent.yaml")).expect("load returns empty for nonexistent");
-        assert!(rules.is_empty());
+        assert!(config.rules.is_empty());
+        assert!(config.workflows.is_empty());
     }
 }

--- a/packages/nudge/src/rules/schema.rs
+++ b/packages/nudge/src/rules/schema.rs
@@ -28,7 +28,48 @@ pub struct RuleConfig {
     pub version: MustBe!(1),
 
     /// The rules defined in this file.
+    #[serde(default)]
     pub rules: Vec<Rule>,
+
+    /// Workflow completion gates defined in this file.
+    #[serde(default)]
+    pub workflows: Vec<Workflow>,
+}
+
+/// A workflow completion gate.
+///
+/// Workflows are opt-in stop-time checks. A workflow activates when a matching
+/// user prompt is submitted, stores the original prompt for the session, and
+/// asks the agent to confirm all configured done criteria before `Stop` can
+/// pass through.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Workflow {
+    /// Unique identifier for this workflow.
+    pub name: String,
+
+    /// Human-readable description of this workflow.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Prompt patterns that activate this workflow.
+    #[serde(default)]
+    pub prompt: Vec<ContentMatcher>,
+
+    /// Completion criteria the agent must verify before stopping.
+    #[serde(default)]
+    pub done: Vec<String>,
+}
+
+impl Workflow {
+    /// Returns whether this workflow should activate for a user prompt.
+    pub fn matches_prompt(&self, prompt: &str) -> bool {
+        self.prompt.iter().all(|matcher| matcher.is_match(prompt))
+    }
+
+    /// The exact line the agent must include to confirm completion.
+    pub fn confirmation_token(&self) -> String {
+        format!("NUDGE_WORKFLOW_COMPLETE: {}", self.name)
+    }
 }
 
 /// A single rule definition.

--- a/packages/nudge/src/workflow.rs
+++ b/packages/nudge/src/workflow.rs
@@ -1,0 +1,261 @@
+//! Opt-in workflow completion gates.
+
+use std::{
+    collections::{HashSet, hash_map::DefaultHasher},
+    env, fs,
+    hash::{Hash, Hasher},
+    path::PathBuf,
+};
+
+use color_eyre::eyre::{Context, Result};
+use indoc::formatdoc;
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    hook::{NudgeHook, Stop, UserPromptSubmit, response::HookOutcome},
+    rules::{self, Workflow},
+};
+
+/// Evaluate workflow hooks and update per-session workflow state.
+pub fn evaluate_hooks(hooks: &[NudgeHook], workflows: &[Workflow]) -> Result<HookOutcome> {
+    if workflows.is_empty() {
+        return Ok(HookOutcome::Passthrough);
+    }
+
+    let mut contexts = Vec::new();
+
+    for hook in hooks {
+        match hook {
+            NudgeHook::UserPromptSubmit(payload) => {
+                if let Some(context) = activate_workflows(payload, workflows)? {
+                    contexts.push(context);
+                }
+            }
+            NudgeHook::Stop(payload) => {
+                return evaluate_stop(payload, workflows);
+            }
+            NudgeHook::PreToolUse(_) | NudgeHook::PermissionRequest(_) | NudgeHook::Other => {}
+        }
+    }
+
+    if contexts.is_empty() {
+        Ok(HookOutcome::Passthrough)
+    } else {
+        Ok(HookOutcome::AddContext {
+            context: contexts.join("\n\n"),
+        })
+    }
+}
+
+fn activate_workflows(
+    payload: &UserPromptSubmit,
+    workflows: &[Workflow],
+) -> Result<Option<String>> {
+    let active = workflows
+        .iter()
+        .filter(|workflow| workflow.matches_prompt(&payload.prompt))
+        .map(|workflow| ActiveWorkflow {
+            name: workflow.name.clone(),
+            prompt: payload.prompt.clone(),
+            done: workflow.done.clone(),
+            confirmation_token: workflow.confirmation_token(),
+        })
+        .collect::<Vec<_>>();
+
+    if active.is_empty() {
+        clear_state(&payload.context)?;
+        return Ok(None);
+    }
+
+    write_state(
+        &payload.context,
+        &WorkflowState {
+            version: 1,
+            active: active.clone(),
+        },
+    )?;
+
+    Ok(Some(activation_context(&active)))
+}
+
+fn evaluate_stop(payload: &Stop, workflows: &[Workflow]) -> Result<HookOutcome> {
+    let Some(mut state) = read_state(&payload.context)? else {
+        return Ok(HookOutcome::Passthrough);
+    };
+
+    let configured_workflows = workflows
+        .iter()
+        .map(|workflow| workflow.name.as_str())
+        .collect::<HashSet<_>>();
+    state
+        .active
+        .retain(|workflow| configured_workflows.contains(workflow.name.as_str()));
+
+    if state.active.is_empty() {
+        clear_state(&payload.context)?;
+        return Ok(HookOutcome::Passthrough);
+    }
+
+    let last_assistant_message = payload
+        .last_assistant_message
+        .as_deref()
+        .unwrap_or_default();
+    let pending = state
+        .active
+        .iter()
+        .filter(|workflow| !last_assistant_message.contains(&workflow.confirmation_token))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    if pending.is_empty() {
+        clear_state(&payload.context)?;
+        return Ok(HookOutcome::Passthrough);
+    }
+
+    Ok(HookOutcome::ContinueStop {
+        reason: continuation_prompt(&pending, payload.stop_hook_active),
+    })
+}
+
+fn activation_context(active: &[ActiveWorkflow]) -> String {
+    active.iter().map(activation_context_for).join("\n\n")
+}
+
+fn activation_context_for(workflow: &ActiveWorkflow) -> String {
+    let criteria = criteria_list(&workflow.done);
+    formatdoc! {"
+        Nudge workflow `{name}` is active for this prompt.
+
+        Original user prompt:
+        {prompt}
+
+        Done criteria:
+        {criteria}
+
+        Before your final answer, verify every criterion against the actual work. If any criterion is incomplete, keep working. When every criterion is complete, include this exact line in your final assistant message:
+        {token}
+    ",
+        name = workflow.name,
+        prompt = workflow.prompt,
+        criteria = criteria,
+        token = workflow.confirmation_token,
+    }
+}
+
+fn continuation_prompt(pending: &[ActiveWorkflow], stop_hook_active: bool) -> String {
+    let retry_note = if stop_hook_active {
+        "This is already a stop-hook continuation attempt. Do not repeat the same final answer unless you have verified the criteria."
+    } else {
+        "You are trying to stop before Nudge has seen workflow completion confirmation."
+    };
+    let workflows = pending.iter().map(continuation_prompt_for).join("\n\n");
+
+    formatdoc! {"
+        {retry_note}
+
+        Evaluate the active workflow criteria below against the work you actually completed. If anything is missing, do the missing work and validation now. If every criterion is complete, respond with a concise final summary and include each exact confirmation line shown.
+
+        {workflows}
+    "}
+}
+
+fn continuation_prompt_for(workflow: &ActiveWorkflow) -> String {
+    let criteria = criteria_list(&workflow.done);
+    formatdoc! {"
+        Workflow: `{name}`
+
+        Original user prompt:
+        {prompt}
+
+        Done criteria:
+        {criteria}
+
+        Required confirmation line:
+        {token}
+    ",
+        name = workflow.name,
+        prompt = workflow.prompt,
+        criteria = criteria,
+        token = workflow.confirmation_token,
+    }
+}
+
+fn criteria_list(done: &[String]) -> String {
+    if done.is_empty() {
+        return "- No explicit criteria configured. Confirm the user's prompt is fully satisfied."
+            .to_string();
+    }
+
+    done.iter()
+        .map(|criterion| format!("- {criterion}"))
+        .join("\n")
+}
+
+fn read_state(context: &crate::hook::HookContext) -> Result<Option<WorkflowState>> {
+    let path = state_path(context)?;
+    let content = match fs::read_to_string(&path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error).with_context(|| format!("read workflow state: {path:?}")),
+    };
+
+    serde_json::from_str(&content)
+        .with_context(|| format!("parse workflow state: {path:?}"))
+        .map(Some)
+}
+
+fn write_state(context: &crate::hook::HookContext, state: &WorkflowState) -> Result<()> {
+    let path = state_path(context)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create workflow state directory: {parent:?}"))?;
+    }
+    let content = serde_json::to_string_pretty(state).context("serialize workflow state")?;
+    fs::write(&path, content).with_context(|| format!("write workflow state: {path:?}"))
+}
+
+fn clear_state(context: &crate::hook::HookContext) -> Result<()> {
+    let path = state_path(context)?;
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).with_context(|| format!("remove workflow state: {path:?}")),
+    }
+}
+
+fn state_path(context: &crate::hook::HookContext) -> Result<PathBuf> {
+    Ok(state_dir().join(format!("{}.json", state_key(context))))
+}
+
+fn state_dir() -> PathBuf {
+    if let Some(path) = env::var_os("NUDGE_STATE_DIR") {
+        return PathBuf::from(path);
+    }
+
+    rules::project_dirs()
+        .map(|dirs| dirs.data_local_dir().join("workflow-state"))
+        .unwrap_or_else(|| env::temp_dir().join("nudge-workflow-state"))
+}
+
+fn state_key(context: &crate::hook::HookContext) -> String {
+    let mut hasher = DefaultHasher::new();
+    format!("{:?}", context.agent).hash(&mut hasher);
+    context.session_id.hash(&mut hasher);
+    context.cwd.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WorkflowState {
+    version: u8,
+    active: Vec<ActiveWorkflow>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ActiveWorkflow {
+    name: String,
+    prompt: String,
+    done: Vec<String>,
+    confirmation_token: String,
+}

--- a/packages/nudge/tests/it/main.rs
+++ b/packages/nudge/tests/it/main.rs
@@ -19,6 +19,7 @@ mod setup;
 mod syntax_tree;
 mod user_prompt;
 mod webfetch;
+mod workflow;
 
 use std::io::Write as _;
 use std::path::PathBuf;
@@ -91,6 +92,21 @@ pub fn user_prompt_hook(prompt: &str) -> String {
         "permission_mode": "default",
         "cwd": "/tmp",
         "prompt": prompt
+    })
+    .to_string()
+}
+
+/// Build a Stop hook JSON payload.
+pub fn stop_hook(last_assistant_message: &str) -> String {
+    serde_json::json!({
+        "hook_event_name": "Stop",
+        "session_id": "test",
+        "turn_id": "turn",
+        "transcript_path": "/tmp/test",
+        "permission_mode": "default",
+        "cwd": "/tmp",
+        "stop_hook_active": false,
+        "last_assistant_message": last_assistant_message
     })
     .to_string()
 }

--- a/packages/nudge/tests/it/setup.rs
+++ b/packages/nudge/tests/it/setup.rs
@@ -45,7 +45,7 @@ fn run_built_nudge_in(dir: &TempDir, args: &[&str]) -> (i32, String, String) {
 }
 
 #[test]
-fn claude_setup_is_idempotent_and_installs_only_handled_events() {
+fn claude_setup_is_idempotent_and_installs_handled_events() {
     let temp = TempDir::new().expect("temp dir");
     let claude_dir = temp.path().join(".claude");
     let claude_dir = claude_dir.to_str().expect("utf-8 path");
@@ -72,8 +72,8 @@ fn claude_setup_is_idempotent_and_installs_only_handled_events() {
     let json = serde_json::from_str::<Value>(&second).expect("valid json");
     assert!(json["hooks"]["PreToolUse"].is_array());
     assert!(json["hooks"]["UserPromptSubmit"].is_array());
+    assert!(json["hooks"]["Stop"].is_array());
     assert!(json["hooks"].get("PostToolUse").is_none());
-    assert!(json["hooks"].get("Stop").is_none());
     pretty_assert_eq!(
         json["hooks"]["PreToolUse"][0]["matcher"],
         "Write|Edit|WebFetch|Bash"
@@ -87,11 +87,6 @@ fn claude_setup_is_idempotent_and_installs_only_handled_events() {
     with_old_events["hooks"]["PostToolUse"] = json!([
         {
             "matcher": "*",
-            "hooks": [{ "type": "command", "command": command, "timeout": 5 }]
-        }
-    ]);
-    with_old_events["hooks"]["Stop"] = json!([
-        {
             "hooks": [{ "type": "command", "command": command, "timeout": 5 }]
         }
     ]);
@@ -109,7 +104,7 @@ fn claude_setup_is_idempotent_and_installs_only_handled_events() {
     )
     .expect("valid json");
     assert!(cleaned["hooks"].get("PostToolUse").is_none());
-    assert!(cleaned["hooks"].get("Stop").is_none());
+    assert!(cleaned["hooks"]["Stop"].is_array());
 }
 
 #[test]
@@ -135,6 +130,7 @@ fn codex_setup_creates_hooks_json_and_is_idempotent() {
         "Bash|apply_patch"
     );
     assert!(json["hooks"]["UserPromptSubmit"][0]["hooks"].is_array());
+    assert!(json["hooks"]["Stop"][0]["hooks"].is_array());
 }
 
 #[test]

--- a/packages/nudge/tests/it/workflow.rs
+++ b/packages/nudge/tests/it/workflow.rs
@@ -1,0 +1,126 @@
+//! Workflow-management integration tests.
+
+use std::fs;
+use std::io::Write as _;
+use std::process::{Command, Stdio};
+
+use pretty_assertions::assert_eq as pretty_assert_eq;
+use serde_json::Value;
+use tempfile::TempDir;
+
+use crate::{nudge_binary, stop_hook, user_prompt_hook};
+
+#[test]
+fn workflow_blocks_stop_until_the_agent_confirms_completion() {
+    let temp = TempDir::new().expect("temp dir");
+    write_workflow_config(&temp);
+
+    let prompt = user_prompt_hook("Fix issue #8 and prove it with tests.");
+    let (exit_code, output) = run_codex_hook_in_dir(&temp, &prompt);
+
+    pretty_assert_eq!(exit_code, 0, "prompt hook failed: {output}");
+    assert!(
+        output.contains("Nudge workflow `issue-resolution` is active"),
+        "expected workflow activation context, got: {output}"
+    );
+    assert!(
+        output.contains("NUDGE_WORKFLOW_COMPLETE: issue-resolution"),
+        "expected confirmation token guidance, got: {output}"
+    );
+
+    let stop = stop_hook("Implemented the change.");
+    let (exit_code, output) = run_codex_hook_in_dir(&temp, &stop);
+
+    pretty_assert_eq!(exit_code, 0, "stop hook failed: {output}");
+    let json = serde_json::from_str::<Value>(&output).expect("valid stop json");
+    pretty_assert_eq!(json["decision"], "block");
+    assert!(
+        json["reason"]
+            .as_str()
+            .is_some_and(|reason| reason.contains("Fix issue #8")
+                && reason.contains("Add end-to-end tests")
+                && reason.contains("NUDGE_WORKFLOW_COMPLETE: issue-resolution")),
+        "expected continuation reason to include prompt, criteria, and token, got: {output}"
+    );
+}
+
+#[test]
+fn workflow_allows_stop_after_the_agent_confirms_completion() {
+    let temp = TempDir::new().expect("temp dir");
+    write_workflow_config(&temp);
+
+    let prompt = user_prompt_hook("Fix issue #8 and prove it with tests.");
+    let (exit_code, output) = run_codex_hook_in_dir(&temp, &prompt);
+    pretty_assert_eq!(exit_code, 0, "prompt hook failed: {output}");
+
+    let stop = stop_hook(
+        "All requested work is complete.\nNUDGE_WORKFLOW_COMPLETE: issue-resolution\nTests: cargo test -p nudge",
+    );
+    let (exit_code, output) = run_codex_hook_in_dir(&temp, &stop);
+
+    pretty_assert_eq!(exit_code, 0, "stop hook failed: {output}");
+    assert!(
+        output.is_empty(),
+        "expected confirmed workflow to pass through, got: {output}"
+    );
+
+    let (exit_code, output) = run_codex_hook_in_dir(&temp, &stop);
+    pretty_assert_eq!(exit_code, 0, "stop hook failed: {output}");
+    assert!(
+        output.is_empty(),
+        "expected confirmed workflow state to be cleared, got: {output}"
+    );
+}
+
+fn write_workflow_config(temp: &TempDir) {
+    fs::write(
+        temp.path().join(".nudge.yaml"),
+        r#"
+version: 1
+workflows:
+  - name: issue-resolution
+    description: Complete GitHub issue work before stopping
+    prompt:
+      - kind: Regex
+        pattern: "(?i)issue #8"
+    done:
+      - "Add end-to-end tests for done and not-done outcomes."
+      - "Implement the permanent fix."
+      - "Run the relevant tests and report proof."
+"#,
+    )
+    .expect("write config");
+}
+
+fn run_codex_hook_in_dir(dir: &TempDir, input: &str) -> (i32, String) {
+    let state_dir = dir.path().join(".nudge-state");
+    fs::create_dir_all(&state_dir).expect("create state dir");
+
+    let mut child = Command::new(nudge_binary())
+        .args(["codex", "hook"])
+        .current_dir(dir.path())
+        .env("NUDGE_STATE_DIR", &state_dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn nudge");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(input.as_bytes())
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("wait for nudge");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = if !stdout.trim().is_empty() {
+        stdout.trim().to_string()
+    } else {
+        stderr.trim().to_string()
+    };
+
+    (output.status.code().unwrap_or(-1), combined)
+}


### PR DESCRIPTION
## Why this change

Issue #8 asks Nudge to help decide whether an agent is actually finished, not only whether an individual tool call or prompt matches a convention. The missing behavior was that Nudge had no `Stop` hook model, no way to remember a prompt's done criteria across hook invocations, and no provider response that could keep the turn alive until completion was confirmed.

This PR adds the concrete, opt-in version of that workflow management loop: `workflows:` config entries activate on matching `UserPromptSubmit` prompts, persist the original prompt and done criteria for the session, and block `Stop` with a continuation prompt until the assistant includes the workflow's exact completion confirmation line.

Closes #8.

## What changed

- Added a top-level `workflows:` config surface with `prompt` matchers and `done` criteria.
- Added normalized `Stop` hook support for Claude Code and Codex CLI payloads.
- Added per-session workflow state stored outside the repo, with `NUDGE_STATE_DIR` for isolated tests/automation.
- Added `Stop` response rendering as `{"decision":"block","reason":...}` so providers continue the turn.
- Updated Claude and Codex setup to install Nudge on `Stop` hooks.
- Updated README, AGENTS.md, and `nudge claude docs` / `nudge codex docs` to explain workflows and setup implications.
- Added end-to-end workflow tests for both not-done and done outcomes.

Breaking/internal API note: `rules::load_all`, `load_all_attributed`, and `load_from` now return a `LoadedConfig` containing both `rules` and `workflows` instead of only `Vec<Rule>`. Existing YAML rule files still work because `rules:` now defaults to an empty list.

## Testing steps performed

Before implementation, the new workflow integration tests failed against the missing behavior:

```text
cargo test -p nudge --test it workflow -- --nocapture
...
missing field `rules` at line 2 column 1
workflow::workflow_blocks_stop_until_the_agent_confirms_completion ... FAILED
workflow::workflow_allows_stop_after_the_agent_confirms_completion ... FAILED
```

After implementation:

```text
cargo test -p nudge
...
test result: ok. 67 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
...
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
...
test result: ok. 74 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.90s
...
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

```text
cargo clippy -p nudge --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.68s
```

Also run:

```text
git diff --check
# no output
```

## Configuration changes after merge

Projects that want workflow completion gates should add a top-level `workflows:` list to `.nudge.yaml` or `.nudge/**/*.yaml`, for example:

```yaml
version: 1
workflows:
  - name: issue-resolution
    prompt:
      - kind: Regex
        pattern: "(?i)issue #[0-9]+|pull request|\\bPR\\b"
    done:
      - "Add or update end-to-end tests for the requested behavior."
      - "Implement the permanent fix."
      - "Run the relevant tests and report exact proof."
```

To receive `Stop` events in an already-configured project, rerun:

```bash
nudge claude setup
nudge codex setup
```

Workflow state is stored in Nudge's per-user data directory. Set `NUDGE_STATE_DIR=/path/to/state` only when isolating test or automation state.
