### PR TITLE
[codex] Verify Rust syntax tree support

### DIFF
--- a/examples/rules/rust.yaml
+++ b/examples/rules/rust.yaml
@@ -7,9 +7,8 @@ version: 1
 
 rules:
   # Catch `use` statements inside function bodies.
-  # Pattern: lines starting with horizontal whitespace followed by `use `.
-  # Limitation: This also triggers on `use` statements inside `mod test`;
-  #             to fix this we need to add treesitter parsing support.
+  # SyntaxTree matching avoids false positives for top-level imports and
+  # module-level imports inside test modules.
   - name: no-inline-imports
     description: Move imports to the top of the file
     message: Move this `use` statement to the top of the file with other imports, then retry.
@@ -18,14 +17,16 @@ rules:
         tool: Write
         file: "**/*.rs"
         content:
-          - kind: Regex
-            pattern: "(?m)^[ \\t]+use "
+          - kind: SyntaxTree
+            language: rust
+            query: "(function_item body: (block (use_declaration) @use))"
       - hook: PreToolUse
         tool: Edit
         file: "**/*.rs"
         new_content:
-          - kind: Regex
-            pattern: "(?m)^[ \\t]+use "
+          - kind: SyntaxTree
+            language: rust
+            query: "(function_item body: (block (use_declaration) @use))"
 
   # Catch left-hand side type annotations in variable declarations.
   # Pattern: `let name: Type = ...` or `let mut name: Type = ...`

--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -218,7 +218,7 @@ const DOCS: &str = cstr!("\
   <white>Basic Syntax:</white>
     <yellow>content:</yellow>
       <yellow>- kind: SyntaxTree</yellow>
-        <yellow>language: rust</yellow>              <dim># Required: rust (more languages coming)</dim>
+        <yellow>language: rust</yellow>              <dim># Required: rust, typescript, javascript, python, go, java, csharp, kotlin, or haskell</dim>
         <yellow>query: |</yellow>
           <yellow>(function_item</yellow>
             <yellow>name: (identifier) @fn_name)</yellow>
@@ -243,8 +243,9 @@ const DOCS: &str = cstr!("\
     <green>Regex</green>       Simple text patterns, doesn't need AST structure
     <green>SyntaxTree</green>  Structural patterns (e.g., \"use inside function body\")
 
-  <dim>Note: If code fails to parse (incomplete or invalid syntax), the matcher</dim>
-  <dim>passes silently. This is intentional because code being written is often incomplete.</dim>
+  <dim>Note: Nudge keeps parser-produced syntax trees even when they contain syntax</dim>
+  <dim>errors, because code being written is often incomplete. If the parser cannot</dim>
+  <dim>produce a tree at all, the matcher passes silently.</dim>
 
 <bold>External Program Matching</bold>
 

--- a/packages/nudge/src/rules/schema/syntax.rs
+++ b/packages/nudge/src/rules/schema/syntax.rs
@@ -183,6 +183,8 @@ impl<'de> Deserialize<'de> for TreeSitterQuery {
 mod tests {
     use std::{panic::catch_unwind, sync::Mutex};
 
+    use pretty_assertions::assert_eq as pretty_assert_eq;
+
     use super::*;
 
     #[test]
@@ -197,6 +199,20 @@ mod tests {
         let code = "fn main( { }";
         let tree = Language::Rust.parse(code);
         assert!(tree.is_some());
+    }
+
+    #[test]
+    fn test_language_parse_rust_reuses_parser_for_multiple_sources() {
+        let first = Language::Rust
+            .parse("fn first() {}")
+            .expect("parse first source");
+        let second = Language::Rust
+            .parse("fn second() { let value: usize = 1; }")
+            .expect("parse second source");
+
+        pretty_assert_eq!(first.root_node().kind(), "source_file");
+        pretty_assert_eq!(second.root_node().kind(), "source_file");
+        assert!(!second.root_node().has_error());
     }
 
     #[test]

--- a/packages/nudge/tests/it/syntax_tree.rs
+++ b/packages/nudge/tests/it/syntax_tree.rs
@@ -18,7 +18,7 @@ use std::fs;
 use std::io::Write as _;
 use std::process::{Command, Stdio};
 
-use crate::nudge_binary;
+use crate::{edit_hook, nudge_binary};
 use pretty_assertions::assert_eq as pretty_assert_eq;
 use tempfile::TempDir;
 
@@ -63,6 +63,22 @@ fn run_hook_in_dir(dir: &TempDir, input: &str) -> (i32, String) {
     };
 
     (exit_code, combined)
+}
+
+fn run_nudge_in_dir(dir: &TempDir, args: &[&str]) -> (i32, String, String) {
+    let output = Command::new(nudge_binary())
+        .args(args)
+        .current_dir(dir.path())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to run nudge");
+
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    (exit_code, stdout, stderr)
 }
 
 /// Build a PreToolUse hook JSON payload for Write tool.
@@ -217,6 +233,142 @@ rules:
     assert!(
         output.contains("my_test_function"),
         "expected suggestion to contain function name, got: {output}"
+    );
+}
+
+#[test]
+fn test_syntax_tree_edit_matches_method_call_with_capture_interpolation() {
+    let config = r#"
+version: 1
+rules:
+  - name: no-unwrap-method
+    description: Use expect instead of unwrap
+    message: "{{ $suggestion }}"
+    on:
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.rs"
+        new_content:
+          - kind: SyntaxTree
+            language: rust
+            query: |
+              (call_expression
+                function: (field_expression
+                  field: (field_identifier) @method)
+                (#eq? @method "unwrap"))
+            suggestion: "Replace .{{ $method }}() with .expect(\"...\") before retrying."
+"#;
+
+    let dir = setup_config(config);
+
+    let input = edit_hook(
+        "src/lib.rs",
+        "let value = maybe;",
+        "let value = maybe.unwrap();",
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected interrupt for .unwrap() method call, got: {output}"
+    );
+    assert!(
+        output.contains(r#"Replace .unwrap() with .expect(\"...\") before retrying."#),
+        "expected interpolated method suggestion, got: {output}"
+    );
+
+    let input = edit_hook(
+        "src/lib.rs",
+        "let value = maybe;",
+        "let value = maybe.ok();",
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0");
+    assert!(
+        output.is_empty(),
+        "expected passthrough for safe method call, got: {output}"
+    );
+}
+
+#[test]
+fn test_syntax_tree_check_scans_rust_files_and_ignores_comments_and_strings() {
+    let config = r#"
+version: 1
+rules:
+  - name: no-lhs-type-annotations-ast
+    description: Use inference or turbofish instead of left-hand type annotations
+    message: "{{ $suggestion }}"
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.rs"
+        content:
+          - kind: SyntaxTree
+            language: rust
+            query: "(let_declaration pattern: (identifier) @binding type: (_) @type)"
+            suggestion: "Remove {{ $type }} from {{ $binding }}, then retry."
+"#;
+
+    let dir = setup_config(config);
+    fs::create_dir_all(dir.path().join("src")).expect("create src dir");
+    fs::write(
+        dir.path().join("src/lib.rs"),
+        r#"fn build() {
+    // let fake: Vec<String> = Vec::new();
+    let items: Vec<String> = Vec::new();
+    let text = "let also_fake: usize = 1;";
+    let inferred = Vec::<String>::new();
+}
+"#,
+    )
+    .expect("write rust source");
+
+    let (exit_code, stdout, stderr) = run_nudge_in_dir(&dir, &["check", "src/lib.rs"]);
+
+    pretty_assert_eq!(exit_code, 1, "expected check failure, stderr: {stderr}");
+    assert!(
+        stdout.contains("Found 1 issue"),
+        "expected exactly one AST issue for the real type annotation, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("src/lib.rs:3 [no-lhs-type-annotations-ast]"),
+        "expected issue on the real let declaration line, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Remove Vec<String> from items, then retry."),
+        "expected capture interpolation from Rust AST nodes, got: {stdout}"
+    );
+}
+
+#[test]
+fn test_syntax_tree_invalid_rust_error_only_tree_passes() {
+    let config = r#"
+version: 1
+rules:
+  - name: function-name-check
+    description: Check function naming
+    message: "Found a complete function."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.rs"
+        content:
+          - kind: SyntaxTree
+            language: rust
+            query: "(function_item name: (identifier) @fn_name)"
+"#;
+
+    let dir = setup_config(config);
+
+    let input = write_hook("src/lib.rs", "fn broken() { let x = ");
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0");
+    assert!(
+        output.is_empty(),
+        "expected passthrough when incomplete Rust only parses as ERROR nodes, got: {output}"
     );
 }
 


### PR DESCRIPTION
## Why this change

Rust is the original SyntaxTree baseline, but it needed current proof across the same surfaces supported by the newer language additions. This PR adds that proof and fixes stale rule-writing docs/examples that still described Rust SyntaxTree support as future-only or regex-only.

## What changed

- Added Rust SyntaxTree integration coverage for PreToolUse Edit evaluation with method-call capture interpolation.
- Added `nudge check` coverage that scans Rust files, reports capture-interpolated suggestions, and avoids false positives in comments, strings, and nearby safe code.
- Added invalid/incomplete Rust coverage for the current parser policy: parser-produced error trees are allowed, and ERROR-only trees do not match complete Rust nodes.
- Added a unit-level parser reuse proof for repeated Rust parses through the static parser path.
- Updated emitted Claude/Codex rule-writing docs to list all supported SyntaxTree languages and describe parser-produced error trees accurately.
- Updated `examples/rules/rust.yaml` to use the now-supported Rust SyntaxTree matcher for inline imports instead of the stale regex workaround.

## Testing steps performed

```text
cargo test -p nudge --test it syntax_tree
# 30 passed; 0 failed; 45 filtered out
```

```text
cargo test -p nudge rules::schema::syntax
# 6 passed; 0 failed
```

```text
cargo run -q -p nudge -- validate examples/rules/rust.yaml
# parsed no-inline-imports as SyntaxTree language: rust for both Write and Edit
```

```text
cargo run -q -p nudge -- claude docs | rg -n "language: rust|typescript|parser-produced|more languages coming|SyntaxTree"
cargo run -q -p nudge -- codex docs | rg -n "language: rust|typescript|parser-produced|more languages coming|SyntaxTree"
# both emitted the full supported language list and parser-produced syntax tree note; no "more languages coming" hit
```

```text
cargo run -q -p nudge -- syntaxtree --language rust 'fn main() { let value: usize = 1; println!("{}", value); }' | rg -n 'function_item|let_declaration|macro_invocation|type:'
# showed function_item, let_declaration, type: primitive_type, and macro_invocation
```

```text
cargo test -p nudge
# 65 unit tests passed, 1 main unit test passed, 75 integration tests passed, 1 doctest passed
```

```text
cargo clippy -p nudge --all-targets -- -D warnings
cargo +nightly fmt --all --check
cargo run -q -p nudge -- check
# clippy/fmt passed; nudge check: Checked 58 files against 6 rules
```

```text
git diff --check
# passed
```

## Configuration changes after merge

None.