### PR TITLE
Keep SyntaxTree docs TypeScript-focused

### DIFF
--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -218,7 +218,7 @@ const DOCS: &str = cstr!("\
   <white>Basic Syntax:</white>
     <yellow>content:</yellow>
       <yellow>- kind: SyntaxTree</yellow>
-        <yellow>language: kotlin</yellow>            <dim># One of: rust, typescript, javascript,</dim>
+        <yellow>language: typescript</yellow>        <dim># One of: rust, typescript, javascript,</dim>
                                             <dim># python, go, java, csharp, kotlin, haskell</dim>
         <yellow>query: |</yellow>
           <yellow>(function_declaration</yellow>
@@ -234,7 +234,7 @@ const DOCS: &str = cstr!("\
 
     <green>(function_declaration)</green>                    Match any function
     <green>(function_declaration name: (identifier))</green> Match function with name field
-    <green>(identifier) @fn_name</green>                     Capture the identifier as \"fn_name\"
+    <green>(identifier) @fn_name</green>              Capture the identifier as \"fn_name\"
 
     See: <cyan>https://tree-sitter.github.io/tree-sitter/using-parsers/queries</cyan>
 


### PR DESCRIPTION
## Why this change

The Kotlin verification PR landed strong Kotlin coverage, but the central rule-writing docs should keep their reference SyntaxTree example focused on TypeScript/Rust rather than rotating to each newly verified language. This restores the SyntaxTree docs example to TypeScript while keeping the full supported-language list intact.

## Testing steps performed

- 206:        [33mlanguage: typescript[39m        [2m# One of: rust, typescript, javascript,[22m
213:  [37mSupported Languages:[39m
- 206:        [33mlanguage: typescript[39m        [2m# One of: rust, typescript, javascript,[22m
213:  [37mSupported Languages:[39m
- 
- 

## Configuration changes after merge

None.