### PR TITLE
Fix nudge check empty explicit targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ nudge check "**/*.rs"
 nudge check || exit 1
 ```
 
+When you pass explicit paths or globs, each one must resolve to at least one
+file. Missing paths, empty directories, and glob patterns that match no files
+fail with a non-zero exit so CI scripts do not silently check nothing.
+
 `nudge check` evaluates file-based block rules for `PreToolUse` Write/Edit
 matchers, including Regex, SyntaxTree, and External content matchers. It
 supports SyntaxTree rules for Rust, TypeScript, JavaScript, Python, Go, Java,

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -25,6 +25,11 @@ Exit behavior:
 - `1`: one or more checkable violations were found.
 - Other non-zero exits: configuration, argument, or runtime errors.
 
+With no path arguments, `nudge check` scans the whole project from the current
+directory. With explicit operands, each path or glob must resolve to at least
+one file. Missing paths, empty directories, and glob patterns that match no
+files fail before rule evaluation with a clear error naming the operand.
+
 Example failure output:
 
 ```text

--- a/packages/nudge/src/cmd/check.rs
+++ b/packages/nudge/src/cmd/check.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use std::process;
 
 use clap::Args;
-use color_eyre::eyre::{Context, Result};
+use color_eyre::eyre::{Context, Result, eyre};
 use glob::Pattern;
 use ignore::WalkBuilder;
 
@@ -189,24 +189,16 @@ fn collect_files(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
     let mut files = Vec::new();
 
     if paths.is_empty() {
-        // Walk entire project from current directory
-        for entry in WalkBuilder::new(".").hidden(false).build() {
-            let entry = entry.context("walk directory")?;
-            if entry.file_type().is_some_and(|ft| ft.is_file()) {
-                files.push(entry.into_path());
-            }
-        }
+        collect_walk_files(Path::new("."), &mut files).context("walk project")?;
     } else {
-        // Process each provided path
         for path in paths {
             let path_str = path.to_string_lossy();
+            let initial_file_count = files.len();
 
-            // Check if it's a glob pattern
-            if path_str.contains('*') || path_str.contains('?') || path_str.contains('[') {
+            if looks_like_glob(&path_str) {
                 let pattern = Pattern::new(&path_str)
                     .with_context(|| format!("invalid glob pattern: {path_str}"))?;
 
-                // Walk from current directory and filter by pattern
                 for entry in WalkBuilder::new(".").hidden(false).build() {
                     let entry = entry.context("walk directory")?;
                     if entry.file_type().is_some_and(|ft| ft.is_file())
@@ -215,23 +207,41 @@ fn collect_files(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
                         files.push(entry.into_path());
                     }
                 }
+
+                if files.len() == initial_file_count {
+                    return Err(eyre!("check glob pattern matched no files: {path_str}"));
+                }
             } else if path.is_dir() {
-                // Walk the directory
-                for entry in WalkBuilder::new(path).hidden(false).build() {
-                    let entry = entry.context("walk directory")?;
-                    if entry.file_type().is_some_and(|ft| ft.is_file()) {
-                        files.push(entry.into_path());
-                    }
+                collect_walk_files(path, &mut files)
+                    .with_context(|| format!("walk check path: {}", path.display()))?;
+
+                if files.len() == initial_file_count {
+                    return Err(eyre!("check path contains no files: {}", path.display()));
                 }
             } else if path.is_file() {
                 files.push(path.clone());
             } else {
-                tracing::warn!(?path, "path does not exist, skipping");
+                return Err(eyre!("check path does not exist: {}", path.display()));
             }
         }
     }
 
     Ok(files)
+}
+
+fn collect_walk_files(root: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in WalkBuilder::new(root).hidden(false).build() {
+        let entry = entry.context("walk directory")?;
+        if entry.file_type().is_some_and(|ft| ft.is_file()) {
+            files.push(entry.into_path());
+        }
+    }
+
+    Ok(())
+}
+
+fn looks_like_glob(input: &str) -> bool {
+    input.contains('*') || input.contains('?') || input.contains('[')
 }
 
 /// Convert a byte offset to a 1-indexed line number.

--- a/packages/nudge/tests/it/check.rs
+++ b/packages/nudge/tests/it/check.rs
@@ -153,6 +153,85 @@ rules:
 }
 
 #[test]
+fn check_fails_when_explicit_path_does_not_exist() {
+    let dir = TempDir::new().expect("create temp dir");
+    fs::write(
+        dir.path().join(".nudge.yaml"),
+        r#"
+version: 1
+rules:
+  - name: block-todo
+    message: "Resolve TODO before commit."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.txt"
+        content:
+          - kind: Regex
+            pattern: "TODO"
+"#,
+    )
+    .expect("write config");
+
+    let (exit_code, stdout, stderr) =
+        run_nudge_in_dir(&dir, &["check", "definitely-does-not-exist.rs"]);
+
+    pretty_assert_eq!(
+        exit_code,
+        1,
+        "check should fail for missing explicit paths, stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("check path does not exist: definitely-does-not-exist.rs"),
+        "expected missing path error, got stderr: {stderr}"
+    );
+    assert!(
+        stdout.is_empty(),
+        "expected no success output for missing path, got: {stdout}"
+    );
+}
+
+#[test]
+fn check_fails_when_glob_pattern_matches_no_files() {
+    let dir = TempDir::new().expect("create temp dir");
+    fs::write(
+        dir.path().join(".nudge.yaml"),
+        r#"
+version: 1
+rules:
+  - name: block-todo
+    message: "Resolve TODO before commit."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.txt"
+        content:
+          - kind: Regex
+            pattern: "TODO"
+"#,
+    )
+    .expect("write config");
+    fs::create_dir_all(dir.path().join("src")).expect("create src dir");
+    fs::write(dir.path().join("src/main.txt"), "Plain text.\n").expect("write file");
+
+    let (exit_code, stdout, stderr) = run_nudge_in_dir(&dir, &["check", "**/*.rs"]);
+
+    pretty_assert_eq!(
+        exit_code,
+        1,
+        "check should fail for zero-match glob patterns, stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("check glob pattern matched no files: **/*.rs"),
+        "expected zero-match glob error, got stderr: {stderr}"
+    );
+    assert!(
+        stdout.is_empty(),
+        "expected no success output for zero-match glob, got: {stdout}"
+    );
+}
+
+#[test]
 fn check_exits_successfully_when_no_file_rules_exist() {
     let dir = TempDir::new().expect("create temp dir");
     fs::write(


### PR DESCRIPTION
**Why this change**

`nudge check` is used as a provider-free CI, pre-commit, and release-gate command, so its exit status has to prove that the intended files were actually inspected. Before this change, `nudge check definitely-does-not-exist.rs` exited `0` and printed `Checked 0 files`, which could let stale paths or mistyped globs produce a false green result in automation.

This PR makes explicit check operands part of the command contract. With no path arguments, `nudge check` still scans the whole project. When a caller provides paths or glob patterns, each operand must resolve to at least one file; missing paths, empty directories, and zero-match globs fail before rule evaluation with an error naming the operand. That keeps full-project scans ergonomic while making scripted targeted checks reliable.

**Testing steps performed**

```text
$ cargo test -p nudge --test it check::
running 4 tests
test check::check_fails_when_explicit_path_does_not_exist ... ok
test check::check_exits_successfully_when_no_file_rules_exist ... ok
test check::check_fails_when_glob_pattern_matches_no_files ... ok
test check::check_runs_file_rules_without_agent_provider ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 123 filtered out
```

```text
$ cargo test -p nudge
test result: ok. 99 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 127 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

```text
$ cargo clippy -p nudge --all-targets --all-features -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s)
```

```text
$ cargo +nightly fmt --all --check
$ git diff --check
```

```text
$ cargo run -q -p nudge -- check definitely-does-not-exist.rs; printf 'exit=%s\n' $?
Error:
   0: check path does not exist: definitely-does-not-exist.rs
exit=1
```

```text
$ cargo run -q -p nudge -- check '**/*.definitely-missing'; printf 'exit=%s\n' $?
Error:
   0: check glob pattern matched no files: **/*.definitely-missing
exit=1
```

```text
$ cargo run -q -p nudge -- check; printf 'exit=%s\n' $?
✓ Checked 62 files against 7 rules
  - .nudge.yaml: 7 rules
exit=0
```

**Notes**

Merged `origin/main` into this branch before pushing, per request. The merge was clean.
