### PR TITLE
Verify Kotlin syntax tree support

### DIFF
--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -218,11 +218,13 @@ const DOCS: &str = cstr!("\
   <white>Basic Syntax:</white>
     <yellow>content:</yellow>
       <yellow>- kind: SyntaxTree</yellow>
-        <yellow>language: rust</yellow>              <dim># Required: rust (more languages coming)</dim>
+        <yellow>language: kotlin</yellow>            <dim># Required</dim>
         <yellow>query: |</yellow>
-          <yellow>(function_item</yellow>
+          <yellow>(function_declaration</yellow>
             <yellow>name: (identifier) @fn_name)</yellow>
         <yellow>suggestion: \"...\"</yellow>           <dim># Optional: same as Regex</dim>
+
+    <dim>Supported languages: rust, typescript, javascript, python, go, java, csharp, kotlin, haskell</dim>
 
   <white>Query Syntax:</white>
     Tree-sitter uses S-expression queries. Nodes are matched by type (in parentheses)

--- a/packages/nudge/tests/it/syntax_tree/kotlin.rs
+++ b/packages/nudge/tests/it/syntax_tree/kotlin.rs
@@ -1,6 +1,11 @@
 //! Kotlin syntax tree tests.
 
+use std::fs;
+use std::process::{Command, Stdio};
+
 use pretty_assertions::assert_eq as pretty_assert_eq;
+
+use crate::{edit_hook, nudge_binary, run_nudge};
 
 use super::{run_hook_in_dir, setup_config, write_hook};
 
@@ -42,11 +47,13 @@ rules:
         "expected interrupt for println, got: {output}"
     );
 
-    // Should pass: logger call
+    // Should pass: logger call, plus println text in a comment and string
     let input = write_hook(
         "Test.kt",
         r#"fun main() {
-    logger.info("debug")
+    // println("debug")
+    val text = "println(\"debug\")"
+    logger.info(text)
 }"#,
     );
     let (exit_code, output) = run_hook_in_dir(&dir, &input);
@@ -105,4 +112,241 @@ rules:
         output.is_empty(),
         "expected passthrough for safe call, got: {output}"
     );
+}
+
+#[test]
+fn test_kotlin_edit_extension_function_suggestion_interpolation() {
+    let config = r#"
+version: 1
+rules:
+  - name: review-extension-function
+    description: Flag Kotlin extension functions in generated edits
+    message: "{{ $suggestion }}"
+    on:
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.kt"
+        new_content:
+          - kind: SyntaxTree
+            language: kotlin
+            query: |
+              (function_declaration
+                (user_type (identifier) @receiver)
+                name: (identifier) @fn_name)
+            suggestion: "Review extension function `{{ $receiver }}.{{ $fn_name }}` before retrying."
+"#;
+
+    let dir = setup_config(config);
+
+    let input = edit_hook(
+        "User.kt",
+        "old code",
+        r#"fun User.displayName(): String {
+    return name.orEmpty()
+}"#,
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected interrupt for extension function, got: {output}"
+    );
+    assert!(
+        output.contains("User.displayName"),
+        "expected capture interpolation in suggestion, got: {output}"
+    );
+
+    let input = edit_hook(
+        "User.kt",
+        "old code",
+        r#"fun displayName(user: User): String {
+    return user.name.orEmpty()
+}"#,
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0");
+    assert!(
+        output.is_empty(),
+        "expected passthrough for ordinary function, got: {output}"
+    );
+}
+
+#[test]
+fn test_kotlin_check_scans_write_and_edit_rules() {
+    let dir = tempfile::TempDir::new().expect("create temp dir");
+    fs::write(
+        dir.path().join(".nudge.yaml"),
+        r#"
+version: 1
+rules:
+  - name: kotlin-data-class
+    description: Review generated data classes
+    message: "Kotlin data class `{{ $class_name }}` needs an explicit review."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.kt"
+        content:
+          - kind: SyntaxTree
+            language: kotlin
+            query: |
+              (class_declaration
+                (modifiers (class_modifier) @modifier)
+                name: (identifier) @class_name
+                (#eq? @modifier "data"))
+  - name: kotlin-launch-call
+    description: Review coroutine launch calls introduced by edits
+    message: "Review coroutine launch on `{{ $receiver }}` before retrying."
+    on:
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.kt"
+        new_content:
+          - kind: SyntaxTree
+            language: kotlin
+            query: |
+              (call_expression
+                (navigation_expression
+                  (identifier) @receiver
+                  (identifier) @method)
+                (#eq? @method "launch"))
+"#,
+    )
+    .expect("write config");
+
+    let src = dir.path().join("src");
+    fs::create_dir(&src).expect("create src dir");
+    fs::write(
+        src.join("Unsafe.kt"),
+        r#"data class User(val name: String?)
+fun load(scope: CoroutineScope) {
+    scope.launch { fetch() }
+}"#,
+    )
+    .expect("write unsafe kotlin");
+    fs::write(
+        src.join("Safe.kt"),
+        r#"class User(val name: String?)
+fun load(scope: CoroutineScope) {
+    // scope.launch { fetch() }
+    val text = "scope.launch { fetch() }"
+    scope.async { fetch() }
+}"#,
+    )
+    .expect("write safe kotlin");
+
+    let (exit_code, stdout, stderr) = run_nudge_in_dir(&dir, &["check", "src/Safe.kt"]);
+    pretty_assert_eq!(
+        exit_code,
+        0,
+        "safe Kotlin should pass check, stdout: {stdout}, stderr: {stderr}"
+    );
+
+    let (exit_code, stdout, stderr) = run_nudge_in_dir(&dir, &["check", "src/Unsafe.kt"]);
+    assert!(
+        exit_code != 0,
+        "unsafe Kotlin should fail check, stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("src/Unsafe.kt:1 [kotlin-data-class]"),
+        "expected data class issue at line 1, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Kotlin data class `User` needs an explicit review."),
+        "expected data class capture interpolation, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("src/Unsafe.kt:3 [kotlin-launch-call]"),
+        "expected launch issue at line 3, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Review coroutine launch on `scope` before retrying."),
+        "expected launch capture interpolation, got: {stdout}"
+    );
+}
+
+#[test]
+fn test_kotlin_incomplete_code_uses_existing_parser_error_policy() {
+    let config = r#"
+version: 1
+rules:
+  - name: no-println
+    description: Don't use println in production code
+    message: "Use a logging framework instead of `println`."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.kt"
+        content:
+          - kind: SyntaxTree
+            language: kotlin
+            query: |
+              (call_expression
+                (identifier) @fn
+                (#eq? @fn "println"))
+"#;
+
+    let dir = setup_config(config);
+
+    let input = write_hook(
+        "Broken.kt",
+        r#"fun main() {
+    println("debug")
+    val unfinished =
+"#,
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected complete Kotlin nodes to match despite nearby syntax errors, got: {output}"
+    );
+
+    let input = write_hook("Broken.kt", "{{{{");
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0");
+    assert!(
+        output.is_empty(),
+        "expected unmatched malformed Kotlin to pass silently, got: {output}"
+    );
+}
+
+#[test]
+fn test_kotlin_syntaxtree_cli() {
+    let (exit_code, stdout, stderr) = run_nudge(&[
+        "syntaxtree",
+        "--language",
+        "kotlin",
+        "data class User(val name: String?)",
+    ]);
+
+    pretty_assert_eq!(exit_code, 0, "syntaxtree should exit 0, stderr: {stderr}");
+    assert!(
+        stdout.contains("class_declaration"),
+        "syntaxtree should show Kotlin class_declaration node, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("nullable_type"),
+        "syntaxtree should show Kotlin nullable_type node, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("User"),
+        "syntaxtree should show Kotlin identifier text, got: {stdout}"
+    );
+}
+
+fn run_nudge_in_dir(dir: &tempfile::TempDir, args: &[&str]) -> (i32, String, String) {
+    let output = Command::new(nudge_binary())
+        .args(args)
+        .current_dir(dir.path())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run nudge");
+
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    (exit_code, stdout, stderr)
 }


### PR DESCRIPTION
## Why this change

Kotlin was already present in the SyntaxTree language enum and grammar wiring, but its integration coverage was thinner than the supported-language surface. This PR verifies Kotlin end to end instead of assuming the shared tree-sitter path works everywhere.

The new coverage proves `language: kotlin` works through YAML/schema deserialization, query compilation, parser reuse through repeated hook/check/CLI invocations, capture spans, capture text interpolation, suggestion interpolation, PreToolUse Write and Edit evaluation, `nudge check` file scanning, incomplete-code parser behavior, and `nudge syntaxtree --language kotlin`.

It also fixes stale rule-writing docs. The shared Claude docs source, which Codex docs delegate to, now lists all supported SyntaxTree languages and uses a Kotlin-shaped example query.

## What changed

- Expanded `packages/nudge/tests/it/syntax_tree/kotlin.rs` with Kotlin-specific end-to-end coverage for:
  - `println` call detection with comment/string false-positive checks
  - unsafe `!!` non-null assertion detection
  - Edit-hook matching of extension functions with suggestion interpolation
  - `nudge check` scanning for both Write and Edit rules, including data classes and coroutine `launch` calls
  - incomplete Kotlin code following the existing parser/error policy
  - `nudge syntaxtree --language kotlin`
- Updated `packages/nudge/src/cmd/claude/docs.rs` so both `nudge claude docs` and `nudge codex docs` describe the current supported SyntaxTree language list.

## Testing steps performed

- `cargo test -p nudge --test it kotlin -- --nocapture`
  - 6 passed; 70 filtered out
- `cargo test -p nudge --test it syntax_tree -- --nocapture`
  - 31 passed; 45 filtered out
- `cargo test -p nudge`
  - unit tests: 64 passed in `src/lib.rs`
  - unit tests: 1 passed in `src/main.rs`
  - integration tests: 76 passed
  - doctests: 1 passed
- `cargo clippy -p nudge --all-targets -- -D warnings`
  - passed
- `cargo +nightly fmt --all --check`
  - passed
- `git diff --check`
  - passed
- `cargo run -q -p nudge -- check`
  - `Checked 58 files against 6 rules`
- `cargo run -q -p nudge -- syntaxtree --language kotlin 'data class User(val name: String?)'`
  - showed Kotlin `class_declaration` and `nullable_type` nodes
- `cargo run -q -p nudge -- claude docs | rg -n "language: kotlin|function_declaration|Supported languages: rust, typescript, javascript, python, go, java, csharp, kotlin, haskell"`
  - matched the updated docs text
- `cargo run -q -p nudge -- codex docs | rg -n "language: kotlin|function_declaration|Supported languages: rust, typescript, javascript, python, go, java, csharp, kotlin, haskell"`
  - matched the updated docs text

## Configuration changes after merge

None.