### PR TITLE
Verify Go SyntaxTree support

### DIFF
--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -218,11 +218,14 @@ const DOCS: &str = cstr!("\
   <white>Basic Syntax:</white>
     <yellow>content:</yellow>
       <yellow>- kind: SyntaxTree</yellow>
-        <yellow>language: rust</yellow>              <dim># Required: rust (more languages coming)</dim>
+        <yellow>language: rust</yellow>              <dim># Required: rust, typescript, javascript, python, go, java, csharp, kotlin, or haskell</dim>
         <yellow>query: |</yellow>
           <yellow>(function_item</yellow>
             <yellow>name: (identifier) @fn_name)</yellow>
         <yellow>suggestion: \"...\"</yellow>           <dim># Optional: same as Regex</dim>
+
+  <white>Supported Languages:</white>
+    <green>rust</green>, <green>typescript</green>, <green>javascript</green>, <green>python</green>, <green>go</green>, <green>java</green>, <green>csharp</green>, <green>kotlin</green>, <green>haskell</green>
 
   <white>Query Syntax:</white>
     Tree-sitter uses S-expression queries. Nodes are matched by type (in parentheses)
@@ -243,8 +246,8 @@ const DOCS: &str = cstr!("\
     <green>Regex</green>       Simple text patterns, doesn't need AST structure
     <green>SyntaxTree</green>  Structural patterns (e.g., \"use inside function body\")
 
-  <dim>Note: If code fails to parse (incomplete or invalid syntax), the matcher</dim>
-  <dim>passes silently. This is intentional because code being written is often incomplete.</dim>
+  <dim>Note: Parser failures pass silently. Recovered parse trees with syntax errors</dim>
+  <dim>are still evaluated so useful matches can be found in incomplete code.</dim>
 
 <bold>External Program Matching</bold>
 

--- a/packages/nudge/src/rules/schema/syntax.rs
+++ b/packages/nudge/src/rules/schema/syntax.rs
@@ -200,6 +200,15 @@ mod tests {
     }
 
     #[test]
+    fn test_go_parse_invalid_returns_tree_with_errors() {
+        let code = "package main\nfunc main( { panic(\"boom\")";
+        let tree = Language::Go
+            .parse(code)
+            .expect("Go parser should recover an error tree");
+        assert!(tree.root_node().has_error());
+    }
+
+    #[test]
     fn test_lock_parser_panics_when_mutex_is_poisoned() {
         let parser = Mutex::new(());
         let poison = catch_unwind(|| {

--- a/packages/nudge/tests/it/cli.rs
+++ b/packages/nudge/tests/it/cli.rs
@@ -145,3 +145,23 @@ fn test_syntaxtree_shows_field_names() {
         "syntaxtree should show 'body:' field, got: {stdout}"
     );
 }
+
+#[test]
+fn test_syntaxtree_go_inline_code() {
+    let (exit_code, stdout, _stderr) = run_nudge(&[
+        "syntaxtree",
+        "--language",
+        "go",
+        "package main\nfunc main() { defer cleanup() }",
+    ]);
+
+    pretty_assert_eq!(exit_code, 0, "syntaxtree should exit 0");
+    assert!(
+        stdout.contains("function_declaration"),
+        "syntaxtree should show Go function_declaration node, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("defer_statement"),
+        "syntaxtree should show Go defer_statement node, got: {stdout}"
+    );
+}

--- a/packages/nudge/tests/it/syntax_tree.rs
+++ b/packages/nudge/tests/it/syntax_tree.rs
@@ -65,6 +65,23 @@ fn run_hook_in_dir(dir: &TempDir, input: &str) -> (i32, String) {
     (exit_code, combined)
 }
 
+/// Run a nudge subcommand in the specified directory.
+fn run_nudge_in_dir(dir: &TempDir, args: &[&str]) -> (i32, String, String) {
+    let output = Command::new(nudge_binary())
+        .args(args)
+        .current_dir(dir.path())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to run nudge");
+
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    (exit_code, stdout, stderr)
+}
+
 /// Build a PreToolUse hook JSON payload for Write tool.
 fn write_hook(file_path: &str, content: &str) -> String {
     serde_json::json!({

--- a/packages/nudge/tests/it/syntax_tree/go.rs
+++ b/packages/nudge/tests/it/syntax_tree/go.rs
@@ -1,8 +1,12 @@
 //! Go syntax tree tests.
 
+use std::fs;
+
 use pretty_assertions::assert_eq as pretty_assert_eq;
 
-use super::{run_hook_in_dir, setup_config, write_hook};
+use crate::edit_hook;
+
+use super::{run_hook_in_dir, run_nudge_in_dir, setup_config, write_hook};
 
 #[test]
 fn test_go_empty_error_check() {
@@ -126,5 +130,237 @@ func example() error {
     assert!(
         output.is_empty(),
         "expected passthrough for error return, got: {output}"
+    );
+}
+
+#[test]
+fn test_go_capture_and_suggestion_interpolation() {
+    let config = r#"
+version: 1
+rules:
+  - name: no-go-panic
+    description: Avoid panic in Go code
+    message: "{{ $suggestion }}"
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.go"
+        content:
+          - kind: SyntaxTree
+            language: go
+            query: |
+              (call_expression
+                function: (identifier) @fn
+                (#eq? @fn "panic")) @call
+            suggestion: "Avoid {{ $fn }} in Go code. Return an error instead."
+"#;
+
+    let dir = setup_config(config);
+    let input = write_hook(
+        "test.go",
+        r#"package main
+
+func example() {
+    panic("something went wrong")
+}"#,
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains("Avoid panic in Go code. Return an error instead."),
+        "expected interpolated Go capture in suggestion, got: {output}"
+    );
+    assert!(
+        output.contains("4 |     panic") && output.contains("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"),
+        "expected snippet to use Go capture span, got: {output}"
+    );
+}
+
+#[test]
+fn test_go_edit_new_content_evaluation() {
+    let config = r#"
+version: 1
+rules:
+  - name: no-go-panic-edit
+    description: Avoid panic in Go edits
+    message: "Return an error instead of panicking."
+    on:
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.go"
+        new_content:
+          - kind: SyntaxTree
+            language: go
+            query: |
+              (call_expression
+                function: (identifier) @fn
+                (#eq? @fn "panic"))
+"#;
+
+    let dir = setup_config(config);
+    let input = edit_hook(
+        "test.go",
+        "return err",
+        r#"func example() {
+    panic("boom")
+}"#,
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected interrupt for Go panic introduced by Edit, got: {output}"
+    );
+}
+
+#[test]
+fn test_go_check_scans_write_and_edit_rules() {
+    let config = r#"
+version: 1
+rules:
+  - name: no-go-panic-check-write
+    description: Avoid panic in Go files
+    message: "Return an error instead of panicking in {{ $fn }}."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.go"
+        content:
+          - kind: SyntaxTree
+            language: go
+            query: |
+              (call_expression
+                function: (identifier) @fn
+                (#eq? @fn "panic"))
+  - name: no-empty-go-error-check
+    description: Do not ignore Go errors
+    message: "Handle this Go error check."
+    on:
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.go"
+        new_content:
+          - kind: SyntaxTree
+            language: go
+            query: |
+              (if_statement
+                condition: (binary_expression
+                  left: (identifier) @err
+                  right: (nil))
+                consequence: (block) @body
+                (#eq? @err "err")
+                (#eq? @body "{}"))
+"#;
+
+    let dir = setup_config(config);
+    fs::write(
+        dir.path().join("bad.go"),
+        r#"package main
+
+func example() {
+    panic("boom")
+    if err != nil {}
+}"#,
+    )
+    .expect("write Go file");
+
+    let (exit_code, stdout, stderr) = run_nudge_in_dir(&dir, &["check"]);
+
+    assert_ne!(exit_code, 0, "check should fail for Go issues");
+    assert!(
+        stdout.contains("bad.go:4 [no-go-panic-check-write]"),
+        "expected Go Write SyntaxTree issue with line number, stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("bad.go:5 [no-empty-go-error-check]"),
+        "expected Go Edit SyntaxTree issue with line number, stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("Return an error instead of panicking in panic."),
+        "expected check message interpolation from Go capture, stdout: {stdout}"
+    );
+}
+
+#[test]
+fn test_go_comments_strings_and_safe_code_do_not_match() {
+    let config = r#"
+version: 1
+rules:
+  - name: no-go-panic
+    description: Avoid panic in Go code
+    message: "Return an error instead of panicking."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.go"
+        content:
+          - kind: SyntaxTree
+            language: go
+            query: |
+              (call_expression
+                function: (identifier) @fn
+                (#eq? @fn "panic"))
+"#;
+
+    let dir = setup_config(config);
+    let input = write_hook(
+        "test.go",
+        r#"package main
+
+func example() error {
+    // panic("comment only")
+    msg := "panic(\"string only\")"
+    defer cleanup()
+    _ = msg
+    return nil
+}"#,
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0");
+    assert!(
+        output.is_empty(),
+        "expected comments, strings, defer, and safe returns to pass, got: {output}"
+    );
+}
+
+#[test]
+fn test_go_incomplete_code_uses_recovered_parse_tree() {
+    let config = r#"
+version: 1
+rules:
+  - name: no-go-panic-in-incomplete-code
+    description: Avoid panic in incomplete Go code
+    message: "Return an error instead of panicking."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.go"
+        content:
+          - kind: SyntaxTree
+            language: go
+            query: |
+              (call_expression
+                function: (identifier) @fn
+                (#eq? @fn "panic"))
+"#;
+
+    let dir = setup_config(config);
+    let input = write_hook(
+        "test.go",
+        r#"package main
+
+func example() {
+    panic("boom")
+"#,
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected recovered incomplete Go tree to match panic call, got: {output}"
     );
 }


### PR DESCRIPTION
## Why this change

Main already had the core Go SyntaxTree wiring, but the proof surface was incomplete and the generated rule docs still described SyntaxTree as Rust-only. This PR verifies Go end to end across rule deserialization, query compilation, parser recovery, capture spans, capture/suggestion interpolation, Write and Edit hooks, `nudge check`, and `nudge syntaxtree --language go`.

## What changed

- Expanded Go SyntaxTree integration tests for empty `if err != nil {}` blocks, `panic()` calls, comments/strings false positives, nearby safe `defer`/return code, capture interpolation, snippet span rendering, Edit new_content evaluation, and `nudge check` file scanning.
- Added a Go `syntaxtree` CLI smoke test using an idiomatic `defer` statement.
- Added parser-policy coverage proving invalid Go recovers a tree with syntax errors, matching the existing language behavior.
- Updated `nudge claude docs` and shared `nudge codex docs` output to list every supported SyntaxTree language, including `go`, and to describe recovered parse trees accurately.

## Testing steps performed

- `cargo test -p nudge go`
  - Result: 1 Go parser unit test passed; 8 Go-related integration tests passed.
- `cargo run -q -p nudge -- claude docs | rg -n "Supported Languages|language: rust|go|Parser failures|more languages" -C 2`
  - Result: generated Claude docs list `go` and the full supported language set; no stale "more languages coming" text.
- `cargo run -q -p nudge -- codex docs | rg -n "Supported Languages|language: rust|go|Parser failures|more languages" -C 2`
  - Result: generated Codex docs show the same synced language list and parser note.
- `cargo test -p nudge`
  - Result: 65 lib tests, 1 main-unit test, 78 integration tests, and 1 doctest passed.
- `cargo clippy -p nudge --all-targets -- -D warnings`
  - Result: passed.
- `cargo +nightly fmt --all --check`
  - Result: passed.
- `git diff --check`
  - Result: passed.
- `cargo run -q -p nudge -- validate .nudge.yaml`
  - Result: parsed 6 rules successfully.
- `cargo run -q -p nudge -- check`
  - Result: checked 58 files against 6 rules successfully.

## Configuration changes after merge

None.
