### PR TITLE
Polish release docs and metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable release-facing changes to Nudge are tracked here.
+
+## Unreleased
+
+### Added
+
+- Added release metadata files for licensing, changelog tracking, and security reporting.
+- Added Cargo package metadata for GitHub release review and generated package information.
+
+### Documentation
+
+- Archived the original Claude-QA prototype plan so it is no longer presented as the current roadmap.
+- Marked RFC 0001 as historical because it documents a stale pre-1.0 rule schema.
+- Refreshed the Rust example rules to match the current syntax-tree-oriented guidance used by Nudge itself.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Nudge is a **collaborative memory layer** for agent hooks. It remembers the codi
 
 Think of Nudge as a helpful tap on the shoulder: *"Hey, remember this codebase uses turbofish syntax"* rather than a guard checking badges at the door.
 
-**See [docs/PLAN.md](docs/PLAN.md) for project goals and roadmap.**
+For current rule syntax, run `nudge claude docs` or `nudge codex docs`. Copyable starter rules live in [examples/rules](examples/rules).
 
 ## The Problem Nudge Solves
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported Versions
+
+Nudge is preparing for its first stable release. Until 1.0 is tagged, security
+fixes are handled on the main development line.
+
+After 1.0, supported versions will be documented here with each release.
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities privately through GitHub's private
+vulnerability reporting flow for this repository when available.
+
+Include:
+
+- A short description of the issue and impact
+- Steps to reproduce or a minimal proof of concept
+- Affected versions or commits, if known
+- Any relevant logs, configuration, or rule files
+
+Please do not file a public issue until maintainers have had a chance to review
+and coordinate a fix.

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -4,7 +4,7 @@ This document captures research on real-world CLAUDE.md usage patterns, common f
 
 ## Problem Validation
 
-The problems described in [PLAN.md](PLAN.md) are widely reported in the Claude Code community. Key GitHub issues confirm:
+The problems described in the archived [prototype plan](archive/prototype-plan.md) are widely reported in the Claude Code community. Key GitHub issues confirm:
 
 - Users report **~95% rule compliance in first messages → ~20-60% after 10+ exchanges**
 - Rules are followed initially but degrade as conversation length increases

--- a/docs/archive/prototype-plan.md
+++ b/docs/archive/prototype-plan.md
@@ -1,3 +1,10 @@
+# Archived Prototype Plan
+
+> Historical context only. This was the original Claude-QA prototype plan and
+> does not describe the current Nudge 1.0 CLI, rule schema, release process, or
+> roadmap. Use the README, `nudge claude docs`, `nudge codex docs`, and
+> `examples/rules/` for current guidance.
+
 ## Claude-QA (better name TBD)
 
 Problem statement:

--- a/docs/rfc/0001-user-defined-rules.md
+++ b/docs/rfc/0001-user-defined-rules.md
@@ -1,4 +1,10 @@
-# RFC 0001: User-Defined Rules
+# RFC 0001: User-Defined Rules (Historical)
+
+> Historical design note. This RFC records an early prototype schema with
+> top-level `match:` and `action: interrupt|continue` fields. That schema is
+> stale for Nudge 1.0. Do not copy the examples in this document into a current
+> Nudge config. For current rule syntax, run `nudge claude docs` or
+> `nudge codex docs`, or start from `examples/rules/`.
 
 ## Summary
 

--- a/examples/rules/rust.yaml
+++ b/examples/rules/rust.yaml
@@ -6,9 +6,8 @@
 version: 1
 
 rules:
-  # Catch `use` statements inside function bodies.
-  # SyntaxTree matching avoids false positives for top-level imports and
-  # module-level imports inside test modules.
+  # Catch `use` statements inside function/closure bodies.
+  # Uses tree-sitter to distinguish block-level imports from module-level imports.
   - name: no-inline-imports
     description: Move imports to the top of the file
     message: Move this `use` statement to the top of the file with other imports, then retry.
@@ -19,33 +18,40 @@ rules:
         content:
           - kind: SyntaxTree
             language: rust
-            query: "(function_item body: (block (use_declaration) @use))"
+            query: |
+              (block (use_declaration) @use)
       - hook: PreToolUse
         tool: Edit
         file: "**/*.rs"
         new_content:
           - kind: SyntaxTree
             language: rust
-            query: "(function_item body: (block (use_declaration) @use))"
+            query: |
+              (block (use_declaration) @use)
 
   # Catch left-hand side type annotations in variable declarations.
-  # Pattern: `let name: Type = ...` or `let mut name: Type = ...`
+  # Uses tree-sitter to match `let name: Type = ...` without false positives
+  # from pattern matching like `let Value::Object(x) = ...`.
   - name: no-lhs-type-annotations
     description: Use type inference or turbofish instead of LHS annotations
-    message: "Remove this type annotation. Use turbofish (`collect::<Vec<_>>()`) or type inference instead, then retry."
+    message: "Use turbofish syntax (e.g., `from_str::<Type>(...)`) or type inference instead of left-hand type annotations, then retry."
     on:
       - hook: PreToolUse
         tool: Write
         file: "**/*.rs"
         content:
-          - kind: Regex
-            pattern: "(?m)^\\s*let\\s+(mut\\s+)?[a-zA-Z_][a-zA-Z0-9_]*\\s*:\\s*"
+          - kind: SyntaxTree
+            language: rust
+            query: |
+              (let_declaration type: (_) @type)
       - hook: PreToolUse
         tool: Edit
         file: "**/*.rs"
         new_content:
-          - kind: Regex
-            pattern: "(?m)^\\s*let\\s+(mut\\s+)?[a-zA-Z_][a-zA-Z0-9_]*\\s*:\\s*"
+          - kind: SyntaxTree
+            language: rust
+            query: |
+              (let_declaration type: (_) @type)
 
   # Catch unnecessarily fully qualified paths in code (not imports).
   # Pattern: paths with 2+ `::` separators followed by ::, (, or <
@@ -67,6 +73,8 @@ rules:
             pattern: "std(::[a-zA-Z_][a-zA-Z0-9_]*){2,}(::|\\(|<)"
 
   # Suggest using `pretty_assertions` for better test output.
+  # Uses tree-sitter to match the exact macro name, avoiding false positives
+  # from `pretty_assert_eq!` which contains `assert_eq` as a substring.
   - name: prefer-pretty-assertions
     description: Use pretty_assertions in tests for better diff output
     message: "Use `pretty_assert_eq!` instead. Add `use pretty_assertions::assert_eq as pretty_assert_eq;` at file top, then retry."
@@ -75,11 +83,51 @@ rules:
         tool: Write
         file: "**/*.rs"
         content:
-          - kind: Regex
-            pattern: "assert_eq!"
+          - kind: SyntaxTree
+            language: rust
+            query: |
+              (macro_invocation
+                macro: (identifier) @macro
+                (#eq? @macro "assert_eq"))
       - hook: PreToolUse
         tool: Edit
         file: "**/*.rs"
         new_content:
-          - kind: Regex
-            pattern: "assert_eq!"
+          - kind: SyntaxTree
+            language: rust
+            query: |
+              (macro_invocation
+                macro: (identifier) @macro
+                (#eq? @macro "assert_eq"))
+
+  # Catch .unwrap() calls and suggest .expect() instead.
+  # Uses tree-sitter to match actual method calls, avoiding false positives
+  # from doc comments or string literals containing ".unwrap()".
+  - name: no-unwrap
+    description: Use .expect() instead of .unwrap() for better error messages
+    message: 'Use `.expect("descriptive error message")` instead of `.unwrap()`, then retry.'
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.rs"
+        content:
+          - kind: SyntaxTree
+            language: rust
+            query: |
+              (call_expression
+                function: (field_expression
+                  field: (field_identifier) @method
+                  (#eq? @method "unwrap"))
+                arguments: (arguments))
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.rs"
+        new_content:
+          - kind: SyntaxTree
+            language: rust
+            query: |
+              (call_expression
+                function: (field_expression
+                  field: (field_identifier) @method
+                  (#eq? @method "unwrap"))
+                arguments: (arguments))

--- a/examples/rules/rust.yaml
+++ b/examples/rules/rust.yaml
@@ -53,6 +53,39 @@ rules:
             query: |
               (let_declaration type: (_) @type)
 
+  # Prefer explicit string construction for string literals.
+  # Uses tree-sitter to match literal receiver calls while ignoring variables.
+  - name: prefer-string-from-literal
+    description: Use String::from instead of .to_string() on string literals
+    message: 'Use `String::from("...")` instead of calling `.to_string()` on a string literal, then retry.'
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.rs"
+        content:
+          - kind: SyntaxTree
+            language: rust
+            query: |
+              (call_expression
+                function: (field_expression
+                  value: (string_literal) @string
+                  field: (field_identifier) @method
+                  (#eq? @method "to_string"))
+                arguments: (arguments))
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.rs"
+        new_content:
+          - kind: SyntaxTree
+            language: rust
+            query: |
+              (call_expression
+                function: (field_expression
+                  value: (string_literal) @string
+                  field: (field_identifier) @method
+                  (#eq? @method "to_string"))
+                arguments: (arguments))
+
   # Catch unnecessarily fully qualified paths in code (not imports).
   # Pattern: paths with 2+ `::` separators followed by ::, (, or <
   - name: no-qualified-paths

--- a/packages/nudge/Cargo.toml
+++ b/packages/nudge/Cargo.toml
@@ -2,6 +2,12 @@
 name = "nudge"
 version = "0.1.0"
 edition = "2024"
+description = "Collaborative memory layer for Claude Code and Codex CLI agent hooks."
+license = "Apache-2.0"
+repository = "https://github.com/attunehq/nudge"
+readme = "../../README.md"
+keywords = ["agent", "hooks", "cli", "codex", "claude"]
+categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 bon = "3.8.1"


### PR DESCRIPTION
## Why this change

Several release-facing docs and metadata surfaces still looked prototype-era or incomplete. README linked to an old roadmap, RFC 0001 documented an obsolete schema, release metadata was missing, and the Rust example was weaker than the current dogfood rules.

This PR cleans up those surfaces for a 1.0-ready repo: archives stale planning docs, marks the old RFC historical, adds Apache-2.0 license metadata, changelog and security policy files, and refreshes the Rust example.

## Testing steps performed

Reported by the implementing thread:

- `cargo metadata --no-deps --format-version 1`
- `cargo run -q -p nudge -- validate examples/rules/rust.yaml`
- `cargo run -q -p nudge -- validate examples/rules/java.yaml`
- `cargo run -q -p nudge -- validate examples/rules/haskell.yaml`
- `cargo run -q -p nudge -- check`
- `cargo test -p nudge` - 83 unit tests, 1 bin test, 115 integration tests, 1 doctest passed

## Configuration changes after merge

Adds repository release metadata files: `LICENSE`, `CHANGELOG.md`, and `SECURITY.md`. Cargo metadata now declares `license = "Apache-2.0"` plus release-facing package metadata.