### PR TITLE
Verify Python syntax tree support

### DIFF
--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -218,7 +218,8 @@ const DOCS: &str = cstr!("\
   <white>Basic Syntax:</white>
     <yellow>content:</yellow>
       <yellow>- kind: SyntaxTree</yellow>
-        <yellow>language: rust</yellow>              <dim># Required: rust (more languages coming)</dim>
+        <yellow>language: rust</yellow>              <dim># One of: rust, typescript, javascript,</dim>
+                                            <dim># python, go, java, csharp, kotlin, haskell</dim>
         <yellow>query: |</yellow>
           <yellow>(function_item</yellow>
             <yellow>name: (identifier) @fn_name)</yellow>
@@ -243,8 +244,8 @@ const DOCS: &str = cstr!("\
     <green>Regex</green>       Simple text patterns, doesn't need AST structure
     <green>SyntaxTree</green>  Structural patterns (e.g., \"use inside function body\")
 
-  <dim>Note: If code fails to parse (incomplete or invalid syntax), the matcher</dim>
-  <dim>passes silently. This is intentional because code being written is often incomplete.</dim>
+  <dim>Note: Tree-sitter recovers from incomplete or invalid syntax. SyntaxTree</dim>
+  <dim>matchers run against the recovered tree so useful matches can still fire.</dim>
 
 <bold>External Program Matching</bold>
 

--- a/packages/nudge/src/rules/schema/syntax.rs
+++ b/packages/nudge/src/rules/schema/syntax.rs
@@ -200,6 +200,26 @@ mod tests {
     }
 
     #[test]
+    fn test_language_parse_valid_python() {
+        let code = "def main():\n    print(\"hello\")\n";
+        let tree = Language::Python.parse(code);
+        assert!(tree.is_some());
+    }
+
+    #[test]
+    fn test_language_parse_invalid_python_returns_tree_with_errors() {
+        let code = "def main(:\n    print(\"hello\")\n";
+        let tree = Language::Python.parse(code);
+        assert!(tree.is_some());
+        assert!(
+            tree.expect("parser should recover a tree")
+                .root_node()
+                .has_error(),
+            "invalid Python should produce a recovered tree with errors"
+        );
+    }
+
+    #[test]
     fn test_lock_parser_panics_when_mutex_is_poisoned() {
         let parser = Mutex::new(());
         let poison = catch_unwind(|| {
@@ -226,6 +246,21 @@ mod tests {
     #[test]
     fn test_treesitter_query_compile_invalid() {
         let query = TreeSitterQuery::new(Language::Rust, "(not_a_real_node)");
+        assert!(query.is_err());
+    }
+
+    #[test]
+    fn test_python_treesitter_query_compile_valid() {
+        let query = TreeSitterQuery::new(
+            Language::Python,
+            "(call function: (identifier) @function_name)",
+        );
+        assert!(query.is_ok());
+    }
+
+    #[test]
+    fn test_python_treesitter_query_compile_invalid() {
+        let query = TreeSitterQuery::new(Language::Python, "(not_a_real_python_node)");
         assert!(query.is_err());
     }
 }

--- a/packages/nudge/tests/it/cli.rs
+++ b/packages/nudge/tests/it/cli.rs
@@ -145,3 +145,23 @@ fn test_syntaxtree_shows_field_names() {
         "syntaxtree should show 'body:' field, got: {stdout}"
     );
 }
+
+#[test]
+fn test_syntaxtree_python_inline_code() {
+    let (exit_code, stdout, _stderr) = run_nudge(&[
+        "syntaxtree",
+        "--language",
+        "python",
+        "def greet(name):\n    print(name)",
+    ]);
+
+    pretty_assert_eq!(exit_code, 0, "syntaxtree should exit 0");
+    assert!(
+        stdout.contains("function_definition"),
+        "syntaxtree should show function_definition node, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("call") && stdout.contains("print"),
+        "syntaxtree should show print call nodes, got: {stdout}"
+    );
+}

--- a/packages/nudge/tests/it/syntax_tree.rs
+++ b/packages/nudge/tests/it/syntax_tree.rs
@@ -65,6 +65,24 @@ fn run_hook_in_dir(dir: &TempDir, input: &str) -> (i32, String) {
     (exit_code, combined)
 }
 
+/// Run a nudge subcommand in a temporary directory and return exit code,
+/// stdout, and stderr.
+fn run_nudge_in_dir(dir: &TempDir, args: &[&str]) -> (i32, String, String) {
+    let output = Command::new(nudge_binary())
+        .args(args)
+        .current_dir(dir.path())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to run nudge");
+
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    (exit_code, stdout, stderr)
+}
+
 /// Build a PreToolUse hook JSON payload for Write tool.
 fn write_hook(file_path: &str, content: &str) -> String {
     serde_json::json!({
@@ -78,6 +96,25 @@ fn write_hook(file_path: &str, content: &str) -> String {
         "tool_input": {
             "file_path": file_path,
             "content": content
+        }
+    })
+    .to_string()
+}
+
+/// Build a PreToolUse hook JSON payload for Edit tool.
+fn edit_hook(file_path: &str, old_string: &str, new_string: &str) -> String {
+    serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "test",
+        "transcript_path": "/tmp/test",
+        "permission_mode": "default",
+        "cwd": "/tmp",
+        "tool_name": "Edit",
+        "tool_use_id": "123",
+        "tool_input": {
+            "file_path": file_path,
+            "old_string": old_string,
+            "new_string": new_string
         }
     })
     .to_string()

--- a/packages/nudge/tests/it/syntax_tree/python.rs
+++ b/packages/nudge/tests/it/syntax_tree/python.rs
@@ -1,8 +1,10 @@
 //! Python syntax tree tests.
 
+use std::fs;
+
 use pretty_assertions::assert_eq as pretty_assert_eq;
 
-use super::{run_hook_in_dir, setup_config, write_hook};
+use super::{edit_hook, run_hook_in_dir, run_nudge_in_dir, setup_config, write_hook};
 
 #[test]
 fn test_python_bare_except() {
@@ -96,5 +98,209 @@ rules:
     assert!(
         output.is_empty(),
         "expected passthrough for logging, got: {output}"
+    );
+
+    // Should pass: print text in comments and strings is not a call node.
+    let input = write_hook(
+        "test.py",
+        r#"# print("debug")
+message = "print('debug')""#,
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0");
+    assert!(
+        output.is_empty(),
+        "expected passthrough for comments and strings, got: {output}"
+    );
+}
+
+#[test]
+fn test_python_capture_and_suggestion_interpolation() {
+    let config = r#"
+version: 1
+rules:
+  - name: no-mutable-default
+    description: Don't use mutable default arguments
+    message: "{{ $suggestion }}"
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.py"
+        content:
+          - kind: SyntaxTree
+            language: python
+            query: |
+              (function_definition
+                name: (identifier) @fn
+                parameters: (parameters
+                  (default_parameter
+                    name: (identifier) @arg
+                    value: (list) @default)))
+            suggestion: "Function `{{ $fn }}` uses mutable default `{{ $arg }}={{ $default }}`. Use `None` and initialize inside the body, then retry."
+"#;
+
+    let dir = setup_config(config);
+
+    let input = write_hook(
+        "cache.py",
+        r#"def connect(cache=[]):
+    return cache"#,
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected interrupt for mutable default, got: {output}"
+    );
+    assert!(
+        output.contains("Function `connect` uses mutable default `cache=[]`"),
+        "expected captured function, argument, and default in suggestion, got: {output}"
+    );
+
+    let input = write_hook(
+        "cache.py",
+        r#"def connect(cache=None):
+    if cache is None:
+        cache = []
+    return cache"#,
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0");
+    assert!(
+        output.is_empty(),
+        "expected passthrough for safe default, got: {output}"
+    );
+}
+
+#[test]
+fn test_python_edit_hook_uses_new_content() {
+    let config = r#"
+version: 1
+rules:
+  - name: no-print-edit
+    description: Don't introduce print() in edits
+    message: "Remove print() from the replacement text, then retry."
+    on:
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.py"
+        new_content:
+          - kind: SyntaxTree
+            language: python
+            query: |
+              (call
+                function: (identifier) @fn
+                (#eq? @fn "print"))
+"#;
+
+    let dir = setup_config(config);
+
+    let input = edit_hook("app.py", "logger.info('ready')", "print('ready')");
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected interrupt for print() introduced by Edit, got: {output}"
+    );
+
+    let input = edit_hook("app.py", "print('ready')", "logger.info('ready')");
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0");
+    assert!(
+        output.is_empty(),
+        "expected passthrough when Edit replacement is safe, got: {output}"
+    );
+}
+
+#[test]
+fn test_python_check_scans_files_and_interpolates_captures() {
+    let config = r#"
+version: 1
+rules:
+  - name: no-bare-except-check
+    description: Don't use bare except clauses
+    message: "Avoid bare `except:` in `{{ $exc }}`, then retry."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.py"
+        content:
+          - kind: SyntaxTree
+            language: python
+            query: "(except_clause !value) @exc"
+"#;
+
+    let dir = setup_config(config);
+    fs::write(
+        dir.path().join("handler.py"),
+        r#"try:
+    risky_operation()
+except:
+    pass
+"#,
+    )
+    .expect("write Python fixture");
+    fs::write(
+        dir.path().join("safe.py"),
+        r#"try:
+    risky_operation()
+except Exception:
+    pass
+"#,
+    )
+    .expect("write safe Python fixture");
+
+    let (exit_code, stdout, stderr) = run_nudge_in_dir(&dir, &["check"]);
+    assert_ne!(
+        exit_code, 0,
+        "expected nudge check to fail for bare except, stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("handler.py:3 [no-bare-except-check]"),
+        "expected check output to report handler.py line 3, got stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("Avoid bare `except:`"),
+        "expected interpolated message in check output, got stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(
+        !stdout.contains("safe.py"),
+        "expected typed except file to pass, got stdout: {stdout}, stderr: {stderr}"
+    );
+}
+
+#[test]
+fn test_python_incomplete_code_uses_recovered_tree() {
+    let config = r#"
+version: 1
+rules:
+  - name: no-print-in-incomplete-code
+    description: Don't use print(), even while code is incomplete
+    message: "Remove print() from this Python code, then retry."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.py"
+        content:
+          - kind: SyntaxTree
+            language: python
+            query: |
+              (call
+                function: (identifier) @fn
+                (#eq? @fn "print"))
+"#;
+
+    let dir = setup_config(config);
+
+    let input = write_hook(
+        "scratch.py",
+        r#"print("debug")
+def unfinished("#,
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected matcher to run on recovered Python tree, got: {output}"
     );
 }


### PR DESCRIPTION
## Why this change

Python support was already partially wired into the syntax-tree language layer, but the public proof was thin and the generated rule docs still said SyntaxTree only supported Rust with more languages coming. This PR turns Python support from a marker into verified behavior across the same surfaces existing SyntaxTree languages rely on.

## What changed

- Added Python parser and query unit coverage for valid code, recovered invalid code, valid query compilation, and invalid query rejection.
- Expanded Python SyntaxTree integration coverage for Write hooks, Edit hooks, `nudge check`, capture text interpolation, suggestion interpolation, comment/string false-positive avoidance, and recovered incomplete-code matching.
- Added `nudge syntaxtree --language python` CLI coverage.
- Updated generated Claude/Codex rule docs to list the current SyntaxTree languages and accurately describe tree-sitter recovered-tree behavior.

## Testing steps performed

- `cargo test -p nudge syntax_tree::python -- --nocapture` - passed, 6 Python SyntaxTree integration tests.
- `cargo test -p nudge python -- --nocapture` - passed, 4 Python unit tests plus 8 Python-matching integration tests.
- `cargo test -p nudge test_syntaxtree_python_inline_code -- --nocapture` - passed, 1 CLI SyntaxTree Python test.
- `cargo test -p nudge` - passed, 68 lib tests, 1 binary unit test, 77 integration tests, and 1 doctest.
- `cargo clippy -p nudge --all-targets -- -D warnings` - passed.
- `cargo +nightly fmt --all --check` - passed.
- `git diff --check` - passed.
- `cargo run -q -p nudge -- claude docs | rg -n "language: rust|python|recovers|recovered"` - confirmed generated Claude docs include Python and recovered-tree wording.
- `cargo run -q -p nudge -- codex docs | rg -n "language: rust|python|recovers|recovered"` - confirmed Codex docs inherit the same updated language list and parser policy.

## Configuration changes after merge

None.