### PR TITLE
Warn on uninspectable Codex apply_patch input

### DIFF
--- a/.nudge.yaml
+++ b/.nudge.yaml
@@ -53,6 +53,39 @@ rules:
             query: |
               (let_declaration type: (_) @type)
 
+  # Prefer explicit string construction for string literals.
+  # Uses tree-sitter to match literal receiver calls while ignoring variables.
+  - name: prefer-string-from-literal
+    description: Use String::from instead of .to_string() on string literals
+    message: 'Use `String::from("...")` instead of calling `.to_string()` on a string literal, then retry.'
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.rs"
+        content:
+          - kind: SyntaxTree
+            language: rust
+            query: |
+              (call_expression
+                function: (field_expression
+                  value: (string_literal) @string
+                  field: (field_identifier) @method
+                  (#eq? @method "to_string"))
+                arguments: (arguments))
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.rs"
+        new_content:
+          - kind: SyntaxTree
+            language: rust
+            query: |
+              (call_expression
+                function: (field_expression
+                  value: (string_literal) @string
+                  field: (field_identifier) @method
+                  (#eq? @method "to_string"))
+                arguments: (arguments))
+
   # Catch unnecessarily fully qualified paths in code (not imports).
   # Pattern: paths with 2+ `::` separators followed by ::, (, or <
   - name: no-qualified-paths

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ When Nudge has something to share, it responds in one of three ways:
 - **Passthrough**: Nothing to note. Carry on!
 - **Continue**: For UserPromptSubmit hooks, Nudge injects context as plain text
 - **Interrupt**: For PreToolUse hooks, Nudge blocks the operation and explains what to fix
+- **Warning**: For provider inputs that look like supported PreToolUse surfaces but cannot be inspected (currently Codex apply_patch parse failures), Nudge allows the operation and tells the model to report the warning to the user
 - **Substitute**: For deterministic PreToolUse Bash rules, Nudge rewrites the command and lets it proceed
 
 The response type is determined by the hook type:

--- a/README.md
+++ b/README.md
@@ -226,8 +226,9 @@ echo '{
   }
 }' | nudge claude hook
 
-# Codex sends apply_patch for file writes and edits; Nudge normalizes those
-# into Write/Edit/Delete before evaluating rules.
+# Codex sends apply_patch for file writes and edits. Nudge normalizes supported
+# add/update/delete patches into Write/Edit/Delete before evaluating rules, and
+# warns the model when an apply_patch input cannot be inspected.
 echo '{
   "hook_event_name": "PreToolUse",
   "cwd": "/tmp",

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ These are the rules Nudge uses on its own codebase (yes, we dogfood):
 |----------------------|-------------------------------------------------------------|
 | No inline imports    | Move `use` statements to the top of the file                |
 | LHS type annotations | Prefer turbofish (`::<T>`) over `let x: T = ...`            |
+| String literals      | Use `String::from("...")` instead of `"...".to_string()`    |
 | Qualified paths      | Import and use shorter names instead of long paths          |
 | Pretty assertions    | Use `pretty_assertions` in tests for better diff output     |
 | No `.unwrap()`       | Use `.expect("...")` with a descriptive message             |

--- a/packages/nudge/src/agent/codex.rs
+++ b/packages/nudge/src/agent/codex.rs
@@ -57,7 +57,15 @@ fn pretooluse(raw: Value, context: HookContext) -> Vec<NudgeHook> {
                     .collect(),
                 Err(error) => {
                     tracing::warn!(?error, "failed to parse Codex apply_patch input");
-                    vec![NudgeHook::Other]
+                    // Codex may change apply_patch syntax faster than Nudge can
+                    // update its parser. Warn the model so the user hears that
+                    // file-content rules were skipped, but allow the work to
+                    // continue instead of blocking on an uninspectable patch.
+                    vec![NudgeHook::WarnPreToolUse {
+                        message: format!(
+                            "Nudge warning: Nudge could not normalize Codex apply_patch input, so file-content rules were not evaluated for this tool call. Continue the requested work, but tell the user about this warning in your next response because they cannot see hook warnings directly.\n\nReason: {error}"
+                        ),
+                    }]
                 }
             }
         }
@@ -230,6 +238,23 @@ mod tests {
 
         assert!(
             matches!(hooks.as_slice(), [NudgeHook::PreToolUse(payload)] if matches!(payload.tool, ToolUse::Delete(_)))
+        );
+    }
+
+    #[test]
+    fn malformed_apply_patch_normalizes_to_pretooluse_warning() {
+        let hooks = parse_hook(json!({
+            "hook_event_name": "PreToolUse",
+            "cwd": "/tmp",
+            "tool_name": "apply_patch",
+            "tool_input": {
+                "command": "*** Begin Patch\n*** Add File: test.rs\n+fn main() {}\n"
+            }
+        }))
+        .expect("parse hook");
+
+        assert!(
+            matches!(hooks.as_slice(), [NudgeHook::WarnPreToolUse { message }] if message.contains("tell the user about this warning"))
         );
     }
 

--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -107,6 +107,7 @@ const DOCS: &str = cstr!("\
   <dim>Delete and PermissionRequest are parsed so Nudge can name them precisely, but</dim>
   <dim>they do not have YAML matchers yet. Codex apply_patch is an adapter detail:</dim>
   <dim>write rules in terms of Write, Edit, and future Delete policy instead.</dim>
+  <dim>Uninspectable Codex apply_patch input is allowed with a model-visible warning.</dim>
 
 <bold>Regex Inline Flags</bold>
 

--- a/packages/nudge/src/cmd/test.rs
+++ b/packages/nudge/src/cmd/test.rs
@@ -67,6 +67,15 @@ pub fn main(config: Config) -> Result<()> {
             println!("Matched content:");
             println!("{message}");
         }
+        HookOutcome::AllowPreToolUseWithContext {
+            system_message,
+            additional_context,
+        } => {
+            println!("Result: Warning");
+            println!();
+            println!("{system_message}");
+            println!("{additional_context}");
+        }
         HookOutcome::UpdatePreToolUse {
             system_message,
             additional_context,
@@ -134,7 +143,7 @@ fn build_tool_use_hook(config: &Config) -> Result<Vec<NudgeHook>> {
         .file
         .as_ref()
         .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_else(|| "test.txt".to_string());
+        .unwrap_or_else(|| String::from("test.txt"));
 
     // Get content from --content or --content-file
     let content = match (&config.content, &config.content_file) {
@@ -158,7 +167,7 @@ fn build_tool_use_hook(config: &Config) -> Result<Vec<NudgeHook>> {
             let url = config
                 .url
                 .clone()
-                .unwrap_or_else(|| "https://example.com".to_string());
+                .unwrap_or_else(|| String::from("https://example.com"));
             json!({
                 "url": url,
                 "prompt": content

--- a/packages/nudge/src/hook.rs
+++ b/packages/nudge/src/hook.rs
@@ -16,6 +16,13 @@ pub enum NudgeHook {
     /// A tool is about to be used.
     PreToolUse(PreToolUse),
 
+    /// A provider tool input could not be fully inspected, but may proceed with
+    /// context.
+    WarnPreToolUse {
+        /// Feedback shown to the agent model.
+        message: String,
+    },
+
     /// The agent is requesting permission for a tool.
     PermissionRequest(PermissionRequest),
 

--- a/packages/nudge/src/hook/evaluate.rs
+++ b/packages/nudge/src/hook/evaluate.rs
@@ -21,12 +21,16 @@ use crate::{
 /// A raw provider hook can normalize into multiple Nudge events. This happens
 /// for Codex `apply_patch`, where one tool call can touch several files.
 pub fn evaluate_hooks(hooks: &[NudgeHook], rules: &[Rule]) -> HookOutcome {
+    let mut pretooluse_warnings = Vec::new();
     let mut pretooluse_matches = Vec::new();
     let mut pretooluse_update = None;
     let mut user_prompt_matches = Vec::new();
 
     for hook in hooks {
         match hook {
+            NudgeHook::WarnPreToolUse { message } => {
+                pretooluse_warnings.push(message.clone());
+            }
             NudgeHook::PreToolUse(payload) => {
                 let (payload, update) = apply_pretooluse_substitutions(payload, rules);
                 pretooluse_update = pretooluse_update.or(update);
@@ -48,6 +52,13 @@ pub fn evaluate_hooks(hooks: &[NudgeHook], rules: &[Rule]) -> HookOutcome {
 
                 {matches}
             "},
+        };
+    }
+
+    if !pretooluse_warnings.is_empty() {
+        return HookOutcome::AllowPreToolUseWithContext {
+            system_message: String::from("Nudge allowed the operation with a warning."),
+            additional_context: pretooluse_warnings.join("\n\n"),
         };
     }
 
@@ -146,7 +157,7 @@ fn updated_tool_input(tool_input: &Value, command: &str) -> Value {
     let mut updated_input = tool_input.clone();
     match &mut updated_input {
         Value::Object(map) => {
-            map.insert("command".to_string(), Value::String(command.to_string()));
+            map.insert(String::from("command"), Value::String(command.to_string()));
             updated_input
         }
         _ => serde_json::json!({ "command": command }),
@@ -352,6 +363,21 @@ rules:
         );
 
         pretty_assert_eq!(evaluate_hooks(&hook, &rules), HookOutcome::Passthrough);
+    }
+
+    #[test]
+    fn normalized_pretooluse_warning_allows_with_context_without_rules() {
+        let hook = vec![NudgeHook::WarnPreToolUse {
+            message: String::from("Provider input could not be inspected fully."),
+        }];
+
+        pretty_assert_eq!(
+            evaluate_hooks(&hook, &[]),
+            HookOutcome::AllowPreToolUseWithContext {
+                system_message: String::from("Nudge allowed the operation with a warning."),
+                additional_context: String::from("Provider input could not be inspected fully."),
+            }
+        );
     }
 
     #[test]

--- a/packages/nudge/src/hook/response.rs
+++ b/packages/nudge/src/hook/response.rs
@@ -18,6 +18,15 @@ pub enum HookOutcome {
         message: String,
     },
 
+    /// Allow a `PreToolUse` operation while surfacing warning context.
+    AllowPreToolUseWithContext {
+        /// User-visible audit message.
+        system_message: String,
+
+        /// Model-visible context explaining the warning.
+        additional_context: String,
+    },
+
     /// Update a `PreToolUse` operation and allow it to proceed.
     UpdatePreToolUse {
         /// User-visible audit message.
@@ -54,13 +63,34 @@ pub fn render(_agent: AgentKind, outcome: HookOutcome) -> Result<RenderedHookOut
         HookOutcome::AddContext { context } => Ok(RenderedHookOutcome::Stdout(context)),
         HookOutcome::DenyPreToolUse { message } => {
             let response = PreToolUseResponse {
-                system_message: Some("Nudge blocked operation due to rule violation.".to_string()),
+                system_message: Some(String::from(
+                    "Nudge blocked operation due to rule violation.",
+                )),
                 hook_specific_output: PreToolUseOutput {
-                    hook_event_name: "PreToolUse".to_string(),
-                    permission_decision: "deny".to_string(),
+                    hook_event_name: String::from("PreToolUse"),
+                    permission_decision: String::from("deny"),
                     permission_decision_reason: Some(message),
                     updated_input: None,
                     additional_context: None,
+                },
+            };
+
+            Ok(RenderedHookOutcome::Stdout(
+                serde_json::to_string(&response).context("serialize hook response")?,
+            ))
+        }
+        HookOutcome::AllowPreToolUseWithContext {
+            system_message,
+            additional_context,
+        } => {
+            let response = PreToolUseResponse {
+                system_message: Some(system_message),
+                hook_specific_output: PreToolUseOutput {
+                    hook_event_name: String::from("PreToolUse"),
+                    permission_decision: String::from("allow"),
+                    permission_decision_reason: None,
+                    updated_input: None,
+                    additional_context: Some(additional_context),
                 },
             };
 
@@ -76,8 +106,8 @@ pub fn render(_agent: AgentKind, outcome: HookOutcome) -> Result<RenderedHookOut
             let response = PreToolUseResponse {
                 system_message: Some(system_message),
                 hook_specific_output: PreToolUseOutput {
-                    hook_event_name: "PreToolUse".to_string(),
-                    permission_decision: "allow".to_string(),
+                    hook_event_name: String::from("PreToolUse"),
+                    permission_decision: String::from("allow"),
                     permission_decision_reason: None,
                     updated_input: Some(updated_input),
                     additional_context: Some(additional_context),
@@ -137,7 +167,7 @@ mod tests {
         let rendered = render(
             AgentKind::Claude,
             HookOutcome::DenyPreToolUse {
-                message: "blocked".to_string(),
+                message: String::from("blocked"),
             },
         )
         .expect("render");
@@ -148,7 +178,7 @@ mod tests {
         let json = serde_json::from_str::<Value>(&output).expect("valid json");
         pretty_assert_eq!(
             json["hookSpecificOutput"]["permissionDecision"],
-            Value::String("deny".to_string())
+            Value::String(String::from("deny"))
         );
     }
 
@@ -157,7 +187,7 @@ mod tests {
         let rendered = render(
             AgentKind::Codex,
             HookOutcome::DenyPreToolUse {
-                message: "blocked".to_string(),
+                message: String::from("blocked"),
             },
         )
         .expect("render");
@@ -168,7 +198,7 @@ mod tests {
         let json = serde_json::from_str::<Value>(&output).expect("valid json");
         pretty_assert_eq!(
             json["hookSpecificOutput"]["permissionDecision"],
-            Value::String("deny".to_string())
+            Value::String(String::from("deny"))
         );
         assert!(json.get("continue").is_none());
         assert!(json.get("stopReason").is_none());
@@ -180,11 +210,12 @@ mod tests {
         let rendered = render(
             AgentKind::Codex,
             HookOutcome::UpdatePreToolUse {
-                system_message: "Nudge substituted `npm install foo` -> `yarn add foo`."
-                    .to_string(),
-                additional_context:
-                    "Nudge rewrote the Bash command from `npm install foo` to `yarn add foo` before execution."
-                        .to_string(),
+                system_message: String::from(
+                    "Nudge substituted `npm install foo` -> `yarn add foo`.",
+                ),
+                additional_context: String::from(
+                    "Nudge rewrote the Bash command from `npm install foo` to `yarn add foo` before execution.",
+                ),
                 updated_input: serde_json::json!({
                     "command": "yarn add foo",
                     "description": "Install foo"
@@ -199,17 +230,43 @@ mod tests {
         let json = serde_json::from_str::<Value>(&output).expect("valid json");
         pretty_assert_eq!(
             json["hookSpecificOutput"]["permissionDecision"],
-            Value::String("allow".to_string())
+            Value::String(String::from("allow"))
         );
         pretty_assert_eq!(
             json["hookSpecificOutput"]["updatedInput"]["command"],
-            Value::String("yarn add foo".to_string())
+            Value::String(String::from("yarn add foo"))
         );
         pretty_assert_eq!(
             json["hookSpecificOutput"]["updatedInput"]["description"],
-            Value::String("Install foo".to_string())
+            Value::String(String::from("Install foo"))
         );
         assert!(json["hookSpecificOutput"]["additionalContext"].is_string());
+    }
+
+    #[test]
+    fn warning_response_allows_with_context_and_no_updated_input() {
+        let rendered = render(
+            AgentKind::Codex,
+            HookOutcome::AllowPreToolUseWithContext {
+                system_message: String::from("Nudge allowed the operation with a warning."),
+                additional_context: String::from("Tell the user about this warning."),
+            },
+        )
+        .expect("render");
+
+        let RenderedHookOutcome::Stdout(output) = rendered else {
+            panic!("expected stdout");
+        };
+        let json = serde_json::from_str::<Value>(&output).expect("valid json");
+        pretty_assert_eq!(
+            json["hookSpecificOutput"]["permissionDecision"],
+            Value::String(String::from("allow"))
+        );
+        pretty_assert_eq!(
+            json["hookSpecificOutput"]["additionalContext"],
+            Value::String(String::from("Tell the user about this warning."))
+        );
+        assert!(json["hookSpecificOutput"].get("updatedInput").is_none());
     }
 
     #[test]
@@ -226,14 +283,14 @@ mod tests {
         let rendered = render(
             AgentKind::Codex,
             HookOutcome::AddContext {
-                context: "remember this".to_string(),
+                context: String::from("remember this"),
             },
         )
         .expect("render");
 
         pretty_assert_eq!(
             rendered,
-            RenderedHookOutcome::Stdout("remember this".to_string())
+            RenderedHookOutcome::Stdout(String::from("remember this"))
         );
     }
 }

--- a/packages/nudge/src/rules/schema/content.rs
+++ b/packages/nudge/src/rules/schema/content.rs
@@ -187,7 +187,7 @@ impl ContentMatcher {
             }
             ContentMatcher::External { command } => {
                 if let Some(command) = run_external_command(command, s) {
-                    let captures = Captures::from_iter([("command".to_string(), command)]);
+                    let captures = Captures::from_iter([(String::from("command"), command)]);
                     vec![Match {
                         span: Span::from(0..s.len()),
                         captures,
@@ -265,7 +265,7 @@ pub(crate) fn apply_suggestion(matches: &mut [Match], suggestion: &Option<String
 
     for m in matches {
         let interpolated = template::interpolate(suggestion_template, &m.captures);
-        m.captures.insert("suggestion".to_string(), interpolated);
+        m.captures.insert(String::from("suggestion"), interpolated);
     }
 }
 
@@ -589,7 +589,7 @@ mod tests {
     #[test]
     fn test_external_is_match_when_command_fails() {
         let matcher = ContentMatcher::External {
-            command: vec!["false".to_string()],
+            command: vec![String::from("false")],
         };
         assert!(matcher.is_match("any content"));
     }
@@ -597,7 +597,7 @@ mod tests {
     #[test]
     fn test_external_is_not_match_when_command_succeeds() {
         let matcher = ContentMatcher::External {
-            command: vec!["true".to_string()],
+            command: vec![String::from("true")],
         };
         assert!(!matcher.is_match("any content"));
     }
@@ -605,13 +605,13 @@ mod tests {
     #[test]
     fn test_external_matches_with_context_sets_command_capture() {
         let matcher = ContentMatcher::External {
-            command: vec!["false".to_string()],
+            command: vec![String::from("false")],
         };
         let matches = matcher.matches_with_context("content");
         pretty_assert_eq!(matches.len(), 1);
         pretty_assert_eq!(
             matches[0].captures.get("command"),
-            Some(&"false".to_string())
+            Some(&String::from("false"))
         );
     }
 
@@ -619,24 +619,28 @@ mod tests {
     fn test_external_matches_with_context_formats_command_with_args() {
         let matcher = ContentMatcher::External {
             command: vec![
-                "test".to_string(),
-                "1".to_string(),
-                "-eq".to_string(),
-                "0".to_string(),
+                String::from("test"),
+                String::from("1"),
+                String::from("-eq"),
+                String::from("0"),
             ],
         };
         let matches = matcher.matches_with_context("content");
         pretty_assert_eq!(matches.len(), 1);
         pretty_assert_eq!(
             matches[0].captures.get("command"),
-            Some(&"test 1 -eq 0".to_string())
+            Some(&String::from("test 1 -eq 0"))
         );
     }
 
     #[test]
     fn test_external_passes_content_to_stdin() {
         let matcher = ContentMatcher::External {
-            command: vec!["grep".to_string(), "-q".to_string(), "needle".to_string()],
+            command: vec![
+                String::from("grep"),
+                String::from("-q"),
+                String::from("needle"),
+            ],
         };
         assert!(!matcher.is_match("haystack with needle inside"));
         assert!(matcher.is_match("haystack without the search term"));

--- a/packages/nudge/src/snippet.rs
+++ b/packages/nudge/src/snippet.rs
@@ -207,7 +207,7 @@ mod tests {
         let source = (1..=30)
             .map(|line| {
                 if line == 25 {
-                    "let value = maybe.unwrap();".to_string()
+                    String::from("let value = maybe.unwrap();")
                 } else {
                     format!("// filler line {line}")
                 }
@@ -231,8 +231,8 @@ mod tests {
     fn test_render_snippet_folds_between_distant_spans() {
         let source = (1..=30)
             .map(|line| match line {
-                5 => "let first = left.unwrap();".to_string(),
-                25 => "let second = right.unwrap();".to_string(),
+                5 => String::from("let first = left.unwrap();"),
+                25 => String::from("let second = right.unwrap();"),
                 _ => format!("// filler line {line}"),
             })
             .collect::<Vec<_>>()

--- a/packages/nudge/src/template.rs
+++ b/packages/nudge/src/template.rs
@@ -29,8 +29,8 @@ pub type Captures = HashMap<String, String>;
 /// use nudge::template::interpolate;
 ///
 /// let mut captures = HashMap::new();
-/// captures.insert("1".to_string(), "foo".to_string());
-/// captures.insert("var".to_string(), "bar".to_string());
+/// captures.insert(String::from("1"), String::from("foo"));
+/// captures.insert(String::from("var"), String::from("bar"));
 ///
 /// let result = interpolate("Use {{ $var }} instead of {{ $1 }}", &captures);
 /// assert_eq!(result, "Use bar instead of foo");
@@ -57,8 +57,8 @@ mod tests {
     #[test]
     fn test_positional_interpolation() {
         let mut captures = Captures::new();
-        captures.insert("0".to_string(), "foo.unwrap()".to_string());
-        captures.insert("1".to_string(), "foo".to_string());
+        captures.insert(String::from("0"), String::from("foo.unwrap()"));
+        captures.insert(String::from("1"), String::from("foo"));
 
         let result = interpolate(
             "Replace {{ $1 }}.unwrap() with {{ $1 }}.expect()",
@@ -70,8 +70,8 @@ mod tests {
     #[test]
     fn test_named_interpolation() {
         let mut captures = Captures::new();
-        captures.insert("var".to_string(), "x".to_string());
-        captures.insert("type".to_string(), "String".to_string());
+        captures.insert(String::from("var"), String::from("x"));
+        captures.insert(String::from("type"), String::from("String"));
 
         let result = interpolate("Variable {{ $var }} has type {{ $type }}", &captures);
         pretty_assert_eq!(result, "Variable x has type String");
@@ -88,8 +88,8 @@ mod tests {
     fn test_suggestion_interpolation() {
         let mut captures = Captures::new();
         captures.insert(
-            "suggestion".to_string(),
-            "use .expect() instead".to_string(),
+            String::from("suggestion"),
+            String::from("use .expect() instead"),
         );
 
         let result = interpolate("Don't use .unwrap(). {{ $suggestion }}", &captures);
@@ -99,9 +99,9 @@ mod tests {
     #[test]
     fn test_mixed_captures() {
         let mut captures = Captures::new();
-        captures.insert("0".to_string(), "foo.is_none()".to_string());
-        captures.insert("1".to_string(), "foo".to_string());
-        captures.insert("var".to_string(), "foo".to_string());
+        captures.insert(String::from("0"), String::from("foo.is_none()"));
+        captures.insert(String::from("1"), String::from("foo"));
+        captures.insert(String::from("var"), String::from("foo"));
 
         let result = interpolate("let Some({{ $var }}) = {{ $var }} else { ... }", &captures);
         pretty_assert_eq!(result, "let Some(foo) = foo else { ... }");
@@ -117,7 +117,7 @@ mod tests {
     #[test]
     fn test_no_placeholders() {
         let mut captures = Captures::new();
-        captures.insert("1".to_string(), "foo".to_string());
+        captures.insert(String::from("1"), String::from("foo"));
 
         let result = interpolate("No placeholders here", &captures);
         pretty_assert_eq!(result, "No placeholders here");

--- a/packages/nudge/tests/it/codex.rs
+++ b/packages/nudge/tests/it/codex.rs
@@ -62,6 +62,33 @@ fn codex_apply_patch_multi_file_aggregates_matches() {
 }
 
 #[test]
+fn codex_apply_patch_malformed_input_warns_model_and_allows() {
+    let patch = "*** Begin Patch\n*** Add File: test.rs\n+fn main() {}\n*** Unsupported Section\n";
+    let input = codex_apply_patch_hook("/tmp", patch);
+
+    let (exit_code, output) = run_codex_hook(&input);
+
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    let json = serde_json::from_str::<serde_json::Value>(&output).expect("valid json output");
+    assert!(
+        json["hookSpecificOutput"]["permissionDecision"] == "allow",
+        "expected permissionDecision:allow, got: {output}"
+    );
+    assert!(
+        json["hookSpecificOutput"]["additionalContext"]
+            .as_str()
+            .is_some_and(|context| context
+                .contains("Nudge could not normalize Codex apply_patch input")
+                && context.contains("tell the user about this warning")),
+        "expected model-visible apply_patch warning, got: {output}"
+    );
+    assert!(
+        json["hookSpecificOutput"].get("updatedInput").is_none(),
+        "expected no updated input for warning-only allow, got: {output}"
+    );
+}
+
+#[test]
 fn codex_permission_request_passes_through() {
     let input = serde_json::json!({
         "hook_event_name": "PermissionRequest",


### PR DESCRIPTION
## Why this change

When Codex `apply_patch` normalization fails, Nudge cannot evaluate file-content rules for that tool call. Before this change, that parser failure fell through as `Other`, which meant the model got no useful context and users could assume Nudge had inspected a patch that it had not inspected.

This PR converts uninspectable Codex `apply_patch` input into a model-visible warning. The tool call is allowed, but Codex receives additional context explaining that file-content rules were not evaluated and instructing the model to tell the user about the warning.

## Testing steps performed

Reported by the implementing thread:

- Focused malformed apply_patch integration test
- Adapter warning unit coverage
- Evaluator warning unit coverage
- Response renderer test for `permissionDecision: allow`, `additionalContext`, and no `updatedInput`
- `cargo test -p nudge`
- `cargo clippy -p nudge --all-targets --all-features -- -D warnings`
- `cargo run -q -p nudge -- check`
- `cargo +nightly fmt --all --check`
- `git diff --check`

## Configuration changes after merge

No setup/config migration required. This changes Codex hook behavior for parser failures: they become explicit model-visible warnings instead of silent passthrough.