### PR TITLE
[codex] Back up provider hook configs during setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ nudge claude setup
 nudge codex setup
 ```
 
-Claude setup adds Nudge to `.claude/settings.local.json`. Codex setup adds Nudge to `.codex/hooks.json`. You can verify with `/hooks` in the relevant agent.
+Claude setup adds Nudge to `.claude/settings.local.json`. Codex setup adds Nudge to `.codex/hooks.json`. If the target file already exists, setup first writes a non-overwriting backup next to it, such as `settings.local.json.bak` or `hooks.json.bak.1`, and prints the backup path. You can verify with `/hooks` in the relevant agent.
 
 > [!NOTE]
 > Hook configuration is loaded when agent sessions start, so restart open Claude Code or Codex sessions after setup. Future changes to rules are internal to Nudge and therefore do not need an agent restart.

--- a/packages/nudge/src/cmd/claude.rs
+++ b/packages/nudge/src/cmd/claude.rs
@@ -19,7 +19,8 @@ enum Commands {
     /// Responds to Claude Code hooks.
     Hook(hook::Config),
 
-    /// Set up Nudge hooks in .claude/settings.local.json.
+    /// Set up Nudge hooks in .claude/settings.local.json, backing up existing
+    /// settings.
     Setup(setup::Config),
 
     /// Show documentation for writing Nudge rules.

--- a/packages/nudge/src/cmd/claude/setup.rs
+++ b/packages/nudge/src/cmd/claude/setup.rs
@@ -107,7 +107,8 @@ pub fn main(config: Config) -> Result<()> {
     ];
     tracing::debug!(?desired_hooks, "generate desired hooks");
 
-    let mut settings = if settings_file.exists() {
+    let settings_existed = settings_file.exists();
+    let mut settings = if settings_existed {
         let content =
             fs::read_to_string(&settings_file).context("read existing settings.local.json")?;
         serde_json::from_str::<Value>(&content).context("parse existing settings.local.json")?
@@ -122,10 +123,6 @@ pub fn main(config: Config) -> Result<()> {
     // existing settings that we may not know about. We've enabled the
     // `preserve_order` feature of serde_json; this should reduce the impact of
     // our changes on the user's settings file.
-    //
-    // TODO: we might want to warn the user so that we don't clobber their
-    // comments or whatever, or at least back up their existing settings file
-    // and leave it behind for them to merge with our changes if desired.
     {
         let hooks = json_hooks::hooks_object(&mut settings, "settings")?;
         let desired_hooks = desired_hooks
@@ -137,10 +134,21 @@ pub fn main(config: Config) -> Result<()> {
     }
 
     let settings_json = serde_json::to_string_pretty(&settings).context("serialize settings")?;
+    let backup_path = if settings_existed {
+        setup_command::backup_existing_file(&settings_file)?
+    } else {
+        None
+    };
     fs::write(&settings_file, settings_json).context("write settings file")?;
     tracing::debug!(?settings, ?settings_file, "wrote merged settings file");
 
     println!("✓ Wrote hooks configuration to {}", settings_file.display());
+    if let Some(backup_path) = backup_path {
+        println!(
+            "  Backed up previous configuration to {}",
+            backup_path.display()
+        );
+    }
     println!();
 
     if !config.skip_claude_md {

--- a/packages/nudge/src/cmd/codex.rs
+++ b/packages/nudge/src/cmd/codex.rs
@@ -19,7 +19,7 @@ enum Commands {
     /// Responds to Codex hooks.
     Hook(hook::Config),
 
-    /// Set up Nudge hooks in .codex/hooks.json.
+    /// Set up Nudge hooks in .codex/hooks.json, backing up existing hooks.
     Setup(setup::Config),
 
     /// Show documentation for writing Nudge rules.

--- a/packages/nudge/src/cmd/codex/setup.rs
+++ b/packages/nudge/src/cmd/codex/setup.rs
@@ -63,7 +63,8 @@ pub fn main(config: Config) -> Result<()> {
         ),
     ];
 
-    let mut config = if hooks_file.exists() {
+    let hooks_file_existed = hooks_file.exists();
+    let mut config = if hooks_file_existed {
         let content = fs::read_to_string(&hooks_file).context("read existing hooks.json")?;
         serde_json::from_str::<Value>(&content).context("parse existing hooks.json")?
     } else {
@@ -74,9 +75,20 @@ pub fn main(config: Config) -> Result<()> {
     json_hooks::merge_hooks(hooks, desired_hooks)?;
 
     let hooks_json = serde_json::to_string_pretty(&config).context("serialize hooks.json")?;
+    let backup_path = if hooks_file_existed {
+        setup_command::backup_existing_file(&hooks_file)?
+    } else {
+        None
+    };
     fs::write(&hooks_file, hooks_json).context("write hooks.json")?;
 
     println!("✓ Wrote hooks configuration to {}", hooks_file.display());
+    if let Some(backup_path) = backup_path {
+        println!(
+            "  Backed up previous configuration to {}",
+            backup_path.display()
+        );
+    }
     println!();
     println!("Next steps:");
     println!("1. Restart Codex sessions so hooks are loaded.");

--- a/packages/nudge/src/cmd/setup_command.rs
+++ b/packages/nudge/src/cmd/setup_command.rs
@@ -1,12 +1,63 @@
 //! Shared setup helpers for provider hook commands.
 
-use std::{env, path::Path};
+use std::{
+    env,
+    fs::{File, OpenOptions},
+    io,
+    path::{Path, PathBuf},
+};
 
 use color_eyre::eyre::{Context, OptionExt, Result};
 
 pub(crate) fn current_hook_command(provider: &str) -> Result<String> {
     let nudge_path = env::current_exe().context("get current executable path")?;
     hook_command(&nudge_path, provider)
+}
+
+pub(crate) fn backup_existing_file(path: &Path) -> Result<Option<PathBuf>> {
+    if !path
+        .try_exists()
+        .with_context(|| format!("check whether {} exists", path.display()))?
+    {
+        return Ok(None);
+    }
+
+    let mut source = File::open(path).with_context(|| format!("open {}", path.display()))?;
+    for suffix in 0.. {
+        let backup_path = backup_path(path, suffix);
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&backup_path)
+        {
+            Ok(mut backup) => {
+                io::copy(&mut source, &mut backup).with_context(|| {
+                    format!(
+                        "copy {} to backup {}",
+                        path.display(),
+                        backup_path.display()
+                    )
+                })?;
+                return Ok(Some(backup_path));
+            }
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("create backup {}", backup_path.display()));
+            }
+        }
+    }
+
+    unreachable!("unbounded backup suffix search should always return or error")
+}
+
+fn backup_path(path: &Path, suffix: u32) -> PathBuf {
+    let mut backup = path.as_os_str().to_os_string();
+    backup.push(".bak");
+    if suffix > 0 {
+        backup.push(format!(".{suffix}"));
+    }
+    PathBuf::from(backup)
 }
 
 fn hook_command(nudge_path: &Path, provider: &str) -> Result<String> {
@@ -18,11 +69,12 @@ fn hook_command(nudge_path: &Path, provider: &str) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::{fs, path::Path};
 
     use pretty_assertions::assert_eq as pretty_assert_eq;
+    use tempfile::TempDir;
 
-    use super::hook_command;
+    use super::{backup_existing_file, hook_command};
 
     #[test]
     fn hook_command_quotes_paths_for_shell_execution() {
@@ -38,5 +90,25 @@ mod tests {
             words,
             vec!["/tmp/Nudge Test/bin/nudge's debug build", "claude", "hook"]
         );
+    }
+
+    #[test]
+    fn backup_existing_file_uses_next_available_suffix() {
+        let temp = TempDir::new().expect("temp dir");
+        let target = temp.path().join("hooks.json");
+        let first_backup = temp.path().join("hooks.json.bak");
+        fs::write(&target, "original").expect("write target");
+        fs::write(&first_backup, "first backup").expect("write first backup");
+
+        let backup = backup_existing_file(&target)
+            .expect("backup")
+            .expect("existing file should get backup");
+
+        pretty_assert_eq!(backup, temp.path().join("hooks.json.bak.1"));
+        pretty_assert_eq!(
+            fs::read_to_string(&first_backup).expect("read first backup"),
+            "first backup"
+        );
+        pretty_assert_eq!(fs::read_to_string(backup).expect("read backup"), "original");
     }
 }

--- a/packages/nudge/tests/it/setup.rs
+++ b/packages/nudge/tests/it/setup.rs
@@ -96,8 +96,16 @@ fn claude_setup_is_idempotent_and_installs_only_handled_events() {
         claude_dir,
         "--skip-claude-md",
     ];
-    let (exit_code, _, stderr) = run_nudge(&args);
+    let (exit_code, stdout, stderr) = run_nudge(&args);
     pretty_assert_eq!(exit_code, 0, "setup failed: {stderr}");
+    assert!(
+        !stdout.contains("Backed up previous configuration"),
+        "fresh setup should not report a backup, got: {stdout}"
+    );
+    assert!(
+        !temp.path().join(".claude/settings.local.json.bak").exists(),
+        "fresh setup should not create a backup"
+    );
     let first =
         fs::read_to_string(temp.path().join(".claude/settings.local.json")).expect("read settings");
 
@@ -152,6 +160,61 @@ fn claude_setup_is_idempotent_and_installs_only_handled_events() {
 }
 
 #[test]
+fn claude_setup_backs_up_existing_settings_without_overwriting_backups() {
+    let temp = TempDir::new().expect("temp dir");
+    let claude_dir = temp.path().join(".claude");
+    fs::create_dir_all(&claude_dir).expect("create .claude");
+    let canonical_claude_dir = claude_dir.canonicalize().expect("canonical .claude");
+
+    let settings_file = claude_dir.join("settings.local.json");
+    let first_backup = canonical_claude_dir.join("settings.local.json.bak");
+    let second_backup = canonical_claude_dir.join("settings.local.json.bak.1");
+    let original = r#"{"env":{"KEEP":"yes"}}"#;
+    fs::write(&settings_file, original).expect("write settings");
+
+    let args = [
+        "claude",
+        "setup",
+        "--claude-dir",
+        claude_dir.to_str().expect("utf-8 path"),
+        "--skip-claude-md",
+    ];
+    let (exit_code, stdout, stderr) = run_nudge(&args);
+    pretty_assert_eq!(exit_code, 0, "setup failed: {stderr}");
+    assert!(
+        stdout.contains(&format!(
+            "Backed up previous configuration to {}",
+            first_backup.display()
+        )),
+        "setup should print backup path, got: {stdout}"
+    );
+    pretty_assert_eq!(
+        fs::read_to_string(&first_backup).expect("read backup"),
+        original
+    );
+    let installed = fs::read_to_string(&settings_file).expect("read installed settings");
+
+    let (exit_code, stdout, stderr) = run_nudge(&args);
+    pretty_assert_eq!(exit_code, 0, "setup failed: {stderr}");
+    assert!(
+        stdout.contains(&format!(
+            "Backed up previous configuration to {}",
+            second_backup.display()
+        )),
+        "repeated setup should print next backup path, got: {stdout}"
+    );
+    pretty_assert_eq!(
+        fs::read_to_string(&first_backup).expect("read first backup"),
+        original,
+        "repeated setup must not overwrite the first backup"
+    );
+    pretty_assert_eq!(
+        fs::read_to_string(second_backup).expect("read second backup"),
+        installed
+    );
+}
+
+#[test]
 fn claude_setup_quotes_binary_path_with_spaces() {
     let temp = TempDir::new().expect("temp dir");
     let binary = copy_nudge_binary_to_path_with_spaces(&temp);
@@ -196,8 +259,16 @@ fn codex_setup_creates_hooks_json_and_is_idempotent() {
     let codex_dir = codex_dir.to_str().expect("utf-8 path");
     let args = ["codex", "setup", "--codex-dir", codex_dir];
 
-    let (exit_code, _, stderr) = run_nudge(&args);
+    let (exit_code, stdout, stderr) = run_nudge(&args);
     pretty_assert_eq!(exit_code, 0, "setup failed: {stderr}");
+    assert!(
+        !stdout.contains("Backed up previous configuration"),
+        "fresh setup should not report a backup, got: {stdout}"
+    );
+    assert!(
+        !temp.path().join(".codex/hooks.json.bak").exists(),
+        "fresh setup should not create a backup"
+    );
     let first = fs::read_to_string(temp.path().join(".codex/hooks.json")).expect("read hooks");
 
     let (exit_code, _, stderr) = run_nudge(&args);
@@ -212,6 +283,61 @@ fn codex_setup_creates_hooks_json_and_is_idempotent() {
         "Bash|apply_patch"
     );
     assert!(json["hooks"]["UserPromptSubmit"][0]["hooks"].is_array());
+}
+
+#[test]
+fn codex_setup_backs_up_existing_hooks_without_overwriting_backups() {
+    let temp = TempDir::new().expect("temp dir");
+    let codex_dir = temp.path().join(".codex");
+    fs::create_dir_all(&codex_dir).expect("create .codex");
+    let canonical_codex_dir = codex_dir.canonicalize().expect("canonical .codex");
+
+    let hooks_file = codex_dir.join("hooks.json");
+    let first_backup = canonical_codex_dir.join("hooks.json.bak");
+    let second_backup = canonical_codex_dir.join("hooks.json.bak.1");
+    let original =
+        r#"{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"echo hi"}]}]}}"#;
+    fs::write(&hooks_file, original).expect("write hooks");
+
+    let args = [
+        "codex",
+        "setup",
+        "--codex-dir",
+        codex_dir.to_str().expect("utf-8 path"),
+    ];
+    let (exit_code, stdout, stderr) = run_nudge(&args);
+    pretty_assert_eq!(exit_code, 0, "setup failed: {stderr}");
+    assert!(
+        stdout.contains(&format!(
+            "Backed up previous configuration to {}",
+            first_backup.display()
+        )),
+        "setup should print backup path, got: {stdout}"
+    );
+    pretty_assert_eq!(
+        fs::read_to_string(&first_backup).expect("read backup"),
+        original
+    );
+    let installed = fs::read_to_string(&hooks_file).expect("read installed hooks");
+
+    let (exit_code, stdout, stderr) = run_nudge(&args);
+    pretty_assert_eq!(exit_code, 0, "setup failed: {stderr}");
+    assert!(
+        stdout.contains(&format!(
+            "Backed up previous configuration to {}",
+            second_backup.display()
+        )),
+        "repeated setup should print next backup path, got: {stdout}"
+    );
+    pretty_assert_eq!(
+        fs::read_to_string(&first_backup).expect("read first backup"),
+        original,
+        "repeated setup must not overwrite the first backup"
+    );
+    pretty_assert_eq!(
+        fs::read_to_string(second_backup).expect("read second backup"),
+        installed
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Why this change

`nudge claude setup` and `nudge codex setup` rewrite provider hook config files. For existing `.claude/settings.local.json` and `.codex/hooks.json` files, that rewrite can discard formatting and comments. Setup now creates a non-overwriting adjacent backup before writing an existing provider config, then prints the backup path so users know where to recover the original file.

## What changed

- Added shared setup backup logic that writes `path.bak`, then `path.bak.1`, `path.bak.2`, and so on without overwriting an existing backup.
- Updated Claude setup to back up existing `.claude/settings.local.json` before writing.
- Updated Codex setup to back up existing `.codex/hooks.json` before writing.
- Kept fresh installs backup-free when the target config does not exist yet.
- Added integration tests for existing config backups, fresh installs, printed backup paths, and repeated setup preserving the first backup.
- Documented the backup behavior in setup docs/help.

## Testing steps performed

- `cargo test -p nudge --test it setup -- --nocapture`
  - Result: `10 passed; 0 failed; 117 filtered out`
- `cargo test -p nudge`
  - Result: `99` lib unit tests passed, `3` binary unit tests passed, `127` integration tests passed, `1` doctest passed
- `cargo clippy -p nudge --all-targets --all-features -- -D warnings`
  - Result: passed
- `cargo +nightly fmt --all --check`
  - Result: passed
- `git diff --check`
  - Result: passed

## Configuration changes after merge

No runtime configuration migration is required. Future setup runs will create backup files next to existing provider hook config files before rewriting them.

## Notes

Merged `origin/main` into the branch before pushing, per request.