### PR TITLE
Document CI check mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Nudge uses agent hook systems to watch supported operations:
 - [Claude Code hooks](https://docs.anthropic.com/en/docs/claude-code/hooks)
 - [Codex CLI hooks](https://developers.openai.com/codex/hooks)
 
+For provider-free usage, `nudge check` runs file rules as a one-shot project
+checker for CI, pre-commit hooks, and other scripts. See
+[CI and programmatic checks](docs/ci.md).
+
 When something matches a rule you've defined:
 
 - **Interrupt** (PreToolUse rules): Nudge catches the issue *before* it's written and explains what to fix
@@ -160,7 +164,9 @@ You'll see Nudge's hook being called and its response in the logs.
 
 ### CI / Linting Mode
 
-Use `nudge check` to validate your entire project against rules, useful for CI pipelines or local linting:
+Use `nudge check` to validate your project against file rules without Claude
+Code, Codex CLI, or installed hooks. This is the right mode for CI pipelines,
+pre-commit checks, release gates, and other programmatic usage.
 
 ```bash
 # Check entire project
@@ -174,7 +180,12 @@ nudge check "**/*.rs"
 nudge check || exit 1
 ```
 
-`nudge check` only evaluates file-based block rules for `PreToolUse` Write/Edit matchers. It ignores `action: substitute` rules because substitutions rewrite live Bash hook payloads and need a provider to receive `updatedInput`.
+`nudge check` evaluates file-based block rules for `PreToolUse` Write/Edit
+matchers, including Regex, SyntaxTree, and External content matchers. It
+supports SyntaxTree rules for Rust, TypeScript, JavaScript, Python, Go, Java,
+C#, Kotlin, and Haskell. Hook-only behavior such as Bash substitutions,
+WebFetch, UserPromptSubmit reminders, permissions, delete events, and
+workflows still belongs to live hook mode.
 
 Example output when violations are found:
 
@@ -199,6 +210,9 @@ When all checks pass:
 Checked 25 files against 6 rules
   - .nudge.yaml: 6 rules
 ```
+
+For the full check-mode contract, CI examples, and supported-feature matrix,
+see [CI and programmatic checks](docs/ci.md).
 
 ### Manual Testing
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,172 @@
+# CI and Programmatic Checks
+
+`nudge check` runs Nudge as a one-shot project checker. It does not require
+Claude Code, Codex CLI, hook installation, or a live agent session. Use it for
+CI jobs, local pre-commit checks, release gates, or any script that needs a
+plain command with a reliable exit status.
+
+## Quick Start
+
+From a project with Nudge rules:
+
+```bash
+# Check the whole project from the current directory.
+nudge check
+
+# Check specific directories, files, or glob patterns.
+nudge check src/ docs/
+nudge check src/lib.rs
+nudge check "**/*.rs"
+```
+
+Exit behavior:
+
+- `0`: no checkable violations were found, or no file-based rules exist.
+- `1`: one or more checkable violations were found.
+- Other non-zero exits: configuration, argument, or runtime errors.
+
+Example failure output:
+
+```text
+x Found 2 issues in 1 file
+
+src/lib.rs:42 [no-unwrap]
+  Use `.expect("descriptive error message")` instead of `.unwrap()`, then retry.
+
+src/lib.rs:57 [no-inline-imports]
+  Move this `use` statement to the top of the file, then retry.
+
+Checked 25 files against 6 rules
+```
+
+## Rule Discovery
+
+`nudge check` loads the same rule files as hook mode:
+
+1. User-level `rules.yaml` from Nudge's platform config directory, if present.
+2. Project `.nudge.yaml`, if present.
+3. Every YAML file under project `.nudge/`, walked recursively in file-name
+   order.
+
+Missing rule files are ignored. Invalid YAML or invalid rule schema fails the
+command before checking files.
+
+## What Check Mode Evaluates
+
+Check mode evaluates provider-independent file rules:
+
+| Rule surface | CI support | Notes |
+|--------------|------------|-------|
+| `PreToolUse` `Write` with `content` | Yes | The current file body is checked as the would-be write content. |
+| `PreToolUse` `Edit` with `new_content` | Yes | The current file body is checked as the would-be edited content. |
+| `kind: Regex` content matchers | Yes | Capture groups and message interpolation work. |
+| `kind: SyntaxTree` content matchers | Yes | Uses the configured tree-sitter language. |
+| `kind: External` content matchers | Yes | The file body is piped to stdin. A non-zero command exit means the rule matched. |
+| `action: block` | Yes | Violations are printed and the command exits `1`. |
+| `action: substitute` | No | Substitutions need a live Bash hook payload and provider `updatedInput`. |
+| `PreToolUse` `Bash` | No | Bash rules inspect commands, not files. |
+| `PreToolUse` `WebFetch` | No | WebFetch rules inspect URLs and prompts, not files. |
+| `UserPromptSubmit` | No | Prompt reminders need a live user prompt. |
+| `PermissionRequest` | No | Permission requests are parsed in hook mode but not matchable from YAML. |
+| `Delete` | No | Delete events are normalized in hook mode but not matchable from YAML yet. |
+| Workflows | No | Workflow gates depend on live hook state. |
+
+Check mode scans files as UTF-8 text. Files that cannot be read as text are
+skipped at debug log level, so keep rules targeted with `file` globs.
+
+## Supported Syntax Languages
+
+`kind: SyntaxTree` works in check mode for every supported Nudge language:
+
+- `rust`
+- `typescript`
+- `javascript`
+- `python`
+- `go`
+- `java`
+- `csharp` (`c-sharp` is accepted as an alias)
+- `kotlin`
+- `haskell`
+
+Use `nudge syntaxtree --language <language> <file-or-source>` when writing a
+query. This prints the parser's node names so the query can match the actual
+grammar shape for that language.
+
+## CI Examples
+
+GitHub Actions:
+
+```yaml
+name: Nudge
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  nudge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Nudge
+        run: curl -sSfL https://raw.githubusercontent.com/attunehq/nudge/main/scripts/install.sh | bash
+      - name: Check Nudge rules
+        run: nudge check
+```
+
+Local pre-commit hook:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+nudge check
+```
+
+Target only staged paths from another script:
+
+```bash
+git diff --cached --name-only --diff-filter=ACMR |
+  xargs -r nudge check
+```
+
+## Writing CI-Friendly Rules
+
+Rules intended for `nudge check` should use file-based Write or Edit hooks with
+clear file globs:
+
+```yaml
+version: 1
+rules:
+  - name: no-unwrap
+    description: Require contextual panics in Rust
+    message: "Use `.expect(\"...\")` with context instead of `.unwrap()`, then retry."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.rs"
+        content:
+          - kind: SyntaxTree
+            language: rust
+            query: |
+              (call_expression
+                function: (field_expression
+                  field: (field_identifier) @method)
+                (#eq? @method "unwrap"))
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.rs"
+        new_content:
+          - kind: SyntaxTree
+            language: rust
+            query: |
+              (call_expression
+                function: (field_expression
+                  field: (field_identifier) @method)
+                (#eq? @method "unwrap"))
+```
+
+For deterministic command rewrites, keep using `action: substitute` in hook
+mode. Pair it with a separate file-based block rule only when there is a real
+file-state invariant that CI can verify.

--- a/packages/nudge/src/git.rs
+++ b/packages/nudge/src/git.rs
@@ -30,24 +30,44 @@ pub fn current_branch(cwd: &Path) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
+    use pretty_assertions::assert_eq as pretty_assert_eq;
+    use std::process::Command;
 
-    #[test]
-    fn test_current_branch_in_git_repo() {
-        // This test runs in the nudge repo, so we should get a branch name
-        let cwd = env::current_dir().expect("get cwd");
-        let branch = current_branch(&cwd);
-        // We should be on some branch (could be main, a feature branch, etc.)
+    fn git(cwd: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(cwd)
+            .args(args)
+            .output()
+            .expect("run git");
+
         assert!(
-            branch.is_some(),
-            "expected to be in a git repo with a branch"
+            output.status.success(),
+            "git command failed: git -C {} {}\nstdout:\n{}\nstderr:\n{}",
+            cwd.display(),
+            args.join(" "),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
         );
     }
 
     #[test]
+    fn test_current_branch_in_git_repo() {
+        let dir = tempfile::TempDir::new().expect("create temp dir");
+        git(dir.path(), &["init"]);
+        git(dir.path(), &["checkout", "-b", "nudge-test-branch"]);
+
+        let branch = current_branch(dir.path());
+
+        pretty_assert_eq!(branch.as_deref(), Some("nudge-test-branch"));
+    }
+
+    #[test]
     fn test_current_branch_not_git_repo() {
-        // /tmp is unlikely to be a git repo
-        let branch = current_branch(Path::new("/tmp"));
+        let dir = tempfile::TempDir::new().expect("create temp dir");
+
+        let branch = current_branch(dir.path());
+
         assert!(branch.is_none(), "expected None for non-git directory");
     }
 }

--- a/packages/nudge/tests/it/check.rs
+++ b/packages/nudge/tests/it/check.rs
@@ -1,0 +1,185 @@
+//! Integration tests for provider-free `nudge check` behavior.
+
+use std::fs;
+use std::process::{Command, Stdio};
+
+use pretty_assertions::assert_eq as pretty_assert_eq;
+use tempfile::TempDir;
+
+use crate::nudge_binary;
+
+fn run_nudge_in_dir(dir: &TempDir, args: &[&str]) -> (i32, String, String) {
+    let output = Command::new(nudge_binary())
+        .args(args)
+        .current_dir(dir.path())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run nudge");
+
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    (exit_code, stdout, stderr)
+}
+
+#[test]
+fn check_runs_file_rules_without_agent_provider() {
+    let dir = TempDir::new().expect("create temp dir");
+    fs::write(
+        dir.path().join(".nudge.yaml"),
+        r#"
+version: 1
+rules:
+  - name: block-todo-write
+    description: Block TODO markers in committed text files
+    message: "Resolve TODO `{{ $todo }}` before commit."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.txt"
+        content:
+          - kind: Regex
+            pattern: "TODO: (?P<todo>.+)"
+  - name: block-fixme-edit
+    description: Block FIXME markers introduced by edits
+    message: "Resolve FIXME before commit."
+    on:
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.txt"
+        new_content:
+          - kind: Regex
+            pattern: "FIXME"
+  - name: require-approved-marker
+    description: Markdown release notes require an approval marker
+    message: "Add APPROVED marker. Verify with `{{ $command }}`."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.md"
+        content:
+          - kind: External
+            command: ["grep", "-q", "APPROVED"]
+  - name: ignored-bash-substitute
+    action: substitute
+    on:
+      - hook: PreToolUse
+        tool: Bash
+        command:
+          - kind: Regex
+            pattern: "^npm install"
+            replace: "yarn add"
+  - name: ignored-webfetch
+    message: "Hook-only WebFetch rule."
+    on:
+      - hook: PreToolUse
+        tool: WebFetch
+        url:
+          - kind: Regex
+            pattern: "example.com"
+  - name: ignored-prompt
+    message: "Hook-only prompt reminder."
+    on:
+      - hook: UserPromptSubmit
+        prompt:
+          - kind: Regex
+            pattern: "release"
+"#,
+    )
+    .expect("write config");
+
+    fs::create_dir_all(dir.path().join("src")).expect("create src dir");
+    fs::create_dir_all(dir.path().join("docs")).expect("create docs dir");
+    fs::write(
+        dir.path().join("src/bad.txt"),
+        "TODO: remove temporary note\nFIXME: finish this\n",
+    )
+    .expect("write bad txt");
+    fs::write(
+        dir.path().join("src/good.txt"),
+        "Plain text with no markers.\n",
+    )
+    .expect("write good txt");
+    fs::write(
+        dir.path().join("docs/bad.md"),
+        "# Release Notes\n\nMissing the marker.\n",
+    )
+    .expect("write bad markdown");
+    fs::write(
+        dir.path().join("docs/good.md"),
+        "# Release Notes\n\nAPPROVED\n",
+    )
+    .expect("write good markdown");
+
+    let (exit_code, stdout, stderr) = run_nudge_in_dir(&dir, &["check", "src", "docs"]);
+
+    pretty_assert_eq!(
+        exit_code,
+        1,
+        "check should fail for file-rule violations, stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("src/bad.txt:1 [block-todo-write]"),
+        "expected Write regex issue with line number, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Resolve TODO `remove temporary note` before commit."),
+        "expected regex capture interpolation, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("src/bad.txt:2 [block-fixme-edit]"),
+        "expected Edit regex issue with line number, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("docs/bad.md:1 [require-approved-marker]"),
+        "expected External issue with line number, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Verify with `grep -q APPROVED`."),
+        "expected External command interpolation, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("ignored-bash-substitute")
+            && !stdout.contains("ignored-webfetch")
+            && !stdout.contains("ignored-prompt"),
+        "hook-only rules should not report in check mode, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("src/good.txt") && !stdout.contains("docs/good.md"),
+        "passing files should not report issues, got: {stdout}"
+    );
+}
+
+#[test]
+fn check_exits_successfully_when_no_file_rules_exist() {
+    let dir = TempDir::new().expect("create temp dir");
+    fs::write(
+        dir.path().join(".nudge.yaml"),
+        r#"
+version: 1
+rules:
+  - name: prompt-only
+    message: "Remember the release checklist."
+    on:
+      - hook: UserPromptSubmit
+        prompt:
+          - kind: Regex
+            pattern: "release"
+"#,
+    )
+    .expect("write config");
+
+    let (exit_code, stdout, stderr) = run_nudge_in_dir(&dir, &["check"]);
+
+    pretty_assert_eq!(
+        exit_code,
+        0,
+        "check should pass when nothing is checkable, stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("No file-based rules found."),
+        "expected no-file-rule summary, got: {stdout}"
+    );
+}

--- a/packages/nudge/tests/it/main.rs
+++ b/packages/nudge/tests/it/main.rs
@@ -7,6 +7,7 @@
 
 mod bash;
 mod basic;
+mod check;
 mod cli;
 mod codex;
 mod edit_tool;


### PR DESCRIPTION
## Why this change

- The main Nudge documentation explains Claude Code and Codex CLI hook integrations, but `nudge check` is also a provider-free one-shot mode for CI, pre-commit hooks, release gates, and other scripts.
- Programmatic users need a clear contract for what `nudge check` loads, what exits it returns, which rule surfaces it evaluates, and which hook-only features intentionally remain outside check mode.
- This adds a dedicated CI/programmatic guide, links it from the README, and documents that check mode evaluates file-based block rules for `PreToolUse` Write/Edit using Regex, SyntaxTree, and External content matchers.
- The documentation also spells out SyntaxTree language support across Rust, TypeScript, JavaScript, Python, Go, Java, C#, Kotlin, and Haskell.
- The test suite now has provider-free check-mode coverage for Write/Edit regex rules, External matchers, path selection, exit/output behavior, and explicit skipping of hook-only rules. While verifying, the ambient-branch-dependent git unit test was made deterministic by creating its own temporary branch fixture.

## Testing steps performed

```text
$ cargo test -p nudge --test it check:: -- --nocapture
running 2 tests
test check::check_exits_successfully_when_no_file_rules_exist ... ok
test check::check_runs_file_rules_without_agent_provider ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 115 filtered out; finished in 0.61s
```

```text
$ cargo test -p nudge --test it syntax_tree -- --nocapture
running 64 tests
...
test result: ok. 64 passed; 0 failed; 0 ignored; 0 measured; 53 filtered out; finished in 0.78s
```

```text
$ cargo test -p nudge
running 83 tests
...
test result: ok. 83 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s

running 1 test
test cmd::codex::setup::tests::detects_inline_hooks_table ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 117 tests
...
test result: ok. 117 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.86s

Doc-tests nudge
running 1 test
test packages/nudge/src/template.rs - template::interpolate (line 27) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

```text
$ cargo clippy -p nudge --all-targets --all-features -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.78s
```

```text
$ cargo +nightly fmt --all --check
# no output; exited 0
```

```text
$ cargo run -q -p nudge -- check
✓ Checked 60 files against 6 rules
  - .nudge.yaml: 6 rules
```

```text
$ cargo run -q -p nudge -- validate
Config file: "/Users/jess/Library/Application Support/com.attunehq.nudge/rules.yaml"
[]

------

Config file: ".nudge.yaml"
# printed parsed rules successfully; exited 0
```

```text
$ git diff --check
# no output; exited 0
```

Smart quote scan over changed docs/tests/code also returned no matches.