### PR TITLE
Verify TypeScript SyntaxTree support

### DIFF
--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -215,12 +215,15 @@ const DOCS: &str = cstr!("\
   against the parsed AST. This is useful when you need to match code structure,
   not just text patterns.
 
+  <white>Supported languages:</white>
+    rust, typescript, javascript, python, go, java, csharp, kotlin, haskell
+
   <white>Basic Syntax:</white>
     <yellow>content:</yellow>
       <yellow>- kind: SyntaxTree</yellow>
-        <yellow>language: rust</yellow>              <dim># Required: rust (more languages coming)</dim>
+        <yellow>language: typescript</yellow>        <dim># Required</dim>
         <yellow>query: |</yellow>
-          <yellow>(function_item</yellow>
+          <yellow>(function_declaration</yellow>
             <yellow>name: (identifier) @fn_name)</yellow>
         <yellow>suggestion: \"...\"</yellow>           <dim># Optional: same as Regex</dim>
 
@@ -228,8 +231,8 @@ const DOCS: &str = cstr!("\
     Tree-sitter uses S-expression queries. Nodes are matched by type (in parentheses)
     and captures are marked with <green>@name</green>.
 
-    <green>(function_item)</green>                    Match any function
-    <green>(function_item name: (identifier))</green> Match function with name field
+    <green>(function_declaration)</green>                    Match any function
+    <green>(function_declaration name: (identifier))</green> Match function with name field
     <green>(identifier) @fn_name</green>              Capture the identifier as \"fn_name\"
 
     See: <cyan>https://tree-sitter.github.io/tree-sitter/using-parsers/queries</cyan>

--- a/packages/nudge/src/rules/schema/syntax.rs
+++ b/packages/nudge/src/rules/schema/syntax.rs
@@ -17,8 +17,10 @@ pub enum Language {
     /// The Rust programming language.
     Rust,
     /// The TypeScript programming language.
+    #[value(name = "typescript", alias = "type-script")]
     TypeScript,
     /// The JavaScript programming language.
+    #[value(name = "javascript", alias = "java-script")]
     JavaScript,
     /// The Python programming language.
     Python,
@@ -27,6 +29,7 @@ pub enum Language {
     /// The Java programming language.
     Java,
     /// The C# programming language.
+    #[value(name = "csharp", alias = "c-sharp")]
     CSharp,
     /// The Kotlin programming language.
     Kotlin,
@@ -183,6 +186,8 @@ impl<'de> Deserialize<'de> for TreeSitterQuery {
 mod tests {
     use std::{panic::catch_unwind, sync::Mutex};
 
+    use clap::ValueEnum;
+
     use super::*;
 
     #[test]
@@ -197,6 +202,37 @@ mod tests {
         let code = "fn main( { }";
         let tree = Language::Rust.parse(code);
         assert!(tree.is_some());
+    }
+
+    #[test]
+    fn test_typescript_parse_invalid_returns_tree_with_errors() {
+        let code = "function process(data: any";
+        let tree = Language::TypeScript
+            .parse(code)
+            .expect("TypeScript parser should return an error-tolerant tree");
+        assert!(tree.root_node().has_error());
+    }
+
+    #[test]
+    fn test_cli_language_values_match_yaml_names_with_legacy_aliases() {
+        assert_eq!(
+            Language::from_str("typescript", false),
+            Ok(Language::TypeScript)
+        );
+        assert_eq!(
+            Language::from_str("type-script", false),
+            Ok(Language::TypeScript)
+        );
+        assert_eq!(
+            Language::from_str("javascript", false),
+            Ok(Language::JavaScript)
+        );
+        assert_eq!(
+            Language::from_str("java-script", false),
+            Ok(Language::JavaScript)
+        );
+        assert_eq!(Language::from_str("csharp", false), Ok(Language::CSharp));
+        assert_eq!(Language::from_str("c-sharp", false), Ok(Language::CSharp));
     }
 
     #[test]

--- a/packages/nudge/src/rules/schema/syntax.rs
+++ b/packages/nudge/src/rules/schema/syntax.rs
@@ -187,6 +187,7 @@ mod tests {
     use std::{panic::catch_unwind, sync::Mutex};
 
     use clap::ValueEnum;
+    use pretty_assertions::assert_eq as pretty_assert_eq;
 
     use super::*;
 
@@ -244,24 +245,24 @@ mod tests {
 
     #[test]
     fn test_cli_language_values_match_yaml_names_with_legacy_aliases() {
-        assert_eq!(
+        pretty_assert_eq!(
             Language::from_str("typescript", false),
             Ok(Language::TypeScript)
         );
-        assert_eq!(
+        pretty_assert_eq!(
             Language::from_str("type-script", false),
             Ok(Language::TypeScript)
         );
-        assert_eq!(
+        pretty_assert_eq!(
             Language::from_str("javascript", false),
             Ok(Language::JavaScript)
         );
-        assert_eq!(
+        pretty_assert_eq!(
             Language::from_str("java-script", false),
             Ok(Language::JavaScript)
         );
-        assert_eq!(Language::from_str("csharp", false), Ok(Language::CSharp));
-        assert_eq!(Language::from_str("c-sharp", false), Ok(Language::CSharp));
+        pretty_assert_eq!(Language::from_str("csharp", false), Ok(Language::CSharp));
+        pretty_assert_eq!(Language::from_str("c-sharp", false), Ok(Language::CSharp));
     }
 
     #[test]

--- a/packages/nudge/tests/it/cli.rs
+++ b/packages/nudge/tests/it/cli.rs
@@ -126,6 +126,42 @@ fn test_syntaxtree_inline_code() {
 }
 
 #[test]
+fn test_syntaxtree_typescript_language() {
+    let (exit_code, stdout, _stderr) = run_nudge(&[
+        "syntaxtree",
+        "--language",
+        "typescript",
+        "interface User { name: string; age?: number }",
+    ]);
+
+    pretty_assert_eq!(exit_code, 0, "syntaxtree should exit 0");
+    assert!(
+        stdout.contains("interface_declaration"),
+        "syntaxtree should show TypeScript interface node, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("property_signature") && stdout.contains("age"),
+        "syntaxtree should show TypeScript property signatures, got: {stdout}"
+    );
+}
+
+#[test]
+fn test_syntaxtree_typescript_legacy_alias() {
+    let (exit_code, stdout, _stderr) = run_nudge(&[
+        "syntaxtree",
+        "--language",
+        "type-script",
+        "const name = user.profile?.name;",
+    ]);
+
+    pretty_assert_eq!(exit_code, 0, "syntaxtree should exit 0");
+    assert!(
+        stdout.contains("member_expression"),
+        "legacy type-script alias should still parse TypeScript, got: {stdout}"
+    );
+}
+
+#[test]
 fn test_syntaxtree_shows_field_names() {
     let (exit_code, stdout, _stderr) = run_nudge(&[
         "syntaxtree",

--- a/packages/nudge/tests/it/syntax_tree.rs
+++ b/packages/nudge/tests/it/syntax_tree.rs
@@ -11,6 +11,7 @@ mod java;
 mod javascript;
 mod kotlin;
 mod python;
+mod typescript_end_to_end;
 mod typescript_errors;
 mod typescript_types;
 
@@ -65,6 +66,23 @@ fn run_hook_in_dir(dir: &TempDir, input: &str) -> (i32, String) {
     (exit_code, combined)
 }
 
+/// Run a nudge subcommand in the given directory.
+fn run_nudge_in_dir(dir: &TempDir, args: &[&str]) -> (i32, String, String) {
+    let output = Command::new(nudge_binary())
+        .args(args)
+        .current_dir(dir.path())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to run nudge");
+
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    (exit_code, stdout, stderr)
+}
+
 /// Build a PreToolUse hook JSON payload for Write tool.
 fn write_hook(file_path: &str, content: &str) -> String {
     serde_json::json!({
@@ -78,6 +96,25 @@ fn write_hook(file_path: &str, content: &str) -> String {
         "tool_input": {
             "file_path": file_path,
             "content": content
+        }
+    })
+    .to_string()
+}
+
+/// Build a PreToolUse hook JSON payload for Edit tool.
+fn edit_hook(file_path: &str, old_string: &str, new_string: &str) -> String {
+    serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "test",
+        "transcript_path": "/tmp/test",
+        "permission_mode": "default",
+        "cwd": "/tmp",
+        "tool_name": "Edit",
+        "tool_use_id": "123",
+        "tool_input": {
+            "file_path": file_path,
+            "old_string": old_string,
+            "new_string": new_string
         }
     })
     .to_string()

--- a/packages/nudge/tests/it/syntax_tree/typescript_end_to_end.rs
+++ b/packages/nudge/tests/it/syntax_tree/typescript_end_to_end.rs
@@ -1,0 +1,217 @@
+//! TypeScript end-to-end SyntaxTree coverage.
+
+use std::fs;
+
+use pretty_assertions::assert_eq as pretty_assert_eq;
+
+use super::{edit_hook, run_hook_in_dir, run_nudge_in_dir, setup_config, write_hook};
+
+#[test]
+fn test_typescript_write_interpolates_captures_and_suggestions() {
+    let config = r#"
+version: 1
+rules:
+  - name: no-any-parameters
+    description: Avoid any in TypeScript parameters
+    message: "{{ $suggestion }}"
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.ts"
+        content:
+          - kind: SyntaxTree
+            language: typescript
+            query: |
+              (required_parameter
+                pattern: (identifier) @param
+                type: (type_annotation (predefined_type) @type)
+                (#eq? @type "any"))
+            suggestion: "Parameter `{{ $param }}` uses `{{ $type }}`."
+"#;
+
+    let dir = setup_config(config);
+
+    let input = write_hook("src/service.ts", "function process(data: any): void {}");
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected interrupt for any parameter, got: {output}"
+    );
+    assert!(
+        output.contains("Parameter `data` uses `any`."),
+        "expected TypeScript capture interpolation in suggestion, got: {output}"
+    );
+
+    let safe_input = write_hook(
+        "src/service.ts",
+        r#"
+// function process(data: any): void {}
+const sample = "function process(data: any): void {}";
+function process(data: unknown): void {}
+"#,
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &safe_input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0");
+    assert!(
+        output.is_empty(),
+        "expected comments, strings, and unknown type to pass, got: {output}"
+    );
+
+    let js_input = write_hook("src/service.js", "function process(data: any): void {}");
+    let (exit_code, output) = run_hook_in_dir(&dir, &js_input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0");
+    assert!(
+        output.is_empty(),
+        "expected .js files to pass a .ts TypeScript rule, got: {output}"
+    );
+}
+
+#[test]
+fn test_typescript_edit_evaluates_new_content_with_non_null_assertions() {
+    let config = r#"
+version: 1
+rules:
+  - name: no-non-null-assertions
+    description: Avoid TypeScript non-null assertions
+    message: "{{ $suggestion }}"
+    on:
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.ts"
+        new_content:
+          - kind: SyntaxTree
+            language: typescript
+            query: "(non_null_expression) @assertion"
+            suggestion: "Replace `{{ $assertion }}` with optional chaining or a guard."
+"#;
+
+    let dir = setup_config(config);
+
+    let input = edit_hook(
+        "src/user.ts",
+        "const name = user.profile?.name;",
+        "const name = user.profile!.name;",
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected interrupt for non-null assertion edit, got: {output}"
+    );
+    assert!(
+        output.contains("user.profile!"),
+        "expected captured non-null expression text in suggestion, got: {output}"
+    );
+
+    let safe_input = edit_hook(
+        "src/user.ts",
+        "const name = user.profile!.name;",
+        "const name = user.profile?.name;",
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, &safe_input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0");
+    assert!(
+        output.is_empty(),
+        "expected optional chaining edit to pass, got: {output}"
+    );
+}
+
+#[test]
+fn test_typescript_check_scans_files_and_reports_capture_lines() {
+    let config = r#"
+version: 1
+rules:
+  - name: no-exported-interfaces
+    description: Prefer type aliases in this project
+    message: "Convert interface `{{ $iface }}` to a type alias."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.ts"
+        content:
+          - kind: SyntaxTree
+            language: typescript
+            query: "(interface_declaration name: (type_identifier) @iface)"
+"#;
+
+    let dir = setup_config(config);
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).expect("create src dir");
+    fs::write(
+        src_dir.join("user.ts"),
+        "\nexport interface User {\n  name: string;\n}\n",
+    )
+    .expect("write TypeScript fixture");
+    fs::write(src_dir.join("user.js"), "export interface User {}\n")
+        .expect("write JavaScript fixture");
+
+    let (exit_code, stdout, stderr) = run_nudge_in_dir(&dir, &["check", "src"]);
+    let output = format!("{stdout}{stderr}");
+
+    pretty_assert_eq!(exit_code, 1, "expected check to fail, output: {output}");
+    assert!(
+        output.contains("src/user.ts:2 [no-exported-interfaces]"),
+        "expected TypeScript issue on the interface line, got: {output}"
+    );
+    assert!(
+        output.contains("Convert interface `User` to a type alias."),
+        "expected interface capture interpolation, got: {output}"
+    );
+    assert!(
+        !output.contains("src/user.js"),
+        "expected .js fixture to be ignored by the .ts rule, got: {output}"
+    );
+}
+
+#[test]
+fn test_typescript_incomplete_code_uses_error_tolerant_parse_tree() {
+    let config = r#"
+version: 1
+rules:
+  - name: no-any-parameters
+    description: Avoid any in TypeScript parameters
+    message: "Parameter `{{ $param }}` uses `{{ $type }}`."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.ts"
+        content:
+          - kind: SyntaxTree
+            language: typescript
+            query: |
+              (required_parameter
+                pattern: (identifier) @param
+                type: (type_annotation (predefined_type) @type)
+                (#eq? @type "any"))
+"#;
+
+    let dir = setup_config(config);
+
+    let input = write_hook("src/service.ts", "function process(data: any");
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected incomplete TypeScript to still expose parsed captures, got: {output}"
+    );
+    assert!(
+        output.contains("Parameter `data` uses `any`."),
+        "expected captures from the error-tolerant parse tree, got: {output}"
+    );
+
+    let invalid_input = write_hook("src/service.ts", "{{{{");
+    let (exit_code, output) = run_hook_in_dir(&dir, &invalid_input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0");
+    assert!(
+        output.is_empty(),
+        "expected unrelated invalid TypeScript to pass without matching, got: {output}"
+    );
+}


### PR DESCRIPTION
## Why this change

TypeScript support was mostly present in the SyntaxTree implementation, but verification exposed a shared spelling mismatch: YAML accepted canonical lower-case language names like `typescript`, while the `syntaxtree` CLI only accepted Clap's default hyphenated form, `type-script`. That made `nudge syntaxtree --language typescript` fail even though `language: typescript` worked in rules.

This PR aligns CLI language names with YAML for `typescript`, `javascript`, and `csharp`, while preserving the prior hyphenated CLI aliases `type-script`, `java-script`, and `c-sharp`. It also adds TypeScript end-to-end coverage across the surfaces that were not previously proven.

## What changed

- Made `typescript`, `javascript`, and `csharp` the canonical CLI `Language` values, with legacy hyphenated aliases preserved.
- Added TypeScript tests for `syntaxtree --language typescript` and the legacy `type-script` alias.
- Added TypeScript SyntaxTree integration coverage for:
  - YAML/schema deserialization and query compilation through real rule configs.
  - PreToolUse `Write` capture interpolation and suggestion interpolation.
  - PreToolUse `Edit` evaluation of `new_content`.
  - `nudge check` scanning with capture-derived line/message output.
  - incomplete/error-tolerant TypeScript parsing behavior.
  - practical non-false-positive cases for comments, strings, optional chaining, safe types, and `.js` files outside `**/*.ts` rules.
- Updated emitted rule-writing docs, shared by `nudge claude docs` and `nudge codex docs`, to list the merged supported SyntaxTree languages and show canonical `language: typescript`.
- Merged latest `origin/main` after the Python and Go SyntaxTree support PRs landed, preserving their docs/tests while resolving shared helper/docs conflicts.

## Testing steps performed

- `cargo test -p nudge`
  - 71 lib tests passed
  - 1 main test passed
  - 89 integration tests passed
  - 1 doctest passed
- `cargo clippy -p nudge --all-targets -- -D warnings`
  - passed
- `cargo +nightly fmt --all --check`
  - passed
- `git diff --check`
  - passed
- Manual CLI/doc spot checks:
  - `cargo run -q -p nudge -- syntaxtree --language typescript 'interface User { name: string }'`
  - `cargo run -q -p nudge -- syntaxtree --language type-script 'const name = user.profile?.name;'`
  - `cargo run -q -p nudge -- claude docs | rg -n "language: typescript|rust, typescript|Supported Languages"`
  - `cargo run -q -p nudge -- codex docs | rg -n "language: typescript|rust, typescript|Supported Languages"`

## Configuration changes after merge

None. Existing hyphenated CLI language spellings continue to work as aliases; YAML spellings remain unchanged.