### PR TITLE
Polish setup installers and syntaxtree CLI

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -43,17 +43,42 @@ jobs:
                     - fresh-versioned
                     - upgrade-versioned
 
-        env:
-            FRESH_VERSION: "0.2.1"
-            UPGRADE_FROM_VERSION: "0.1.0"
-            UPGRADE_TO_VERSION: "0.2.1"
-
         steps:
             - uses: actions/checkout@v4
+
+            - name: Select release versions
+              id: releases
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const { owner, repo } = context.repo;
+                      const latest = await github.rest.repos.getLatestRelease({ owner, repo });
+                      const releases = await github.paginate(github.rest.repos.listReleases, {
+                        owner,
+                        repo,
+                        per_page: 100,
+                      });
+                      const candidates = releases
+                        .filter((release) => !release.draft && !release.prerelease)
+                        .sort((left, right) => new Date(right.published_at) - new Date(left.published_at));
+                      const previous = candidates.find((release) => release.tag_name !== latest.data.tag_name);
+
+                      if (!previous) {
+                        core.setFailed("Need at least two published non-prerelease releases to test versioned installs and upgrades.");
+                        return;
+                      }
+
+                      const stripPrefix = (tag) => tag.replace(/^v/, "");
+                      core.setOutput("latest_version", stripPrefix(latest.data.tag_name));
+                      core.setOutput("previous_version", stripPrefix(previous.tag_name));
+                      core.notice(`Selected installer versions: LATEST=${latest.data.tag_name}, LATEST-1=${previous.tag_name}`);
 
             - name: Run shell installer
               if: matrix.platform.installer == 'shell'
               shell: bash
+              env:
+                  LATEST_VERSION: ${{ steps.releases.outputs.latest_version }}
+                  PREVIOUS_VERSION: ${{ steps.releases.outputs.previous_version }}
               run: |
                   case "${{ matrix.scenario }}" in
                     help)
@@ -78,35 +103,37 @@ jobs:
                       ;;
                     fresh-versioned)
                       # Exercises a fresh install with --version, --bin-dir, and
-                      # --tmp-dir against a known released artifact.
+                      # --tmp-dir against LATEST-1, selected by CI from published
+                      # GitHub Releases.
                       bin_dir="$RUNNER_TEMP/nudge-bin-fresh-versioned"
                       tmp_dir="$RUNNER_TEMP/nudge-installer-fresh-versioned"
                       mkdir -p "$bin_dir" "$tmp_dir"
 
                       bash scripts/install.sh \
-                        --version "$FRESH_VERSION" \
+                        --version "$PREVIOUS_VERSION" \
                         --bin-dir "$bin_dir" \
                         --tmp-dir "$tmp_dir"
-                      "$bin_dir/nudge" --version | grep -q "v$FRESH_VERSION"
+                      "$bin_dir/nudge" --version | grep -q "v$PREVIOUS_VERSION"
                       ;;
                     upgrade-versioned)
-                      # Exercises the upgrade path by installing an older release,
-                      # then installing a newer release into the same --bin-dir.
+                      # Exercises the upgrade path by installing LATEST-1, then
+                      # installing LATEST into the same --bin-dir. CI owns the
+                      # release selection; the installer remains generic.
                       bin_dir="$RUNNER_TEMP/nudge-bin-upgrade"
                       tmp_dir="$RUNNER_TEMP/nudge-installer-upgrade"
                       mkdir -p "$bin_dir" "$tmp_dir"
 
                       bash scripts/install.sh \
-                        -v "$UPGRADE_FROM_VERSION" \
+                        -v "$PREVIOUS_VERSION" \
                         -b "$bin_dir" \
                         -t "$tmp_dir"
-                      "$bin_dir/nudge" --version | grep -q "v$UPGRADE_FROM_VERSION"
+                      "$bin_dir/nudge" --version | grep -q "v$PREVIOUS_VERSION"
 
                       bash scripts/install.sh \
-                        -v "$UPGRADE_TO_VERSION" \
+                        -v "$LATEST_VERSION" \
                         -b "$bin_dir" \
                         -t "$tmp_dir"
-                      "$bin_dir/nudge" --version | grep -q "v$UPGRADE_TO_VERSION"
+                      "$bin_dir/nudge" --version | grep -q "v$LATEST_VERSION"
                       ;;
                     *)
                       echo "Unknown installer scenario: ${{ matrix.scenario }}" >&2
@@ -118,6 +145,9 @@ jobs:
             - name: Run PowerShell installer
               if: matrix.platform.installer == 'powershell'
               shell: pwsh
+              env:
+                  LATEST_VERSION: ${{ steps.releases.outputs.latest_version }}
+                  PREVIOUS_VERSION: ${{ steps.releases.outputs.previous_version }}
               run: |
                   switch ("${{ matrix.scenario }}") {
                       "help" {
@@ -140,30 +170,31 @@ jobs:
                       }
                       "fresh-versioned" {
                           # Exercises a fresh install with -Version and -BinDir against
-                          # a known released artifact.
+                          # LATEST-1, selected by CI from published GitHub Releases.
                           $binDir = Join-Path $env:RUNNER_TEMP "nudge-bin-fresh-versioned"
 
-                          ./scripts/install.ps1 -Version $env:FRESH_VERSION -BinDir $binDir
+                          ./scripts/install.ps1 -Version $env:PREVIOUS_VERSION -BinDir $binDir
                           $version = & (Join-Path $binDir "nudge.exe") --version
-                          if ($version -notmatch "v$env:FRESH_VERSION") {
-                              throw "Expected v$env:FRESH_VERSION, got $version"
+                          if ($version -notmatch "v$env:PREVIOUS_VERSION") {
+                              throw "Expected v$env:PREVIOUS_VERSION, got $version"
                           }
                       }
                       "upgrade-versioned" {
-                          # Exercises the upgrade path by installing an older release,
-                          # then installing a newer release into the same -BinDir.
+                          # Exercises the upgrade path by installing LATEST-1, then
+                          # installing LATEST into the same -BinDir. CI owns the
+                          # release selection; the installer remains generic.
                           $binDir = Join-Path $env:RUNNER_TEMP "nudge-bin-upgrade"
 
-                          ./scripts/install.ps1 -Version $env:UPGRADE_FROM_VERSION -BinDir $binDir
+                          ./scripts/install.ps1 -Version $env:PREVIOUS_VERSION -BinDir $binDir
                           $oldVersion = & (Join-Path $binDir "nudge.exe") --version
-                          if ($oldVersion -notmatch "v$env:UPGRADE_FROM_VERSION") {
-                              throw "Expected v$env:UPGRADE_FROM_VERSION, got $oldVersion"
+                          if ($oldVersion -notmatch "v$env:PREVIOUS_VERSION") {
+                              throw "Expected v$env:PREVIOUS_VERSION, got $oldVersion"
                           }
 
-                          ./scripts/install.ps1 -Version $env:UPGRADE_TO_VERSION -BinDir $binDir
+                          ./scripts/install.ps1 -Version $env:LATEST_VERSION -BinDir $binDir
                           $newVersion = & (Join-Path $binDir "nudge.exe") --version
-                          if ($newVersion -notmatch "v$env:UPGRADE_TO_VERSION") {
-                              throw "Expected v$env:UPGRADE_TO_VERSION, got $newVersion"
+                          if ($newVersion -notmatch "v$env:LATEST_VERSION") {
+                              throw "Expected v$env:LATEST_VERSION, got $newVersion"
                           }
                       }
                       default {

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -22,12 +22,12 @@ concurrency:
 
 jobs:
     installers:
-        name: Test ${{ matrix.name }} installer
-        runs-on: ${{ matrix.os }}
+        name: Test ${{ matrix.platform.name }} installer (${{ matrix.scenario }})
+        runs-on: ${{ matrix.platform.os }}
         strategy:
             fail-fast: false
             matrix:
-                include:
+                platform:
                     - name: Linux
                       os: ubuntu-latest
                       installer: shell
@@ -37,26 +37,136 @@ jobs:
                     - name: Windows
                       os: windows-latest
                       installer: powershell
+                scenario:
+                    - help
+                    - fresh-latest
+                    - fresh-versioned
+                    - upgrade-versioned
+
+        env:
+            FRESH_VERSION: "0.2.1"
+            UPGRADE_FROM_VERSION: "0.1.0"
+            UPGRADE_TO_VERSION: "0.2.1"
 
         steps:
             - uses: actions/checkout@v4
 
             - name: Run shell installer
-              if: matrix.installer == 'shell'
+              if: matrix.platform.installer == 'shell'
               shell: bash
               run: |
-                  bin_dir="$RUNNER_TEMP/nudge-bin"
-                  tmp_dir="$RUNNER_TEMP/nudge-installer"
-                  mkdir -p "$bin_dir" "$tmp_dir"
+                  case "${{ matrix.scenario }}" in
+                    help)
+                      # Exercises -h/--help without installing.
+                      bash scripts/install.sh --help | tee "$RUNNER_TEMP/nudge-install-help.txt"
+                      grep -q -- "--version" "$RUNNER_TEMP/nudge-install-help.txt"
+                      grep -q -- "--bin-dir" "$RUNNER_TEMP/nudge-install-help.txt"
+                      grep -q -- "--tmp-dir" "$RUNNER_TEMP/nudge-install-help.txt"
+                      bash scripts/install.sh -h > /dev/null
+                      ;;
+                    fresh-latest)
+                      # Exercises a fresh install with default latest-version lookup,
+                      # plus explicit --bin-dir and --tmp-dir. This is the release
+                      # health case most likely to fail when the latest published
+                      # release is missing assets or checksums.
+                      bin_dir="$RUNNER_TEMP/nudge-bin-fresh-latest"
+                      tmp_dir="$RUNNER_TEMP/nudge-installer-fresh-latest"
+                      mkdir -p "$bin_dir" "$tmp_dir"
 
-                  bash scripts/install.sh --bin-dir "$bin_dir" --tmp-dir "$tmp_dir"
-                  "$bin_dir/nudge" --version
+                      bash scripts/install.sh --bin-dir "$bin_dir" --tmp-dir "$tmp_dir"
+                      "$bin_dir/nudge" --version
+                      ;;
+                    fresh-versioned)
+                      # Exercises a fresh install with --version, --bin-dir, and
+                      # --tmp-dir against a known released artifact.
+                      bin_dir="$RUNNER_TEMP/nudge-bin-fresh-versioned"
+                      tmp_dir="$RUNNER_TEMP/nudge-installer-fresh-versioned"
+                      mkdir -p "$bin_dir" "$tmp_dir"
+
+                      bash scripts/install.sh \
+                        --version "$FRESH_VERSION" \
+                        --bin-dir "$bin_dir" \
+                        --tmp-dir "$tmp_dir"
+                      "$bin_dir/nudge" --version | grep -q "v$FRESH_VERSION"
+                      ;;
+                    upgrade-versioned)
+                      # Exercises the upgrade path by installing an older release,
+                      # then installing a newer release into the same --bin-dir.
+                      bin_dir="$RUNNER_TEMP/nudge-bin-upgrade"
+                      tmp_dir="$RUNNER_TEMP/nudge-installer-upgrade"
+                      mkdir -p "$bin_dir" "$tmp_dir"
+
+                      bash scripts/install.sh \
+                        -v "$UPGRADE_FROM_VERSION" \
+                        -b "$bin_dir" \
+                        -t "$tmp_dir"
+                      "$bin_dir/nudge" --version | grep -q "v$UPGRADE_FROM_VERSION"
+
+                      bash scripts/install.sh \
+                        -v "$UPGRADE_TO_VERSION" \
+                        -b "$bin_dir" \
+                        -t "$tmp_dir"
+                      "$bin_dir/nudge" --version | grep -q "v$UPGRADE_TO_VERSION"
+                      ;;
+                    *)
+                      echo "Unknown installer scenario: ${{ matrix.scenario }}" >&2
+                      exit 1
+                      ;;
+                  esac
+
 
             - name: Run PowerShell installer
-              if: matrix.installer == 'powershell'
+              if: matrix.platform.installer == 'powershell'
               shell: pwsh
               run: |
-                  $binDir = Join-Path $env:RUNNER_TEMP "nudge-bin"
+                  switch ("${{ matrix.scenario }}") {
+                      "help" {
+                          # Exercises -Help without installing.
+                          $help = ./scripts/install.ps1 -Help | Out-String
+                          $help | Write-Host
+                          if ($help -notmatch "Version" -or $help -notmatch "BinDir" -or $help -notmatch "Help") {
+                              throw "Installer help did not list expected options"
+                          }
+                      }
+                      "fresh-latest" {
+                          # Exercises a fresh install with default latest-version lookup,
+                          # plus explicit -BinDir. This is the release health case most
+                          # likely to fail when the latest published release is missing
+                          # assets or checksums.
+                          $binDir = Join-Path $env:RUNNER_TEMP "nudge-bin-fresh-latest"
 
-                  ./scripts/install.ps1 -BinDir $binDir
-                  & (Join-Path $binDir "nudge.exe") --version
+                          ./scripts/install.ps1 -BinDir $binDir
+                          & (Join-Path $binDir "nudge.exe") --version
+                      }
+                      "fresh-versioned" {
+                          # Exercises a fresh install with -Version and -BinDir against
+                          # a known released artifact.
+                          $binDir = Join-Path $env:RUNNER_TEMP "nudge-bin-fresh-versioned"
+
+                          ./scripts/install.ps1 -Version $env:FRESH_VERSION -BinDir $binDir
+                          $version = & (Join-Path $binDir "nudge.exe") --version
+                          if ($version -notmatch "v$env:FRESH_VERSION") {
+                              throw "Expected v$env:FRESH_VERSION, got $version"
+                          }
+                      }
+                      "upgrade-versioned" {
+                          # Exercises the upgrade path by installing an older release,
+                          # then installing a newer release into the same -BinDir.
+                          $binDir = Join-Path $env:RUNNER_TEMP "nudge-bin-upgrade"
+
+                          ./scripts/install.ps1 -Version $env:UPGRADE_FROM_VERSION -BinDir $binDir
+                          $oldVersion = & (Join-Path $binDir "nudge.exe") --version
+                          if ($oldVersion -notmatch "v$env:UPGRADE_FROM_VERSION") {
+                              throw "Expected v$env:UPGRADE_FROM_VERSION, got $oldVersion"
+                          }
+
+                          ./scripts/install.ps1 -Version $env:UPGRADE_TO_VERSION -BinDir $binDir
+                          $newVersion = & (Join-Path $binDir "nudge.exe") --version
+                          if ($newVersion -notmatch "v$env:UPGRADE_TO_VERSION") {
+                              throw "Expected v$env:UPGRADE_TO_VERSION, got $newVersion"
+                          }
+                      }
+                      default {
+                          throw "Unknown installer scenario: ${{ matrix.scenario }}"
+                      }
+                  }

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -1,0 +1,62 @@
+# Smoke-test nudge installers against published GitHub Release assets.
+#
+# These checks run installer scripts from the checked-out workflow ref, but the
+# installers intentionally download the latest published release artifact. They
+# do not test installing the binary built from the same CI commit. That limitation
+# is expected: installer scripts are release-facing entrypoints, and this workflow
+# verifies that installer logic, platform detection, archive names, checksums,
+# extraction, and the current latest release assets continue to agree.
+#
+# Keep this separate from PR CI because failures can be caused by published
+# release state, not by the pull request being tested.
+name: Installers
+
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: "17 16 * * *"
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    installers:
+        name: Test ${{ matrix.name }} installer
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - name: Linux
+                      os: ubuntu-latest
+                      installer: shell
+                    - name: macOS
+                      os: macos-15-intel
+                      installer: shell
+                    - name: Windows
+                      os: windows-latest
+                      installer: powershell
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Run shell installer
+              if: matrix.installer == 'shell'
+              shell: bash
+              run: |
+                  bin_dir="$RUNNER_TEMP/nudge-bin"
+                  tmp_dir="$RUNNER_TEMP/nudge-installer"
+                  mkdir -p "$bin_dir" "$tmp_dir"
+
+                  bash scripts/install.sh --bin-dir "$bin_dir" --tmp-dir "$tmp_dir"
+                  "$bin_dir/nudge" --version
+
+            - name: Run PowerShell installer
+              if: matrix.installer == 'powershell'
+              shell: pwsh
+              run: |
+                  $binDir = Join-Path $env:RUNNER_TEMP "nudge-bin"
+
+                  ./scripts/install.ps1 -BinDir $binDir
+                  & (Join-Path $binDir "nudge.exe") --version

--- a/packages/nudge/src/cmd.rs
+++ b/packages/nudge/src/cmd.rs
@@ -4,6 +4,7 @@ pub mod check;
 pub mod claude;
 pub mod codex;
 pub(crate) mod json_hooks;
+pub(crate) mod setup_command;
 pub mod syntaxtree;
 pub mod test;
 pub mod validate;

--- a/packages/nudge/src/cmd/claude.rs
+++ b/packages/nudge/src/cmd/claude.rs
@@ -19,7 +19,7 @@ enum Commands {
     /// Responds to Claude Code hooks.
     Hook(hook::Config),
 
-    /// Set up Nudge hooks in .claude/hooks.
+    /// Set up Nudge hooks in .claude/settings.local.json.
     Setup(setup::Config),
 
     /// Show documentation for writing Nudge rules.

--- a/packages/nudge/src/cmd/claude/setup.rs
+++ b/packages/nudge/src/cmd/claude/setup.rs
@@ -1,6 +1,5 @@
 //! Set up Nudge hooks for Claude Code.
 
-use std::env;
 use std::fs;
 use std::io::{self, BufRead, Write};
 use std::path::PathBuf;
@@ -15,7 +14,7 @@ use serde::Serialize;
 use serde_json::{Value, json};
 use tracing::instrument;
 
-use crate::cmd::json_hooks;
+use crate::cmd::{json_hooks, setup_command};
 
 #[derive(Args, Clone, Debug)]
 pub struct Config {
@@ -92,13 +91,7 @@ pub fn main(config: Config) -> Result<()> {
     let settings_file = dotclaude.join("settings.local.json");
     tracing::debug!(?dotclaude, ?settings_file, "read existing settings");
 
-    let nudge_path = env::current_exe()
-        .context("get current executable path")?
-        .to_str()
-        .ok_or_eyre("convert current executable path to string")?
-        .to_string();
-
-    let nudge_command = format!("{nudge_path} claude hook");
+    let nudge_command = setup_command::current_hook_command("claude")?;
     let nudge_hook = HookConfig::builder()
         .command(&nudge_command)
         .timeout(5)

--- a/packages/nudge/src/cmd/codex/setup.rs
+++ b/packages/nudge/src/cmd/codex/setup.rs
@@ -1,17 +1,17 @@
 //! Set up Nudge hooks for Codex CLI.
 
 use std::{
-    env, fs,
+    fs,
     io::ErrorKind,
     path::{Path, PathBuf},
 };
 
 use clap::Args;
-use color_eyre::eyre::{Context, OptionExt, Result};
+use color_eyre::eyre::{Context, Result};
 use serde_json::{Value, json};
 use tracing::instrument;
 
-use crate::cmd::json_hooks;
+use crate::cmd::{json_hooks, setup_command};
 
 #[derive(Args, Clone, Debug)]
 pub struct Config {
@@ -39,12 +39,7 @@ pub fn main(config: Config) -> Result<()> {
     }
 
     let hooks_file = dotcodex.join("hooks.json");
-    let nudge_path = env::current_exe()
-        .context("get current executable path")?
-        .to_str()
-        .ok_or_eyre("convert current executable path to string")?
-        .to_string();
-    let nudge_command = format!("{nudge_path} codex hook");
+    let nudge_command = setup_command::current_hook_command("codex")?;
 
     let nudge_hook = json!({
         "type": "command",

--- a/packages/nudge/src/cmd/setup_command.rs
+++ b/packages/nudge/src/cmd/setup_command.rs
@@ -1,0 +1,42 @@
+//! Shared setup helpers for provider hook commands.
+
+use std::{env, path::Path};
+
+use color_eyre::eyre::{Context, OptionExt, Result};
+
+pub(crate) fn current_hook_command(provider: &str) -> Result<String> {
+    let nudge_path = env::current_exe().context("get current executable path")?;
+    hook_command(&nudge_path, provider)
+}
+
+fn hook_command(nudge_path: &Path, provider: &str) -> Result<String> {
+    let nudge_path = nudge_path
+        .to_str()
+        .ok_or_eyre("convert current executable path to string")?;
+    Ok(shell_words::join([nudge_path, provider, "hook"]))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use pretty_assertions::assert_eq as pretty_assert_eq;
+
+    use super::hook_command;
+
+    #[test]
+    fn hook_command_quotes_paths_for_shell_execution() {
+        let command = hook_command(
+            Path::new("/tmp/Nudge Test/bin/nudge's debug build"),
+            "claude",
+        )
+        .expect("build command");
+
+        assert!(command.starts_with("'/tmp/Nudge Test/bin/nudge"));
+        let words = shell_words::split(&command).expect("split command");
+        pretty_assert_eq!(
+            words,
+            vec!["/tmp/Nudge Test/bin/nudge's debug build", "claude", "hook"]
+        );
+    }
+}

--- a/packages/nudge/src/cmd/syntaxtree.rs
+++ b/packages/nudge/src/cmd/syntaxtree.rs
@@ -7,7 +7,7 @@ use std::fs;
 use std::path::Path;
 
 use clap::Args;
-use color_eyre::Result;
+use color_eyre::eyre::{Context, Result, bail};
 use color_print::cformat;
 
 use nudge::rules::Language;
@@ -23,7 +23,7 @@ pub struct Config {
 }
 
 pub fn main(config: Config) -> Result<()> {
-    let code = resolve_input(&config.input);
+    let code = resolve_input(&config.input)?;
 
     let Some(tree) = config.language.parse(&code) else {
         println!("Failed to parse code");
@@ -39,13 +39,41 @@ pub fn main(config: Config) -> Result<()> {
 }
 
 /// Resolve the input as either a file path or literal code.
-fn resolve_input(input: &str) -> String {
+fn resolve_input(input: &str) -> Result<String> {
     let path = Path::new(input);
     if path.exists() {
-        fs::read_to_string(path).unwrap_or_else(|_| input.to_string())
-    } else {
-        input.to_string()
+        return fs::read_to_string(path)
+            .with_context(|| format!("read syntax tree input file: {input}"));
     }
+
+    if looks_like_path(input) {
+        bail!("syntax tree input looks like a file path, but it does not exist: {input}");
+    }
+
+    Ok(input.to_string())
+}
+
+fn looks_like_path(input: &str) -> bool {
+    let path = Path::new(input);
+    input.contains(std::path::MAIN_SEPARATOR)
+        || input.contains('/')
+        || input.contains('\\')
+        || matches!(
+            path.extension().and_then(|extension| extension.to_str()),
+            Some(
+                "rs" | "js"
+                    | "jsx"
+                    | "ts"
+                    | "tsx"
+                    | "py"
+                    | "go"
+                    | "java"
+                    | "cs"
+                    | "kt"
+                    | "kts"
+                    | "hs"
+            )
+        )
 }
 
 /// A flattened syntax node for rendering.

--- a/packages/nudge/tests/it/cli.rs
+++ b/packages/nudge/tests/it/cli.rs
@@ -126,6 +126,21 @@ fn test_syntaxtree_inline_code() {
 }
 
 #[test]
+fn test_syntaxtree_missing_path_like_input_fails() {
+    let (exit_code, _stdout, stderr) =
+        run_nudge(&["syntaxtree", "--language", "rust", "missing.rs"]);
+
+    assert_ne!(
+        exit_code, 0,
+        "syntaxtree should reject missing path-like input"
+    );
+    assert!(
+        stderr.contains("looks like a file path") && stderr.contains("missing.rs"),
+        "syntaxtree should explain missing path-like input, got: {stderr}"
+    );
+}
+
+#[test]
 fn test_syntaxtree_javascript_language_name() {
     let (exit_code, stdout, stderr) = run_nudge(&[
         "syntaxtree",

--- a/packages/nudge/tests/it/install_script.rs
+++ b/packages/nudge/tests/it/install_script.rs
@@ -1,0 +1,31 @@
+//! Static checks for installer safety behavior.
+
+use std::{fs, path::Path};
+
+#[test]
+fn powershell_installer_fails_closed_when_checksum_verification_is_unavailable() {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("packages dir")
+        .parent()
+        .expect("repo root");
+    let script_path = repo_root.join("scripts/install.ps1");
+    let script = fs::read_to_string(&script_path).expect("read install.ps1");
+
+    assert!(
+        !script.contains("Write-Warning-Message \"Could not verify checksum"),
+        "checksum verification must not warn and continue"
+    );
+    assert!(
+        script.contains("Write-Error-Message \"Could not download checksums"),
+        "missing checksum downloads must stop installation"
+    );
+    assert!(
+        script.contains("Write-Error-Message \"Could not find checksum"),
+        "missing archive checksums must stop installation"
+    );
+    assert!(
+        script.contains("Write-Error-Message \"Checksum verification failed!"),
+        "checksum mismatches must stop installation"
+    );
+}

--- a/packages/nudge/tests/it/main.rs
+++ b/packages/nudge/tests/it/main.rs
@@ -12,6 +12,7 @@ mod codex;
 mod edit_tool;
 mod external;
 mod inline_imports;
+mod install_script;
 mod message_content;
 mod multiple_rules;
 mod non_rust_files;

--- a/packages/nudge/tests/it/setup.rs
+++ b/packages/nudge/tests/it/setup.rs
@@ -2,6 +2,7 @@
 
 use std::{
     fs,
+    path::{Path, PathBuf},
     process::{Command, Stdio},
 };
 
@@ -11,7 +12,11 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 fn run_nudge(args: &[&str]) -> (i32, String, String) {
-    let output = Command::new(nudge_binary())
+    run_nudge_binary(&nudge_binary(), args)
+}
+
+fn run_nudge_binary(binary: &Path, args: &[&str]) -> (i32, String, String) {
+    let output = Command::new(binary)
         .args(args)
         .env("RUST_BACKTRACE", "0")
         .env("NUDGE_LOG", "error")
@@ -23,6 +28,40 @@ fn run_nudge(args: &[&str]) -> (i32, String, String) {
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
     (exit_code, stdout, stderr)
+}
+
+fn copy_nudge_binary_to_path_with_spaces(temp: &TempDir) -> PathBuf {
+    let bin_dir = temp.path().join("bin with spaces");
+    fs::create_dir_all(&bin_dir).expect("create spaced bin dir");
+
+    let source = nudge_binary();
+    let target = bin_dir.join(source.file_name().expect("binary filename"));
+    fs::copy(&source, &target).expect("copy nudge binary");
+
+    #[cfg(unix)]
+    {
+        let permissions = fs::metadata(&source)
+            .expect("source metadata")
+            .permissions();
+        fs::set_permissions(&target, permissions).expect("preserve executable permissions");
+    }
+
+    target
+}
+
+#[test]
+fn claude_setup_help_mentions_settings_local_json() {
+    let (exit_code, stdout, stderr) = run_nudge(&["claude", "setup", "--help"]);
+
+    pretty_assert_eq!(exit_code, 0, "help failed: {stderr}");
+    assert!(
+        stdout.contains(".claude/settings.local.json"),
+        "help should mention settings.local.json, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains(".claude/hooks"),
+        "help should not mention stale .claude/hooks path, got: {stdout}"
+    );
 }
 
 fn run_built_nudge_in(dir: &TempDir, args: &[&str]) -> (i32, String, String) {
@@ -113,6 +152,44 @@ fn claude_setup_is_idempotent_and_installs_only_handled_events() {
 }
 
 #[test]
+fn claude_setup_quotes_binary_path_with_spaces() {
+    let temp = TempDir::new().expect("temp dir");
+    let binary = copy_nudge_binary_to_path_with_spaces(&temp);
+    let claude_dir = temp.path().join(".claude");
+    let args = [
+        "claude",
+        "setup",
+        "--claude-dir",
+        claude_dir.to_str().expect("utf-8 path"),
+        "--skip-claude-md",
+    ];
+
+    let (exit_code, _stdout, stderr) = run_nudge_binary(&binary, &args);
+    pretty_assert_eq!(exit_code, 0, "setup failed: {stderr}");
+
+    let json = serde_json::from_str::<Value>(
+        &fs::read_to_string(claude_dir.join("settings.local.json")).expect("read settings"),
+    )
+    .expect("valid json");
+    let command = json["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+        .as_str()
+        .expect("command");
+    assert!(
+        command.starts_with('\''),
+        "expected shell-quoted command for spaced path, got: {command}"
+    );
+    let words = shell_words::split(command).expect("split command");
+    pretty_assert_eq!(
+        words,
+        vec![
+            binary.to_str().expect("utf-8 binary").to_string(),
+            "claude".to_string(),
+            "hook".to_string()
+        ]
+    );
+}
+
+#[test]
 fn codex_setup_creates_hooks_json_and_is_idempotent() {
     let temp = TempDir::new().expect("temp dir");
     let codex_dir = temp.path().join(".codex");
@@ -135,6 +212,43 @@ fn codex_setup_creates_hooks_json_and_is_idempotent() {
         "Bash|apply_patch"
     );
     assert!(json["hooks"]["UserPromptSubmit"][0]["hooks"].is_array());
+}
+
+#[test]
+fn codex_setup_quotes_binary_path_with_spaces() {
+    let temp = TempDir::new().expect("temp dir");
+    let binary = copy_nudge_binary_to_path_with_spaces(&temp);
+    let codex_dir = temp.path().join(".codex");
+    let args = [
+        "codex",
+        "setup",
+        "--codex-dir",
+        codex_dir.to_str().expect("utf-8 path"),
+    ];
+
+    let (exit_code, _stdout, stderr) = run_nudge_binary(&binary, &args);
+    pretty_assert_eq!(exit_code, 0, "setup failed: {stderr}");
+
+    let json = serde_json::from_str::<Value>(
+        &fs::read_to_string(codex_dir.join("hooks.json")).expect("read hooks"),
+    )
+    .expect("valid json");
+    let command = json["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+        .as_str()
+        .expect("command");
+    assert!(
+        command.starts_with('\''),
+        "expected shell-quoted command for spaced path, got: {command}"
+    );
+    let words = shell_words::split(command).expect("split command");
+    pretty_assert_eq!(
+        words,
+        vec![
+            binary.to_str().expect("utf-8 binary").to_string(),
+            "codex".to_string(),
+            "hook".to_string()
+        ]
+    );
 }
 
 #[test]

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -119,27 +119,36 @@ function Install-Binary {
 
     Write-Info "Verifying checksum..."
 
+    # Download checksums
     try {
-        # Download checksums
         $checksums = Invoke-RestMethod -Uri $checksumsUrl -ErrorAction Stop
-
-        # Calculate hash
-        $hash = (Get-FileHash -Path $archivePath -Algorithm SHA256).Hash.ToLower()
-
-        # Find expected hash
-        $expectedHash = ($checksums -split "`n" | Where-Object { $_ -match $archiveName } | ForEach-Object {
-            ($_ -split '\s+')[0]
-        })
-
-        if ($hash -ne $expectedHash) {
-            Write-Error-Message "Checksum verification failed!`nExpected: $expectedHash`nGot: $hash"
-        }
-
-        Write-Info "Checksum verified successfully"
     }
     catch {
-        Write-Warning-Message "Could not verify checksum: $_"
+        Write-Error-Message "Could not download checksums from $checksumsUrl. Error: $_"
     }
+
+    # Calculate hash
+    try {
+        $hash = (Get-FileHash -Path $archivePath -Algorithm SHA256 -ErrorAction Stop).Hash.ToLower()
+    }
+    catch {
+        Write-Error-Message "Could not calculate checksum for $archivePath. Error: $_"
+    }
+
+    # Find expected hash
+    $expectedHash = ($checksums -split "`n" | Where-Object { $_ -match $archiveName } | ForEach-Object {
+        ($_ -split '\s+')[0]
+    } | Select-Object -First 1)
+
+    if ([string]::IsNullOrWhiteSpace($expectedHash)) {
+        Write-Error-Message "Could not find checksum for $archiveName in $checksumsUrl"
+    }
+
+    if ($hash -ne $expectedHash.ToLower()) {
+        Write-Error-Message "Checksum verification failed!`nExpected: $expectedHash`nGot: $hash"
+    }
+
+    Write-Info "Checksum verified successfully"
 
     Write-Info "Extracting archive..."
 


### PR DESCRIPTION
## Why this change

The setup and installer surfaces had several 1.0 readiness footguns: Claude setup help named the wrong destination, generated hook command strings did not quote executable paths with spaces, the PowerShell installer could warn through checksum verification failures, and `nudge syntaxtree missing.rs` could make a typo look like successful literal source parsing.

This PR fixes those user-facing sharp edges and adds installer workflow coverage for released installer behavior.

## Testing steps performed

Reported by the implementing thread:

- `cargo test -p nudge`
- `cargo clippy -p nudge --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all --check`
- `git diff --check`
- `bun -e ...` static check for `install.ps1` checksum fail-closed behavior
- `actionlint .github/workflows/installers.yml`
- Ruby YAML parse for the installer workflow
- Local shell help option check
- Local shell fresh `0.2.1` install
- Local shell upgrade `0.1.0 -> 0.2.1`

`pwsh` was unavailable locally, so PowerShell behavior was covered by static checks and Rust integration coverage.

## Configuration changes after merge

Adds `.github/workflows/installers.yml`, a scheduled/manual installer smoke workflow. It tests checked-out installer scripts against published GitHub release artifacts, not the current CI-built binary. The workflow includes comments documenting that limitation.

## Notes

The `fresh-latest` installer scenario currently exposes the known release-health problem: latest `v0.3.0` has no release assets.