### PR TITLE
Tighten rule config validation

### DIFF
--- a/packages/nudge/src/cmd/validate.rs
+++ b/packages/nudge/src/cmd/validate.rs
@@ -3,7 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use clap::Args;
-use color_eyre::eyre::{Context, Result};
+use color_eyre::eyre::{Context, Result, bail};
 use nudge::rules;
 
 #[derive(Args, Clone, Debug)]
@@ -37,6 +37,14 @@ fn validate_all() -> Result<()> {
 
 /// Validate a single config file and print results.
 fn validate_file(path: &Path) -> Result<()> {
+    if !path.exists() {
+        bail!("config file does not exist: {}", path.display());
+    }
+
+    if !path.is_file() {
+        bail!("config path is not a file: {}", path.display());
+    }
+
     let rules = rules::load_from(path).context("parse rules file")?;
     let yaml = serde_yaml::to_string(&rules).context("serialize rules")?;
     println!("{yaml}");

--- a/packages/nudge/src/rules/schema.rs
+++ b/packages/nudge/src/rules/schema.rs
@@ -1,7 +1,7 @@
 //! Schema types for user-defined rules.
 
 use monostate::MustBe;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 
 use crate::{
     fmap_match,
@@ -23,6 +23,7 @@ mod url;
 
 /// A rule configuration file.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RuleConfig {
     /// The version of the rule configuration file.
     pub version: MustBe!(1),
@@ -33,6 +34,7 @@ pub struct RuleConfig {
 
 /// A single rule definition.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Rule {
     /// Unique identifier for this rule.
     pub name: String,
@@ -61,7 +63,21 @@ pub struct Rule {
     /// Every incoming hook event from the agent is evaluated against this list
     /// in the order in which they are defined; if any rule matches then the
     /// overall rule is considered to match.
+    #[serde(deserialize_with = "deserialize_non_empty_vec")]
     pub on: Vec<Hook>,
+}
+
+fn deserialize_non_empty_vec<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    let values = Vec::<T>::deserialize(deserializer)?;
+    if values.is_empty() {
+        return Err(de::Error::invalid_length(0, &"at least one matcher"));
+    }
+
+    Ok(values)
 }
 
 impl Rule {
@@ -239,6 +255,7 @@ pub enum PreToolUseMatcher {
 
 /// Matches the Write tool.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PreToolUseWriteMatcher {
     // Monostate fields to parse the overall object.
     hook: MustBe!("PreToolUse"),
@@ -255,12 +272,13 @@ pub struct PreToolUseWriteMatcher {
     ///
     /// When the content being written by the agent matches all of these
     /// patterns, the rule is triggered.
-    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_non_empty_vec")]
     pub content: Vec<ContentMatcher>,
 }
 
 /// Matches the Edit tool.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PreToolUseEditMatcher {
     // Monostate fields to parse the overall object.
     hook: MustBe!("PreToolUse"),
@@ -277,12 +295,13 @@ pub struct PreToolUseEditMatcher {
     ///
     /// When the new content being written by the agent matches all of these
     /// patterns, the rule is triggered.
-    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_non_empty_vec")]
     pub new_content: Vec<ContentMatcher>,
 }
 
 /// Matches the WebFetch tool.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PreToolUseWebFetchMatcher {
     // Monostate fields to parse the overall object.
     hook: MustBe!("PreToolUse"),
@@ -292,12 +311,13 @@ pub struct PreToolUseWebFetchMatcher {
     ///
     /// When the URL being fetched by the agent matches all of these
     /// patterns, the rule is triggered.
-    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_non_empty_vec")]
     pub url: Vec<UrlMatcher>,
 }
 
 /// Matches the Bash tool.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PreToolUseBashMatcher {
     // Monostate fields to parse the overall object.
     hook: MustBe!("PreToolUse"),
@@ -307,7 +327,7 @@ pub struct PreToolUseBashMatcher {
     ///
     /// When the command being executed by the agent matches all of these
     /// patterns, the rule is triggered.
-    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_non_empty_vec")]
     pub command: Vec<ContentMatcher>,
 
     /// Project state matchers.
@@ -321,6 +341,7 @@ pub struct PreToolUseBashMatcher {
 
 /// Matches the UserPromptSubmit hook.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct UserPromptSubmitMatcher {
     // Monostate field to parse the overall object.
     hook: MustBe!("UserPromptSubmit"),
@@ -329,7 +350,7 @@ pub struct UserPromptSubmitMatcher {
     ///
     /// When the user's prompt submitted to the agent matches all of these
     /// patterns, the rule is triggered.
-    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_non_empty_vec")]
     pub prompt: Vec<ContentMatcher>,
 }
 
@@ -372,5 +393,125 @@ mod tests {
             serde_yaml::from_str::<PreToolUseBashMatcher>(yaml).expect("valid bash matcher yaml");
         pretty_assert_eq!(matcher.command.len(), 1);
         pretty_assert_eq!(matcher.project_state.len(), 1);
+    }
+
+    #[test]
+    fn rule_config_rejects_unknown_top_level_fields() {
+        let yaml = r#"
+            version: 1
+            rules: []
+            workflows: []
+        "#;
+
+        let result = serde_yaml::from_str::<RuleConfig>(yaml);
+
+        assert!(result.is_err(), "unknown top-level fields must fail");
+    }
+
+    #[test]
+    fn rule_rejects_unknown_fields() {
+        let yaml = r#"
+            version: 1
+            rules:
+              - name: test
+                message: test
+                typo: true
+                on:
+                  - hook: UserPromptSubmit
+                    prompt:
+                      - kind: Regex
+                        pattern: test
+        "#;
+
+        let result = serde_yaml::from_str::<RuleConfig>(yaml);
+
+        assert!(result.is_err(), "unknown rule fields must fail");
+    }
+
+    #[test]
+    fn matcher_rejects_unknown_fields() {
+        let yaml = r#"
+            version: 1
+            rules:
+              - name: test
+                message: test
+                on:
+                  - hook: PreToolUse
+                    tool: Write
+                    file: "**/*.rs"
+                    content:
+                      - kind: Regex
+                        pattern: test
+                    typo: true
+        "#;
+
+        let result = serde_yaml::from_str::<RuleConfig>(yaml);
+
+        assert!(result.is_err(), "unknown matcher fields must fail");
+    }
+
+    #[test]
+    fn content_matcher_rejects_unknown_fields() {
+        let yaml = r#"
+            kind: Regex
+            pattern: test
+            typo: true
+        "#;
+
+        let result = serde_yaml::from_str::<ContentMatcher>(yaml);
+
+        assert!(result.is_err(), "unknown content matcher fields must fail");
+    }
+
+    #[test]
+    fn write_matcher_requires_content_matchers() {
+        let yaml = r#"
+            version: 1
+            rules:
+              - name: test
+                message: test
+                on:
+                  - hook: PreToolUse
+                    tool: Write
+                    file: "**/*.rs"
+                    content: []
+        "#;
+
+        let result = serde_yaml::from_str::<RuleConfig>(yaml);
+
+        assert!(result.is_err(), "empty content matcher lists must fail");
+    }
+
+    #[test]
+    fn bash_matcher_requires_command_matchers() {
+        let yaml = r#"
+            version: 1
+            rules:
+              - name: test
+                message: test
+                on:
+                  - hook: PreToolUse
+                    tool: Bash
+                    command: []
+        "#;
+
+        let result = serde_yaml::from_str::<RuleConfig>(yaml);
+
+        assert!(result.is_err(), "empty command matcher lists must fail");
+    }
+
+    #[test]
+    fn rules_require_at_least_one_hook_matcher() {
+        let yaml = r#"
+            version: 1
+            rules:
+              - name: test
+                message: test
+                on: []
+        "#;
+
+        let result = serde_yaml::from_str::<RuleConfig>(yaml);
+
+        assert!(result.is_err(), "rules without hook matchers must fail");
     }
 }

--- a/packages/nudge/src/rules/schema/content.rs
+++ b/packages/nudge/src/rules/schema/content.rs
@@ -78,54 +78,60 @@ impl<'de> Deserialize<'de> for ContentMatcher {
         D: Deserializer<'de>,
     {
         #[derive(Deserialize)]
-        #[serde(deny_unknown_fields)]
-        struct Raw {
-            kind: String,
-            pattern: Option<String>,
-            language: Option<Language>,
-            query: Option<String>,
-            command: Option<Vec<String>>,
-            suggestion: Option<String>,
-            replace: Option<String>,
+        #[serde(tag = "kind")]
+        enum RawContentMatcher {
+            Regex(RawRegexMatcher),
+            SyntaxTree(RawSyntaxTreeMatcher),
+            External(RawExternalMatcher),
         }
 
-        let raw = Raw::deserialize(deserializer)?;
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct RawRegexMatcher {
+            pattern: Option<String>,
+            replace: Option<String>,
+            suggestion: Option<String>,
+        }
 
-        match raw.kind.as_str() {
-            "Regex" => Ok(ContentMatcher::Regex {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct RawSyntaxTreeMatcher {
+            language: Language,
+            query: String,
+            suggestion: Option<String>,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct RawExternalMatcher {
+            command: Vec<String>,
+        }
+
+        let raw = RawContentMatcher::deserialize(deserializer)?;
+
+        match raw {
+            RawContentMatcher::Regex(raw) => Ok(ContentMatcher::Regex {
                 pattern: deserialize_regex(raw.pattern)?,
                 replace: raw.replace,
                 suggestion: raw.suggestion,
             }),
-            "SyntaxTree" => {
-                let language = raw
-                    .language
-                    .ok_or_else(|| serde::de::Error::missing_field("language"))?;
-                let query = raw
-                    .query
-                    .ok_or_else(|| serde::de::Error::missing_field("query"))
-                    .and_then(|query| {
-                        TreeSitterQuery::new(language, query).map_err(serde::de::Error::custom)
-                    })?;
+            RawContentMatcher::SyntaxTree(raw) => {
+                let query = TreeSitterQuery::new(raw.language, raw.query)
+                    .map_err(serde::de::Error::custom)?;
                 Ok(ContentMatcher::SyntaxTree {
-                    language,
+                    language: raw.language,
                     query,
                     suggestion: raw.suggestion,
                 })
             }
-            "External" => {
-                let command = raw
-                    .command
-                    .ok_or_else(|| serde::de::Error::missing_field("command"))?;
-                if command.is_empty() {
+            RawContentMatcher::External(raw) => {
+                if raw.command.is_empty() {
                     return Err(serde::de::Error::custom("command cannot be empty"));
                 }
-                Ok(ContentMatcher::External { command })
+                Ok(ContentMatcher::External {
+                    command: raw.command,
+                })
             }
-            other => Err(serde::de::Error::unknown_variant(
-                other,
-                &["Regex", "SyntaxTree", "External"],
-            )),
         }
     }
 }
@@ -468,6 +474,69 @@ mod tests {
         .expect("valid regex matcher yaml");
 
         pretty_assert_eq!(matcher.replace_all("npm install lodash"), "yarn add lodash");
+    }
+
+    #[test]
+    fn content_matchers_reject_fields_from_other_variants() {
+        let cases = [
+            (
+                "Regex with External command",
+                r#"
+                kind: Regex
+                pattern: test
+                command: ["false"]
+                "#,
+            ),
+            (
+                "External with Regex pattern",
+                r#"
+                kind: External
+                command: ["false"]
+                pattern: test
+                "#,
+            ),
+            (
+                "External with Regex suggestion",
+                r#"
+                kind: External
+                command: ["false"]
+                suggestion: use something else
+                "#,
+            ),
+            (
+                "External with Regex replace",
+                r#"
+                kind: External
+                command: ["false"]
+                replace: replacement
+                "#,
+            ),
+            (
+                "SyntaxTree with Regex replace",
+                r#"
+                kind: SyntaxTree
+                language: rust
+                query: "(function_item)"
+                replace: replacement
+                "#,
+            ),
+            (
+                "SyntaxTree with External command",
+                r#"
+                kind: SyntaxTree
+                language: rust
+                query: "(function_item)"
+                command: ["false"]
+                "#,
+            ),
+        ];
+
+        for (name, yaml) in cases {
+            assert!(
+                serde_yaml::from_str::<ContentMatcher>(yaml).is_err(),
+                "{name} should reject fields from another matcher variant"
+            );
+        }
     }
 
     #[test]

--- a/packages/nudge/src/rules/schema/content.rs
+++ b/packages/nudge/src/rules/schema/content.rs
@@ -78,6 +78,7 @@ impl<'de> Deserialize<'de> for ContentMatcher {
         D: Deserializer<'de>,
     {
         #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
         struct Raw {
             kind: String,
             pattern: Option<String>,

--- a/packages/nudge/src/rules/schema/project_state.rs
+++ b/packages/nudge/src/rules/schema/project_state.rs
@@ -26,6 +26,7 @@ impl<'de> Deserialize<'de> for ProjectStateMatcher {
         D: Deserializer<'de>,
     {
         #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
         struct Raw {
             kind: String,
             #[serde(default)]

--- a/packages/nudge/src/rules/schema/url.rs
+++ b/packages/nudge/src/rules/schema/url.rs
@@ -28,6 +28,7 @@ impl<'de> Deserialize<'de> for UrlMatcher {
         D: Deserializer<'de>,
     {
         #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
         struct Raw {
             kind: String,
             pattern: Option<String>,

--- a/packages/nudge/tests/it/cli.rs
+++ b/packages/nudge/tests/it/cli.rs
@@ -33,13 +33,12 @@ fn test_validate_specific_file() {
 
 #[test]
 fn test_validate_nonexistent_file() {
-    let (exit_code, stdout, _stderr) = run_nudge(&["validate", "nonexistent.yaml"]);
+    let (exit_code, _stdout, stderr) = run_nudge(&["validate", "nonexistent.yaml"]);
 
-    pretty_assert_eq!(exit_code, 0, "validate should exit 0 for nonexistent file");
-    // An empty list prints as [] in YAML
+    assert_ne!(exit_code, 0, "validate should fail for nonexistent file");
     assert!(
-        stdout.contains("[]") || stdout.trim().is_empty(),
-        "validate should report empty for nonexistent file, got: {stdout}"
+        stderr.contains("config file does not exist") || stderr.contains("nonexistent.yaml"),
+        "validate should report missing file, got: {stderr}"
     );
 }
 


### PR DESCRIPTION
## Why this change

Nudge should fail loudly when rule authors make config mistakes. Before this change, unknown fields and empty matcher lists could validate successfully, which made typoed rules silently inert. Explicit `nudge validate <path>` also treated missing files as empty config, which made a validator command look successful when it was not validating anything.

This PR tightens the 1.0 rule-config contract by rejecting unknown fields, requiring non-empty hook and matcher lists where a predicate is required, and making explicit missing validation paths fail.

## Testing steps performed

Reported by the implementing thread:

- `cargo test -p nudge`
- `cargo clippy -p nudge --all-targets --all-features -- -D warnings`
- `cargo run -q -p nudge -- check`
- `cargo +nightly fmt --all --check`
- `git diff --check`
- Direct invalid probes for `workflows: []`, `typo: true`, and `content: []`, all exiting 1
- Current configs and shipped examples validate cleanly

## Configuration changes after merge

This is an intentional schema strictness change. Rule files with unknown fields, empty matcher lists, or missing explicit validation paths that previously passed will now fail validation.