### PR TITLE
Coordinate Nudge issue stack

### DIFF
--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -330,10 +330,16 @@ const DOCS: &str = cstr!("\
   <white>When to Use Each:</white>
     <green>Regex</green>       Simple text patterns, doesn't need AST structure
     <green>SyntaxTree</green>  Structural patterns (e.g., \"use inside function body\")
+    <green>StutteringTypeName</green>
+                 Rust type names that repeat module context or generic suffixes
     <green>RustIndexedIteration</green>
                  Rust-specific `0..items.len()` iteration that indexes `items[i]`
+    <green>RustFunctionalMutation</green>
+                 Simple Rust `let mut` plus `for` loops that can become iterator chains
     <green>RustCheckThenUnwrap</green>
                   Rust Option/Result guard clauses followed by same-value unwrap
+    <green>WhatComment</green>
+                 Adjacent comments that restate what the next code already says
 
   <dim>Note: If code fails to parse (incomplete or invalid syntax), the matcher</dim>
   <dim>passes silently. This is intentional because code being written is often incomplete.</dim>

--- a/packages/nudge/src/cmd/test.rs
+++ b/packages/nudge/src/cmd/test.rs
@@ -1,7 +1,7 @@
 //! Test rules against sample input.
 
 use std::path::PathBuf;
-use std::{env, fs};
+use std::{env, fs, slice};
 
 use clap::Args;
 use color_eyre::eyre::{Context, Result, bail, eyre};
@@ -72,7 +72,7 @@ pub fn main(config: Config) -> Result<()> {
         let now = now_seconds();
         let mut state = InteractionState::default();
         let file_hooks = build_changed_file_hooks(&config)?;
-        state.record_file_changes(&file_hooks, std::slice::from_ref(&rule), now);
+        state.record_file_changes(&file_hooks, slice::from_ref(&rule), now);
         evaluate_hooks_with_state(&hooks, &[rule], &mut state)
     };
 

--- a/packages/nudge/src/hook/evaluate.rs
+++ b/packages/nudge/src/hook/evaluate.rs
@@ -1,5 +1,7 @@
 //! Rule evaluation for normalized hook events.
 
+use std::path::{Path, PathBuf};
+
 use color_eyre::eyre::Result;
 use indoc::formatdoc;
 use itertools::Itertools;
@@ -149,7 +151,7 @@ fn evaluate_hooks_at(
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct UserPromptStateUpdate {
-    cwd: std::path::PathBuf,
+    cwd: PathBuf,
     rule_name: String,
     change_id: Option<u64>,
     change_timestamp: Option<u64>,
@@ -488,13 +490,13 @@ fn source_for_tool(tool: &ToolUse) -> Source {
 /// Evaluate all content matchers and return matches only if every matcher
 /// matched.
 fn evaluate_all_matched(content: &str, matchers: &[ContentMatcher]) -> Vec<Match> {
-    evaluate_all_file_matched(std::path::Path::new(""), content, matchers)
+    evaluate_all_file_matched(Path::new(""), content, matchers)
 }
 
 /// Evaluate all content matchers with file path context and return matches only
 /// if every matcher matched.
 fn evaluate_all_file_matched(
-    path: &std::path::Path,
+    path: &Path,
     content: &str,
     matchers: &[ContentMatcher],
 ) -> Vec<Match> {

--- a/packages/nudge/src/hook/state.rs
+++ b/packages/nudge/src/hook/state.rs
@@ -276,6 +276,7 @@ fn state_file_path() -> Result<Option<PathBuf>> {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq as pretty_assert_eq;
     use serde_json::json;
     use tempfile::TempDir;
 
@@ -332,6 +333,6 @@ rules:
                 now,
             )
             .expect("recorded change");
-        assert_eq!(change.path, "packages/hurry/src/main.rs");
+        pretty_assert_eq!(change.path, "packages/hurry/src/main.rs");
     }
 }

--- a/packages/nudge/src/rules/schema/stuttering.rs
+++ b/packages/nudge/src/rules/schema/stuttering.rs
@@ -1,4 +1,5 @@
 use std::{
+    cmp::Reverse,
     collections::{BTreeMap, BTreeSet},
     path::{Component, Path},
 };
@@ -303,7 +304,7 @@ fn replacement_for(name: &str, module_terms: &[Term], redundant_terms: &[Term]) 
         .chain(redundant_terms)
         .map(|term| term.text.as_str())
         .collect::<Vec<_>>();
-    terms.sort_by_key(|term| std::cmp::Reverse(term.len()));
+    terms.sort_by_key(|term| Reverse(term.len()));
     terms.dedup();
 
     loop {
@@ -383,7 +384,7 @@ fn module_terms(
         }
     }
 
-    terms.sort_by_key(|term| std::cmp::Reverse(term.text.len()));
+    terms.sort_by_key(|term| Reverse(term.text.len()));
     terms
 }
 
@@ -400,7 +401,7 @@ fn redundant_terms(suffixes: &[String]) -> Vec<Term> {
         );
     }
 
-    terms.sort_by_key(|term| std::cmp::Reverse(term.text.len()));
+    terms.sort_by_key(|term| Reverse(term.text.len()));
     terms
 }
 
@@ -515,6 +516,8 @@ fn is_rust_identifier(module: &str) -> bool {
 mod tests {
     use super::*;
 
+    use pretty_assertions::assert_eq as pretty_assert_eq;
+
     fn matches(path: Option<&Path>, source: &str) -> Vec<Match> {
         rust_type_name_matches(
             Language::Rust,
@@ -533,20 +536,20 @@ mod tests {
             "pub struct CasStorage;\n",
         );
 
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].captures["type"], "CasStorage");
-        assert_eq!(matches[0].captures["module"], "storage");
-        assert_eq!(matches[0].captures["replacement"], "Cas");
+        pretty_assert_eq!(matches.len(), 1);
+        pretty_assert_eq!(matches[0].captures["type"], "CasStorage");
+        pretty_assert_eq!(matches[0].captures["module"], "storage");
+        pretty_assert_eq!(matches[0].captures["replacement"], "Cas");
     }
 
     #[test]
     fn detects_inline_module_alias_exact() {
         let matches = matches(None, "mod db { pub struct Database; }");
 
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].captures["type"], "Database");
-        assert_eq!(matches[0].captures["term"], "Database");
-        assert_eq!(matches[0].captures["replacement"], "a concrete name");
+        pretty_assert_eq!(matches.len(), 1);
+        pretty_assert_eq!(matches[0].captures["type"], "Database");
+        pretty_assert_eq!(matches[0].captures["term"], "Database");
+        pretty_assert_eq!(matches[0].captures["replacement"], "a concrete name");
     }
 
     #[test]
@@ -565,13 +568,13 @@ mod tests {
 
     #[test]
     fn file_module_stack_uses_path_after_src() {
-        assert_eq!(
+        pretty_assert_eq!(
             file_module_stack(Some(Path::new(
                 "packages/nudge/src/rules/schema/content.rs"
             ))),
             vec!["rules", "schema", "content"]
         );
-        assert_eq!(
+        pretty_assert_eq!(
             file_module_stack(Some(Path::new("src/storage/mod.rs"))),
             vec!["storage"]
         );

--- a/packages/nudge/src/workflow.rs
+++ b/packages/nudge/src/workflow.rs
@@ -4,6 +4,7 @@ use std::{
     collections::{HashSet, hash_map::DefaultHasher},
     env, fs,
     hash::{Hash, Hasher},
+    io::ErrorKind,
     path::PathBuf,
 };
 
@@ -13,7 +14,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    hook::{NudgeHook, Stop, UserPromptSubmit, response::HookOutcome},
+    hook::{HookContext, NudgeHook, Stop, UserPromptSubmit, response::HookOutcome},
     rules::{self, Workflow},
 };
 
@@ -192,11 +193,11 @@ fn criteria_list(done: &[String]) -> String {
         .join("\n")
 }
 
-fn read_state(context: &crate::hook::HookContext) -> Result<Option<WorkflowState>> {
+fn read_state(context: &HookContext) -> Result<Option<WorkflowState>> {
     let path = state_path(context)?;
     let content = match fs::read_to_string(&path) {
         Ok(content) => content,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(error).with_context(|| format!("read workflow state: {path:?}")),
     };
 
@@ -205,7 +206,7 @@ fn read_state(context: &crate::hook::HookContext) -> Result<Option<WorkflowState
         .map(Some)
 }
 
-fn write_state(context: &crate::hook::HookContext, state: &WorkflowState) -> Result<()> {
+fn write_state(context: &HookContext, state: &WorkflowState) -> Result<()> {
     let path = state_path(context)?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
@@ -215,16 +216,16 @@ fn write_state(context: &crate::hook::HookContext, state: &WorkflowState) -> Res
     fs::write(&path, content).with_context(|| format!("write workflow state: {path:?}"))
 }
 
-fn clear_state(context: &crate::hook::HookContext) -> Result<()> {
+fn clear_state(context: &HookContext) -> Result<()> {
     let path = state_path(context)?;
     match fs::remove_file(&path) {
         Ok(()) => Ok(()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
         Err(error) => Err(error).with_context(|| format!("remove workflow state: {path:?}")),
     }
 }
 
-fn state_path(context: &crate::hook::HookContext) -> Result<PathBuf> {
+fn state_path(context: &HookContext) -> Result<PathBuf> {
     Ok(state_dir().join(format!("{}.json", state_key(context))))
 }
 

--- a/packages/nudge/tests/it/what_comments.rs
+++ b/packages/nudge/tests/it/what_comments.rs
@@ -7,7 +7,7 @@ use std::fs;
 use std::io::Write as _;
 use std::process::{Command, Stdio};
 
-use crate::{edit_hook, nudge_binary, write_hook};
+use crate::{codex_apply_patch_hook, edit_hook, nudge_binary, write_hook};
 use pretty_assertions::assert_eq as pretty_assert_eq;
 use tempfile::TempDir;
 
@@ -52,8 +52,16 @@ rules:
 }
 
 fn run_hook_in_dir(dir: &TempDir, input: &str) -> (i32, String) {
+    run_agent_hook_in_dir("claude", dir, input)
+}
+
+fn run_codex_hook_in_dir(dir: &TempDir, input: &str) -> (i32, String) {
+    run_agent_hook_in_dir("codex", dir, input)
+}
+
+fn run_agent_hook_in_dir(agent: &str, dir: &TempDir, input: &str) -> (i32, String) {
     let mut child = Command::new(nudge_binary())
-        .args(["claude", "hook"])
+        .args([agent, "hook"])
         .current_dir(dir.path())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -133,6 +141,16 @@ fn detects_obvious_what_comments_on_write() {
         let (exit_code, output) = run_hook_in_dir(&dir, &input);
         assert_denied(exit_code, &output, comment);
     }
+}
+
+#[test]
+fn detects_obvious_what_comments_on_codex_write() {
+    let dir = setup_config(write_rule());
+    let patch = "*** Begin Patch\n*** Add File: src/lib.rs\n+// Set retries to 3\n+let retries = 3;\n*** End Patch\n";
+    let input = codex_apply_patch_hook(dir.path().to_str().expect("utf-8 path"), patch);
+
+    let (exit_code, output) = run_codex_hook_in_dir(&dir, &input);
+    assert_denied(exit_code, &output, "Set retries to 3");
 }
 
 #[test]

--- a/packages/nudge/tests/it/workflow.rs
+++ b/packages/nudge/tests/it/workflow.rs
@@ -45,6 +45,36 @@ fn workflow_blocks_stop_until_the_agent_confirms_completion() {
 }
 
 #[test]
+fn workflow_blocks_claude_stop_until_the_agent_confirms_completion() {
+    let temp = TempDir::new().expect("temp dir");
+    write_workflow_config(&temp);
+
+    let prompt = user_prompt_hook("Fix issue #8 and prove it with tests.");
+    let (exit_code, output) = run_claude_hook_in_dir(&temp, &prompt);
+
+    pretty_assert_eq!(exit_code, 0, "prompt hook failed: {output}");
+    assert!(
+        output.contains("Nudge workflow `issue-resolution` is active"),
+        "expected workflow activation context, got: {output}"
+    );
+
+    let stop = stop_hook("Implemented the change.");
+    let (exit_code, output) = run_claude_hook_in_dir(&temp, &stop);
+
+    pretty_assert_eq!(exit_code, 0, "stop hook failed: {output}");
+    let json = serde_json::from_str::<Value>(&output).expect("valid stop json");
+    pretty_assert_eq!(json["decision"], "block");
+    assert!(
+        json["reason"]
+            .as_str()
+            .is_some_and(|reason| reason.contains("Fix issue #8")
+                && reason.contains("Add end-to-end tests")
+                && reason.contains("NUDGE_WORKFLOW_COMPLETE: issue-resolution")),
+        "expected continuation reason to include prompt, criteria, and token, got: {output}"
+    );
+}
+
+#[test]
 fn workflow_allows_stop_after_the_agent_confirms_completion() {
     let temp = TempDir::new().expect("temp dir");
     write_workflow_config(&temp);
@@ -93,11 +123,19 @@ workflows:
 }
 
 fn run_codex_hook_in_dir(dir: &TempDir, input: &str) -> (i32, String) {
+    run_agent_hook_in_dir("codex", dir, input)
+}
+
+fn run_claude_hook_in_dir(dir: &TempDir, input: &str) -> (i32, String) {
+    run_agent_hook_in_dir("claude", dir, input)
+}
+
+fn run_agent_hook_in_dir(agent: &str, dir: &TempDir, input: &str) -> (i32, String) {
     let state_dir = dir.path().join(".nudge-state");
     fs::create_dir_all(&state_dir).expect("create state dir");
 
     let mut child = Command::new(nudge_binary())
-        .args(["codex", "hook"])
+        .args([agent, "hook"])
         .current_dir(dir.path())
         .env("NUDGE_STATE_DIR", &state_dir)
         .stdin(Stdio::piped())


### PR DESCRIPTION
## Why this change

This is the top validation PR for the stacked Nudge issue series. The issue PRs are now arranged as a true branch-base stack: each PR's base is the branch below it, so reviewers can inspect each issue incrementally and GitHub can merge the chain in order.

Stack order:

1. #33 `main` <- `jssblck/issue-8-workflow-management`
2. #31 `jssblck/issue-8-workflow-management` <- `jssblck/issue-6-semantic-prompts`
3. #29 `jssblck/issue-6-semantic-prompts` <- `jssblck/issue-3-stuttering-types`
4. #27 `jssblck/issue-3-stuttering-types` <- `jssblck/issue-1-array-indexing`
5. #30 `jssblck/issue-1-array-indexing` <- `jssblck/issue-2-functional-mutation`
6. #28 `jssblck/issue-2-functional-mutation` <- `jssblck/issue-5-let-else-unwrap`
7. #32 `jssblck/issue-5-let-else-unwrap` <- `jssblck/issue-4-what-comments`
8. #34 `jssblck/issue-4-what-comments` <- `jssblck/nudge-issues-coordination`

The issue branches carry their own feature work. This top PR carries the cross-stack cleanup and validation layer: combined-tree dogfood fixes, missing provider-mode tests, and docs wording that presents the new semantic matcher family as one cohesive rule surface.

The important product integration point is that full-config evaluation now has a stateful path, so workflow gates and semantic prompt reminders are evaluated together without dropping interaction state.

## Testing steps performed

Automated checks:

```text
$ cargo +nightly fmt --all --check
exit 0
```

```text
$ cargo test -p nudge
test result: ok. 98 passed; 0 failed
test result: ok. 1 passed; 0 failed
test result: ok. 118 passed; 0 failed
Doc-tests nudge: ok. 1 passed; 0 failed; 1 ignored
```

```text
$ cargo clippy -p nudge --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s)
```

```text
$ cargo run -q -p nudge -- check
Checked 72 files against 9 rules
```

Manual provider matrix:

```text
PASS claude PreToolUse blocks WhatComment
PASS codex apply_patch blocks WhatComment
PASS claude semantic reminder follows changed file
PASS codex semantic reminder follows changed file
PASS claude workflow stop gate blocks unfinished issue
PASS codex workflow stop gate blocks unfinished issue
PASS ci check reports WhatComment
PASS ci check passes clean why comment
```

GitHub checks after stacking:

```text
#27 CLEAN: Check format, Check clippy, Run tests, Build
#28 CLEAN: Check format, Check clippy, Run tests, Build
#29 CLEAN: Check format, Check clippy, Run tests, Build
#30 CLEAN: Check format, Check clippy, Run tests, Build
#31 CLEAN: Check format, Check clippy, Run tests, Build
#32 CLEAN: Check format, Check clippy, Run tests, Build
#33 CLEAN: Check format, Check clippy, Run tests, Build
#34 CLEAN: Check format, Check clippy, Run tests, Build
```

Automated mode coverage added or verified:

- Codex: `what_comments::detects_obvious_what_comments_on_codex_write`, Codex apply_patch tests, Codex prompt tests, Codex workflow Stop tests.
- Claude: Write/Edit hook tests, semantic prompt tests, and `workflow::workflow_blocks_claude_stop_until_the_agent_confirms_completion`.
- CI: `nudge check` integration tests for WhatComment, Rust indexed iteration, Rust check-then-unwrap, stuttering types, plus the full repository dogfood check above.

## Configuration changes after merge

No runtime migration is required.

Projects can opt into the new rule surface by adding matchers such as `StutteringTypeName`, `RustIndexedIteration`, `RustFunctionalMutation`, `RustCheckThenUnwrap`, `WhatComment`, semantic `UserPromptSubmit` reminders, or top-level `workflows:` entries to `.nudge.yaml`.

## Notes

The stack commits that connect each branch to the one below it intentionally preserve the validated integration snapshots. That keeps the review chain incremental while making the final product state exactly match the tested combined tree.
