### PR TITLE
Document Nudge release version contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,17 @@ cargo run -p nudge -- validate         # Validate rule config files
 cargo run -p nudge -- check            # Check project files against rules (for CI)
 ```
 
+## Release Version Contract
+
+`packages/nudge/Cargo.toml` keeps `[package] version = "0.1.0"` as package
+metadata only. This is intentional, not stale metadata.
+
+Nudge is distributed as built GitHub release binaries. The release version
+source of truth is the git tag, the built binary version derived by
+`packages/nudge/build.rs`, and the GitHub release assets. Do not flag Cargo
+package version metadata as a release blocker unless the project explicitly
+decides to publish crates.io artifacts.
+
 ## Architecture
 
 ### CLI Structure

--- a/packages/nudge/Cargo.toml
+++ b/packages/nudge/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
 name = "nudge"
+# Cargo package metadata is not the release source of truth. Nudge ships as
+# built GitHub release binaries, and the CLI version comes from git tags/build
+# metadata via build.rs.
 version = "0.1.0"
 edition = "2024"
 description = "Collaborative memory layer for Claude Code and Codex CLI agent hooks."


### PR DESCRIPTION
## Why this change

- Nudge intentionally ships as built GitHub release binaries, and the CLI version is derived from git tags and build metadata.
- The Cargo package version in `packages/nudge/Cargo.toml` is package metadata only. It is intentionally left at `0.1.0`, and it is not the release source of truth.
- Future reviewers and agents were likely to treat the Cargo version as stale 1.0 release metadata. This PR documents the contract next to the field and in repo guidance so that review churn stops.
- Cargo package version metadata should only become a release concern if Nudge explicitly decides to publish crates.io artifacts.

## Testing steps performed

```text
cargo +nightly fmt --all --check
# exit 0, no output
```

```text
cargo test -p nudge
# test result: ok. 99 passed; 0 failed
# test result: ok. 2 passed; 0 failed
# test result: ok. 125 passed; 0 failed
# Doc-tests nudge: ok. 1 passed; 0 failed
```

```text
git diff --check
# exit 0, no output
```
