### PR TITLE
Verify CSharp SyntaxTree language support

### DIFF
--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -218,11 +218,17 @@ const DOCS: &str = cstr!("\
   <white>Basic Syntax:</white>
     <yellow>content:</yellow>
       <yellow>- kind: SyntaxTree</yellow>
-        <yellow>language: rust</yellow>              <dim># Required: rust (more languages coming)</dim>
+        <yellow>language: rust</yellow>              <dim># Required: rust, typescript, javascript, python, go, java, csharp, kotlin, or haskell</dim>
         <yellow>query: |</yellow>
           <yellow>(function_item</yellow>
             <yellow>name: (identifier) @fn_name)</yellow>
         <yellow>suggestion: \"...\"</yellow>           <dim># Optional: same as Regex</dim>
+
+  <white>Supported Languages:</white>
+    <green>rust</green>, <green>typescript</green>, <green>javascript</green>, <green>python</green>, <green>go</green>, <green>java</green>, <green>csharp</green>, <green>kotlin</green>, <green>haskell</green>
+
+  Use <cyan>nudge syntaxtree --language csharp 'public class Example {}'</cyan> to inspect
+  the node and field names for a snippet before writing a query.
 
   <white>Query Syntax:</white>
     Tree-sitter uses S-expression queries. Nodes are matched by type (in parentheses)
@@ -243,8 +249,8 @@ const DOCS: &str = cstr!("\
     <green>Regex</green>       Simple text patterns, doesn't need AST structure
     <green>SyntaxTree</green>  Structural patterns (e.g., \"use inside function body\")
 
-  <dim>Note: If code fails to parse (incomplete or invalid syntax), the matcher</dim>
-  <dim>passes silently. This is intentional because code being written is often incomplete.</dim>
+  <dim>Note: Incomplete or invalid code is still evaluated when tree-sitter can</dim>
+  <dim>produce a partial tree. If parsing returns no tree, the matcher passes silently.</dim>
 
 <bold>External Program Matching</bold>
 

--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -228,9 +228,6 @@ const DOCS: &str = cstr!("\
   <white>Supported Languages:</white>
     <green>rust</green>, <green>typescript</green>, <green>javascript</green>, <green>python</green>, <green>go</green>, <green>java</green>, <green>csharp</green>, <green>kotlin</green>, <green>haskell</green>
 
-  Use <cyan>nudge syntaxtree --language csharp 'public class Example {}'</cyan> to inspect
-  the node and field names for a snippet before writing a query.
-
   <white>Query Syntax:</white>
     Tree-sitter uses S-expression queries. Nodes are matched by type (in parentheses)
     and captures are marked with <green>@name</green>.

--- a/packages/nudge/src/rules/schema/syntax.rs
+++ b/packages/nudge/src/rules/schema/syntax.rs
@@ -27,6 +27,7 @@ pub enum Language {
     /// The Java programming language.
     Java,
     /// The C# programming language.
+    #[value(name = "csharp", alias = "c-sharp")]
     CSharp,
     /// The Kotlin programming language.
     Kotlin,
@@ -200,6 +201,15 @@ mod tests {
     }
 
     #[test]
+    fn test_language_parse_invalid_csharp_returns_tree_with_errors() {
+        let code = "public class Test { public void Example( { Console.WriteLine(\"debug\"); }";
+        let tree = Language::CSharp
+            .parse(code)
+            .expect("C# parser should return a tree");
+        assert!(tree.root_node().has_error());
+    }
+
+    #[test]
     fn test_lock_parser_panics_when_mutex_is_poisoned() {
         let parser = Mutex::new(());
         let poison = catch_unwind(|| {
@@ -220,6 +230,12 @@ mod tests {
     #[test]
     fn test_treesitter_query_compile_valid() {
         let query = TreeSitterQuery::new(Language::Rust, "(function_item)");
+        assert!(query.is_ok());
+    }
+
+    #[test]
+    fn test_treesitter_query_compile_valid_csharp() {
+        let query = TreeSitterQuery::new(Language::CSharp, "(method_declaration)");
         assert!(query.is_ok());
     }
 

--- a/packages/nudge/tests/it/cli.rs
+++ b/packages/nudge/tests/it/cli.rs
@@ -145,3 +145,23 @@ fn test_syntaxtree_shows_field_names() {
         "syntaxtree should show 'body:' field, got: {stdout}"
     );
 }
+
+#[test]
+fn test_syntaxtree_accepts_csharp_language_name() {
+    let (exit_code, stdout, _stderr) = run_nudge(&[
+        "syntaxtree",
+        "--language",
+        "csharp",
+        "public class Test { public void Example() { Console.WriteLine(\"debug\"); } }",
+    ]);
+
+    pretty_assert_eq!(exit_code, 0, "syntaxtree should exit 0");
+    assert!(
+        stdout.contains("class_declaration"),
+        "syntaxtree should show C# class node, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("invocation_expression") && stdout.contains("WriteLine"),
+        "syntaxtree should show C# invocation, got: {stdout}"
+    );
+}

--- a/packages/nudge/tests/it/syntax_tree/csharp.rs
+++ b/packages/nudge/tests/it/syntax_tree/csharp.rs
@@ -1,5 +1,9 @@
 //! C# syntax tree tests.
 
+use std::fs;
+use std::process::Command;
+
+use crate::{edit_hook, nudge_binary};
 use pretty_assertions::assert_eq as pretty_assert_eq;
 
 use super::{run_hook_in_dir, setup_config, write_hook};
@@ -125,5 +129,275 @@ rules:
     assert!(
         output.is_empty(),
         "expected passthrough for logger, got: {output}"
+    );
+
+    // Should pass: comments and strings mentioning Console.WriteLine are not
+    // invocations.
+    let input = write_hook(
+        "Test.cs",
+        r#"public class Test {
+    public void Example() {
+        // Console.WriteLine("debug");
+        var text = "Console.WriteLine(\"debug\")";
+    }
+}"#,
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0");
+    assert!(
+        output.is_empty(),
+        "expected passthrough for comments and strings, got: {output}"
+    );
+}
+
+#[test]
+fn test_csharp_async_void_edit() {
+    let config = r#"
+version: 1
+rules:
+  - name: no-async-void
+    description: Use Task-returning async methods except for event handlers
+    message: "Use `Task` instead of `async void` for `{{ $method }}`, then retry."
+    on:
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.cs"
+        new_content:
+          - kind: SyntaxTree
+            language: csharp
+            query: |
+              (method_declaration
+                (modifier) @modifier
+                returns: (predefined_type) @return_type
+                name: (identifier) @method
+                (#eq? @modifier "async")
+                (#eq? @return_type "void"))
+"#;
+
+    let dir = setup_config(config);
+
+    let input = edit_hook(
+        "Test.cs",
+        "old code",
+        r#"public class Test {
+    public async void SaveAsync() {
+        await Task.Delay(1);
+    }
+}"#,
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#) && output.contains("SaveAsync"),
+        "expected interrupt with captured method name, got: {output}"
+    );
+
+    let input = edit_hook(
+        "Test.cs",
+        "old code",
+        r#"public class Test {
+    public async Task SaveAsync() {
+        await Task.Delay(1);
+    }
+}"#,
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0");
+    assert!(
+        output.is_empty(),
+        "expected passthrough for async Task, got: {output}"
+    );
+}
+
+#[test]
+fn test_csharp_nullable_capture_and_suggestion_interpolation() {
+    let config = r#"
+version: 1
+rules:
+  - name: nullable-property-review
+    description: Review nullable public properties
+    message: "{{ $suggestion }}"
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.cs"
+        content:
+          - kind: SyntaxTree
+            language: csharp
+            query: |
+              (property_declaration
+                type: (nullable_type) @type
+                name: (identifier) @property)
+            suggestion: "Review nullable property `{{ $property }}` of type `{{ $type }}`."
+"#;
+
+    let dir = setup_config(config);
+
+    let input = write_hook(
+        "Test.cs",
+        r#"public class Test {
+    public string? DisplayName { get; set; }
+}"#,
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#)
+            && output.contains("DisplayName")
+            && output.contains("string?"),
+        "expected interpolated nullable property capture, got: {output}"
+    );
+
+    let input = write_hook(
+        "Test.cs",
+        r#"public class Test {
+    public string DisplayName { get; set; }
+}"#,
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0");
+    assert!(
+        output.is_empty(),
+        "expected passthrough for non-nullable property, got: {output}"
+    );
+}
+
+#[test]
+fn test_csharp_incomplete_code_uses_partial_tree() {
+    let config = r#"
+version: 1
+rules:
+  - name: no-console-writeline
+    description: Don't use Console.WriteLine in production code
+    message: "Use a logging framework instead of `Console.WriteLine`."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.cs"
+        content:
+          - kind: SyntaxTree
+            language: csharp
+            query: |
+              (invocation_expression
+                function: (member_access_expression
+                  expression: (identifier) @obj
+                  name: (identifier) @method)
+                (#eq? @obj "Console")
+                (#eq? @method "WriteLine"))
+"#;
+
+    let dir = setup_config(config);
+
+    let input = write_hook(
+        "Test.cs",
+        r#"public class Test {
+    public void Example() {
+        Console.WriteLine("debug");
+"#,
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected partial C# tree to still expose complete invocation, got: {output}"
+    );
+}
+
+#[test]
+fn test_csharp_check_scans_write_and_edit_rules() {
+    let config = r#"
+version: 1
+rules:
+  - name: no-console-writeline
+    description: Don't use Console.WriteLine in production code
+    message: "Use a logging framework instead of `Console.WriteLine`."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.cs"
+        content:
+          - kind: SyntaxTree
+            language: csharp
+            query: |
+              (invocation_expression
+                function: (member_access_expression
+                  expression: (identifier) @obj
+                  name: (identifier) @method)
+                (#eq? @obj "Console")
+                (#eq? @method "WriteLine"))
+  - name: no-async-void
+    description: Use Task-returning async methods except for event handlers
+    message: "Use `Task` instead of `async void` for `{{ $method }}`, then retry."
+    on:
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.cs"
+        new_content:
+          - kind: SyntaxTree
+            language: csharp
+            query: |
+              (method_declaration
+                (modifier) @modifier
+                returns: (predefined_type) @return_type
+                name: (identifier) @method
+                (#eq? @modifier "async")
+                (#eq? @return_type "void"))
+"#;
+
+    let dir = setup_config(config);
+    fs::write(
+        dir.path().join("Unsafe.cs"),
+        r#"public class Unsafe {
+    public async void SaveAsync() {
+        await Task.Delay(1);
+    }
+
+    public void Example() {
+        Console.WriteLine("debug");
+    }
+}"#,
+    )
+    .expect("write unsafe C# file");
+    fs::write(
+        dir.path().join("Safe.cs"),
+        r#"public class Safe {
+    public async Task SaveAsync() {
+        await Task.Delay(1);
+    }
+
+    public void Example(ILogger logger) {
+        logger.LogInformation("debug");
+    }
+}"#,
+    )
+    .expect("write safe C# file");
+
+    let output = Command::new(nudge_binary())
+        .arg("check")
+        .arg("Unsafe.cs")
+        .current_dir(dir.path())
+        .output()
+        .expect("run nudge check on unsafe file");
+    pretty_assert_eq!(output.status.code(), Some(1), "check should fail");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Unsafe.cs")
+            && stdout.contains("no-console-writeline")
+            && stdout.contains("no-async-void")
+            && stdout.contains("SaveAsync"),
+        "expected check to report both C# SyntaxTree rules, got: {stdout}"
+    );
+
+    let output = Command::new(nudge_binary())
+        .arg("check")
+        .arg("Safe.cs")
+        .current_dir(dir.path())
+        .output()
+        .expect("run nudge check on safe file");
+    pretty_assert_eq!(output.status.code(), Some(0), "check should pass");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Checked 1 files"),
+        "expected check to scan the safe C# file, got: {stdout}"
     );
 }


### PR DESCRIPTION
## Why this change

- SyntaxTree rule YAML uses compact language names such as `typescript`, `javascript`, and `csharp`, but the `nudge syntaxtree` CLI previously exposed clap-generated hyphenated names for compound variants: `type-script`, `java-script`, and `c-sharp`.
- Rule authors should be able to copy the same canonical language spelling between YAML and CLI query inspection. This PR makes `typescript`, `javascript`, and `csharp` the canonical CLI names.
- Existing users of the old hyphenated CLI spellings are not forced to change immediately: `type-script`, `java-script`, and `c-sharp` remain accepted aliases.
- The branch is updated on top of the merged Python and Go SyntaxTree work, preserving their docs and integration tests while adding CSharp coverage and shared CLI alias coverage.
- The shared Claude/Codex rule-writing docs list the supported SyntaxTree languages and describe the recovered-tree parser policy used by the implementation.

## Testing steps performed

```text
cargo test -p nudge test_syntaxtree_accepts_canonical_and_legacy_compound_language_names -- --nocapture

running 1 test
test cli::test_syntaxtree_accepts_canonical_and_legacy_compound_language_names ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 88 filtered out
```

```text
cargo test -p nudge csharp -- --nocapture

running 2 tests
test rules::schema::syntax::tests::test_language_parse_invalid_csharp_returns_tree_with_errors ... ok
test rules::schema::syntax::tests::test_treesitter_query_compile_valid_csharp ... ok

running 7 tests
test cli::test_syntaxtree_accepts_csharp_language_name ... ok
test syntax_tree::csharp::test_csharp_incomplete_code_uses_partial_tree ... ok
test syntax_tree::csharp::test_csharp_empty_catch_block ... ok
test syntax_tree::csharp::test_csharp_nullable_capture_and_suggestion_interpolation ... ok
test syntax_tree::csharp::test_csharp_async_void_edit ... ok
test syntax_tree::csharp::test_csharp_console_writeline ... ok
test syntax_tree::csharp::test_csharp_check_scans_write_and_edit_rules ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 82 filtered out
```

```text
cargo test -p nudge

test result: ok. 71 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 89 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

```text
cargo clippy -p nudge --all-targets -- -D warnings

Finished `dev` profile [unoptimized + debuginfo] target(s)
```

```text
cargo +nightly fmt --all --check

exit 0
```

```text
git diff --check

exit 0
```

```text
cargo run -q -p nudge -- claude docs | rg -n "csharp|typescript|javascript|Supported Languages|recovers"
cargo run -q -p nudge -- codex docs | rg -n "csharp|typescript|javascript|Supported Languages|recovers"

206:        language: rust              # One of: rust, typescript, javascript,
207:                                            # python, go, java, csharp, kotlin, haskell
213:  Supported Languages:
214:    rust, typescript, javascript, python, go, java, csharp, kotlin, haskell
216:  Use nudge syntaxtree --language csharp 'public class Example {}' to inspect
238:  Note: Tree-sitter recovers from incomplete or invalid syntax. SyntaxTree
```

```text
for lang in typescript type-script javascript java-script csharp c-sharp; do
  cargo run -q -p nudge -- syntaxtree --language "$lang" 'public class Test {}' >/tmp/nudge-${lang}.out 2>/tmp/nudge-${lang}.err || {
    echo "$lang failed"
    cat /tmp/nudge-${lang}.err
    exit 1
  }
  echo "$lang ok"
done

typescript ok
type-script ok
javascript ok
java-script ok
csharp ok
c-sharp ok
```

```text
cargo run -q -p nudge -- check

Checked 58 files against 6 rules
  - .nudge.yaml: 6 rules
```

```text
git merge-base --is-ancestor origin/main HEAD && echo origin-main-is-ancestor

origin-main-is-ancestor
```

## Notes

- No configuration changes are required after merge.
- PR #39 remains a draft until the coordinated SyntaxTree language stack is ready to land.
