### PR TITLE
Add Mermaid syntax-tree support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "packages/tree-sitter-mermaid/upstream"]
+	path = packages/tree-sitter-mermaid/upstream
+	url = https://github.com/monaqa/tree-sitter-mermaid.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,6 +689,7 @@ dependencies = [
  "tree-sitter-java",
  "tree-sitter-javascript",
  "tree-sitter-kotlin-ng",
+ "tree-sitter-mermaid",
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
@@ -1190,6 +1191,15 @@ name = "tree-sitter-language"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8"
+
+[[package]]
+name = "tree-sitter-mermaid"
+version = "0.0.1"
+dependencies = [
+ "cc",
+ "tree-sitter",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-python"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "3"
 members = [
     "packages/nudge",
+    "packages/tree-sitter-mermaid",
 ]
 
 [workspace.lints.clippy]

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ nudge check || exit 1
 `nudge check` evaluates file-based block rules for `PreToolUse` Write/Edit
 matchers, including Regex, SyntaxTree, and External content matchers. It
 supports SyntaxTree rules for Rust, TypeScript, JavaScript, Python, Go, Java,
-C#, Kotlin, and Haskell. Hook-only behavior such as Bash substitutions,
+C#, Kotlin, Haskell, and Mermaid. Hook-only behavior such as Bash substitutions,
 WebFetch, UserPromptSubmit reminders, permissions, delete events, and
 workflows still belongs to live hook mode.
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -87,10 +87,15 @@ skipped at debug log level, so keep rules targeted with `file` globs.
 - `csharp` (`c-sharp` is accepted as an alias)
 - `kotlin`
 - `haskell`
+- `mermaid`
 
 Use `nudge syntaxtree --language <language> <file-or-source>` when writing a
 query. This prints the parser's node names so the query can match the actual
 grammar shape for that language.
+
+For standalone Mermaid diagrams, target the file extensions you use, such as
+`**/*.mmd` and `**/*.mermaid`, and set `language: mermaid`. Markdown fenced
+Mermaid blocks are intentionally outside this surface for now.
 
 ## CI Examples
 

--- a/examples/rules/mermaid.yaml
+++ b/examples/rules/mermaid.yaml
@@ -1,0 +1,27 @@
+# Nudge rules for standalone Mermaid diagrams.
+#
+# These rules demonstrate SyntaxTree matchers against tree-sitter-mermaid.
+# Markdown fenced Mermaid blocks are not covered by this standalone file rule.
+
+version: 1
+rules:
+  - name: review-flowchart-edges
+    description: Review Mermaid flowchart edges
+    message: "{{ $suggestion }}"
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.mmd"
+        content:
+          - kind: SyntaxTree
+            language: mermaid
+            query: "(flow_stmt_vertice) @edge"
+            suggestion: "Review Mermaid flow edge `{{ $edge }}`."
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.mermaid"
+        content:
+          - kind: SyntaxTree
+            language: mermaid
+            query: "(flow_stmt_vertice) @edge"
+            suggestion: "Review Mermaid flow edge `{{ $edge }}`."

--- a/packages/nudge/Cargo.toml
+++ b/packages/nudge/Cargo.toml
@@ -41,6 +41,7 @@ tree-sitter-java = "0.23.5"
 tree-sitter-c-sharp = "0.23.1"
 tree-sitter-kotlin-ng = "1.1.0"
 tree-sitter-haskell = "0.23.1"
+tree-sitter-mermaid = { path = "../tree-sitter-mermaid" }
 derive_more = { version = "2.1.0", features = ["full"] }
 itertools = "0.14.0"
 indoc = "2.0.7"

--- a/packages/nudge/src/cmd/check.rs
+++ b/packages/nudge/src/cmd/check.rs
@@ -11,7 +11,7 @@ use std::process;
 use clap::Args;
 use color_eyre::eyre::{Context, Result};
 use glob::Pattern;
-use ignore::WalkBuilder;
+use ignore::{DirEntry, WalkBuilder};
 
 use nudge::rules::{self, ContentMatcher, GlobMatcher, Hook, PreToolUseMatcher, Rule, RuleAction};
 
@@ -189,13 +189,7 @@ fn collect_files(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
     let mut files = Vec::new();
 
     if paths.is_empty() {
-        // Walk entire project from current directory
-        for entry in WalkBuilder::new(".").hidden(false).build() {
-            let entry = entry.context("walk directory")?;
-            if entry.file_type().is_some_and(|ft| ft.is_file()) {
-                files.push(entry.into_path());
-            }
-        }
+        files.extend(walk_files(Path::new("."), None)?);
     } else {
         // Process each provided path
         for path in paths {
@@ -206,23 +200,9 @@ fn collect_files(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
                 let pattern = Pattern::new(&path_str)
                     .with_context(|| format!("invalid glob pattern: {path_str}"))?;
 
-                // Walk from current directory and filter by pattern
-                for entry in WalkBuilder::new(".").hidden(false).build() {
-                    let entry = entry.context("walk directory")?;
-                    if entry.file_type().is_some_and(|ft| ft.is_file())
-                        && pattern.matches_path(entry.path())
-                    {
-                        files.push(entry.into_path());
-                    }
-                }
+                files.extend(walk_files(Path::new("."), Some(&pattern))?);
             } else if path.is_dir() {
-                // Walk the directory
-                for entry in WalkBuilder::new(path).hidden(false).build() {
-                    let entry = entry.context("walk directory")?;
-                    if entry.file_type().is_some_and(|ft| ft.is_file()) {
-                        files.push(entry.into_path());
-                    }
-                }
+                files.extend(walk_files(path, None)?);
             } else if path.is_file() {
                 files.push(path.clone());
             } else {
@@ -232,6 +212,34 @@ fn collect_files(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
     }
 
     Ok(files)
+}
+
+fn walk_files(root: &Path, pattern: Option<&Pattern>) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    let root = root.to_path_buf();
+
+    for entry in WalkBuilder::new(&root)
+        .hidden(false)
+        .filter_entry(move |entry| should_walk_entry(&root, entry))
+        .build()
+    {
+        let entry = entry.context("walk directory")?;
+        if entry.file_type().is_some_and(|ft| ft.is_file())
+            && pattern.is_none_or(|pattern| pattern.matches_path(entry.path()))
+        {
+            files.push(entry.into_path());
+        }
+    }
+
+    Ok(files)
+}
+
+fn should_walk_entry(root: &Path, entry: &DirEntry) -> bool {
+    entry.path() == root || !is_git_submodule_dir(entry.path())
+}
+
+fn is_git_submodule_dir(path: &Path) -> bool {
+    path.is_dir() && path.join(".git").is_file()
 }
 
 /// Convert a byte offset to a 1-indexed line number.

--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -220,14 +220,15 @@ const DOCS: &str = cstr!("\
     <yellow>content:</yellow>
       <yellow>- kind: SyntaxTree</yellow>
         <yellow>language: typescript</yellow>        <dim># One of: rust, typescript, javascript,</dim>
-                                            <dim># python, go, java, csharp, kotlin, haskell</dim>
+                                            <dim># python, go, java, csharp, kotlin,</dim>
+                                            <dim># haskell, mermaid</dim>
         <yellow>query: |</yellow>
           <yellow>(function_declaration</yellow>
             <yellow>name: (identifier) @fn_name)</yellow>
         <yellow>suggestion: \"...\"</yellow>           <dim># Optional: same as Regex</dim>
 
   <white>Supported Languages:</white>
-    <green>rust</green>, <green>typescript</green>, <green>javascript</green>, <green>python</green>, <green>go</green>, <green>java</green>, <green>csharp</green>, <green>kotlin</green>, <green>haskell</green>
+    <green>rust</green>, <green>typescript</green>, <green>javascript</green>, <green>python</green>, <green>go</green>, <green>java</green>, <green>csharp</green>, <green>kotlin</green>, <green>haskell</green>, <green>mermaid</green>
 
   <white>Query Syntax:</white>
     Tree-sitter uses S-expression queries. Nodes are matched by type (in parentheses)

--- a/packages/nudge/src/rules/schema/syntax.rs
+++ b/packages/nudge/src/rules/schema/syntax.rs
@@ -35,6 +35,8 @@ pub enum Language {
     Kotlin,
     /// The Haskell programming language.
     Haskell,
+    /// The Mermaid diagram syntax.
+    Mermaid,
 }
 
 impl Language {
@@ -50,6 +52,7 @@ impl Language {
             Language::CSharp => tree_sitter_c_sharp::LANGUAGE.into(),
             Language::Kotlin => tree_sitter_kotlin_ng::LANGUAGE.into(),
             Language::Haskell => tree_sitter_haskell::LANGUAGE.into(),
+            Language::Mermaid => tree_sitter_mermaid::LANGUAGE.into(),
         }
     }
 
@@ -79,6 +82,7 @@ fn parser_for(language: Language) -> &'static Mutex<Parser> {
     static CSHARP: LazyLock<Mutex<Parser>> = LazyLock::new(|| new_parser(Language::CSharp));
     static KOTLIN: LazyLock<Mutex<Parser>> = LazyLock::new(|| new_parser(Language::Kotlin));
     static HASKELL: LazyLock<Mutex<Parser>> = LazyLock::new(|| new_parser(Language::Haskell));
+    static MERMAID: LazyLock<Mutex<Parser>> = LazyLock::new(|| new_parser(Language::Mermaid));
 
     match language {
         Language::Rust => &RUST,
@@ -90,6 +94,7 @@ fn parser_for(language: Language) -> &'static Mutex<Parser> {
         Language::CSharp => &CSHARP,
         Language::Kotlin => &KOTLIN,
         Language::Haskell => &HASKELL,
+        Language::Mermaid => &MERMAID,
     }
 }
 
@@ -308,6 +313,24 @@ mod tests {
         );
         pretty_assert_eq!(Language::from_str("csharp", false), Ok(Language::CSharp));
         pretty_assert_eq!(Language::from_str("c-sharp", false), Ok(Language::CSharp));
+        pretty_assert_eq!(Language::from_str("mermaid", false), Ok(Language::Mermaid));
+    }
+
+    #[test]
+    fn test_language_parse_mermaid_reuses_parser_and_accepts_error_trees() {
+        let valid = "flowchart TD\n  Start --> Done\n";
+        let first_tree = Language::Mermaid.parse(valid).expect("parse valid Mermaid");
+        let second_tree = Language::Mermaid.parse(valid).expect("parse Mermaid again");
+
+        pretty_assert_eq!(first_tree.root_node().kind(), "source_file");
+        pretty_assert_eq!(second_tree.root_node().kind(), "source_file");
+        assert!(!first_tree.root_node().has_error());
+
+        let incomplete = "flowchart TD\n  Start -->";
+        let tree = Language::Mermaid
+            .parse(incomplete)
+            .expect("parse incomplete Mermaid into an error tree");
+        assert!(tree.root_node().has_error());
     }
 
     #[test]
@@ -390,6 +413,12 @@ mod tests {
               (#eq? @fn "head"))
             "#,
         );
+        assert!(query.is_ok());
+    }
+
+    #[test]
+    fn test_treesitter_query_compile_valid_mermaid() {
+        let query = TreeSitterQuery::new(Language::Mermaid, "(diagram_flow) @diagram");
         assert!(query.is_ok());
     }
 

--- a/packages/nudge/tests/it/check.rs
+++ b/packages/nudge/tests/it/check.rs
@@ -183,3 +183,53 @@ rules:
         "expected no-file-rule summary, got: {stdout}"
     );
 }
+
+#[test]
+fn check_skips_git_submodule_directories() {
+    let dir = TempDir::new().expect("create temp dir");
+    fs::write(
+        dir.path().join(".nudge.yaml"),
+        r#"
+version: 1
+rules:
+  - name: block-todo
+    description: Block TODO markers
+    message: "Resolve TODO before commit."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.txt"
+        content:
+          - kind: Regex
+            pattern: "TODO"
+"#,
+    )
+    .expect("write config");
+
+    fs::write(dir.path().join("root.txt"), "Clean root file.\n").expect("write root fixture");
+    let submodule = dir.path().join("vendor/upstream");
+    fs::create_dir_all(&submodule).expect("create submodule fixture");
+    fs::write(
+        submodule.join(".git"),
+        "gitdir: ../../.git/modules/vendor/upstream\n",
+    )
+    .expect("write submodule gitfile");
+    fs::write(submodule.join("bad.txt"), "TODO: third-party code\n")
+        .expect("write submodule fixture");
+
+    let (exit_code, stdout, stderr) = run_nudge_in_dir(&dir, &["check"]);
+
+    pretty_assert_eq!(
+        exit_code,
+        0,
+        "check should skip submodule files, stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("Checked 1 files against 1 rules"),
+        "expected only the root fixture to be checked, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("vendor/upstream"),
+        "submodule contents should not be reported, got: {stdout}"
+    );
+}

--- a/packages/nudge/tests/it/cli.rs
+++ b/packages/nudge/tests/it/cli.rs
@@ -200,6 +200,30 @@ fn test_syntaxtree_typescript_legacy_alias() {
 }
 
 #[test]
+fn test_syntaxtree_mermaid_language_name() {
+    let (exit_code, stdout, stderr) = run_nudge(&[
+        "syntaxtree",
+        "--language",
+        "mermaid",
+        "flowchart TD\n  Start --> Done\n",
+    ]);
+
+    pretty_assert_eq!(
+        exit_code,
+        0,
+        "syntaxtree should accept language:mermaid, stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("diagram_flow"),
+        "syntaxtree should show Mermaid diagram_flow, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("flow_stmt_vertice") && stdout.contains("Start --> Done"),
+        "syntaxtree should show Mermaid flow edge, got: {stdout}"
+    );
+}
+
+#[test]
 fn test_syntaxtree_shows_field_names() {
     let (exit_code, stdout, _stderr) = run_nudge(&[
         "syntaxtree",

--- a/packages/nudge/tests/it/syntax_tree.rs
+++ b/packages/nudge/tests/it/syntax_tree.rs
@@ -10,6 +10,7 @@ mod haskell;
 mod java;
 mod javascript;
 mod kotlin;
+mod mermaid;
 mod python;
 mod typescript_end_to_end;
 mod typescript_errors;

--- a/packages/nudge/tests/it/syntax_tree/mermaid.rs
+++ b/packages/nudge/tests/it/syntax_tree/mermaid.rs
@@ -1,0 +1,120 @@
+//! Mermaid syntax tree tests.
+
+use std::fs;
+
+use pretty_assertions::assert_eq as pretty_assert_eq;
+
+use super::{run_hook_in_dir, run_nudge_in_dir, setup_config, write_hook};
+
+#[test]
+fn test_mermaid_flowchart_write_matches_standalone_mmd() {
+    let config = mermaid_flowchart_config();
+    let dir = setup_config(config);
+
+    let input = write_hook("diagram.mmd", "flowchart TD\n  Start --> Done\n");
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0, output: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected interrupt for Mermaid flow edge, got: {output}"
+    );
+    assert!(
+        output.contains("Review Mermaid flow edge `Start --> Done`."),
+        "expected Mermaid capture interpolation, got: {output}"
+    );
+
+    let input = write_hook("diagram.mmd", "This is not a Mermaid diagram.\n");
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0");
+    assert!(
+        output.is_empty(),
+        "expected passthrough for non-Mermaid content, got: {output}"
+    );
+
+    let input = write_hook("diagram.md", "flowchart TD\n  Start --> Done\n");
+    let (exit_code, output) = run_hook_in_dir(&dir, &input);
+    pretty_assert_eq!(exit_code, 0, "expected exit 0");
+    assert!(
+        output.is_empty(),
+        "expected passthrough for Markdown because this thread only supports standalone Mermaid files, got: {output}"
+    );
+}
+
+#[test]
+fn test_mermaid_check_scans_mmd_and_mermaid_files() {
+    let config = mermaid_flowchart_config();
+    let dir = setup_config(config);
+    let diagrams = dir.path().join("diagrams");
+    fs::create_dir(&diagrams).expect("create diagrams directory");
+    fs::write(diagrams.join("bad.mmd"), "flowchart TD\n  Start --> Done\n")
+        .expect("write .mmd fixture");
+    fs::write(
+        diagrams.join("bad.mermaid"),
+        "flowchart TD\n  Login --> Dashboard\n",
+    )
+    .expect("write .mermaid fixture");
+    fs::write(
+        diagrams.join("notes.md"),
+        "flowchart TD\n  Hidden --> Ignored\n",
+    )
+    .expect("write Markdown fixture");
+    fs::write(
+        diagrams.join("safe.mmd"),
+        "sequenceDiagram\n  participant User\n",
+    )
+    .expect("write safe Mermaid fixture");
+
+    let (exit_code, stdout, stderr) = run_nudge_in_dir(&dir, &["check", "diagrams"]);
+    pretty_assert_eq!(
+        exit_code,
+        1,
+        "expected check to report Mermaid issues, stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("diagrams/bad.mmd:2 [review-mermaid-flow]"),
+        "expected check to report .mmd flow edge, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Review Mermaid flow edge `Start --> Done`."),
+        "expected check message for .mmd capture, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("diagrams/bad.mermaid:2 [review-mermaid-flow]"),
+        "expected check to report .mermaid flow edge, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Review Mermaid flow edge `Login --> Dashboard`."),
+        "expected check message for .mermaid capture, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("notes.md") && !stdout.contains("safe.mmd"),
+        "expected check to skip Markdown and non-flow Mermaid files, got: {stdout}"
+    );
+}
+
+fn mermaid_flowchart_config() -> &'static str {
+    r#"
+version: 1
+rules:
+  - name: review-mermaid-flow
+    description: Review Mermaid flowchart edges
+    message: "{{ $suggestion }}"
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.mmd"
+        content:
+          - kind: SyntaxTree
+            language: mermaid
+            query: "(flow_stmt_vertice) @edge"
+            suggestion: "Review Mermaid flow edge `{{ $edge }}`."
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.mermaid"
+        content:
+          - kind: SyntaxTree
+            language: mermaid
+            query: "(flow_stmt_vertice) @edge"
+            suggestion: "Review Mermaid flow edge `{{ $edge }}`."
+"#
+}

--- a/packages/tree-sitter-mermaid/Cargo.toml
+++ b/packages/tree-sitter-mermaid/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "tree-sitter-mermaid"
+description = "Mermaid grammar for the tree-sitter parsing library."
+version = "0.0.1"
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/monaqa/tree-sitter-mermaid"
+
+build = "bindings/rust/build.rs"
+include = [
+  "bindings/rust/*",
+  "upstream/src/*",
+]
+
+[lib]
+path = "bindings/rust/lib.rs"
+
+[dependencies]
+tree-sitter-language = "0.1"
+
+[build-dependencies]
+cc = "1.1"
+
+[dev-dependencies]
+tree-sitter = "0.25"

--- a/packages/tree-sitter-mermaid/README.md
+++ b/packages/tree-sitter-mermaid/README.md
@@ -1,0 +1,10 @@
+# tree-sitter-mermaid
+
+This local crate wraps the generated parser from the
+`packages/tree-sitter-mermaid/upstream` Git submodule for Nudge's current
+`tree-sitter` API. The submodule points at
+`https://github.com/monaqa/tree-sitter-mermaid`.
+
+The upstream repository includes Rust bindings, but they target an older
+`tree-sitter` crate API. This wrapper exposes the same `LANGUAGE` constant shape
+used by Nudge's other grammar crates through `tree-sitter-language`.

--- a/packages/tree-sitter-mermaid/bindings/rust/build.rs
+++ b/packages/tree-sitter-mermaid/bindings/rust/build.rs
@@ -1,0 +1,20 @@
+use std::path::Path;
+
+fn main() {
+    let src_dir = Path::new("upstream/src");
+    let parser_path = src_dir.join("parser.c");
+
+    cc::Build::new()
+        .include(src_dir)
+        .file(&parser_path)
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable")
+        .flag_if_supported("-Wno-trigraphs")
+        .compile("parser");
+
+    println!("cargo:rerun-if-changed={}", parser_path.display());
+    println!(
+        "cargo:rerun-if-changed={}",
+        src_dir.join("tree_sitter/parser.h").display()
+    );
+}

--- a/packages/tree-sitter-mermaid/bindings/rust/lib.rs
+++ b/packages/tree-sitter-mermaid/bindings/rust/lib.rs
@@ -1,0 +1,24 @@
+//! Mermaid grammar support for the tree-sitter parsing library.
+
+use tree_sitter_language::LanguageFn;
+
+extern "C" {
+    fn tree_sitter_mermaid() -> *const ();
+}
+
+/// The tree-sitter language function for Mermaid.
+pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_mermaid) };
+
+/// The content of the `node-types.json` file for this grammar.
+pub const NODE_TYPES: &str = include_str!("../../upstream/src/node-types.json");
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_can_load_grammar() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&super::LANGUAGE.into())
+            .expect("Error loading Mermaid parser");
+    }
+}


### PR DESCRIPTION
## Why this change

Nudge's SyntaxTree matcher already treats supported languages as a first-class rule-writing surface, but standalone Mermaid diagrams could not be parsed or matched. This adds Mermaid to that language surface so rules can target Mermaid AST nodes through `language: mermaid`, including standalone `.mmd` and `.mermaid` files via normal file globs.

The upstream `monaqa/tree-sitter-mermaid` repository includes generated parser sources and Rust bindings, but those bindings target an older `tree-sitter` API. This PR adds a small local compatibility wrapper crate and pulls the upstream grammar in as a Git submodule at `packages/tree-sitter-mermaid/upstream`, pinned to `90ae195b31933ceb9d079abfa8a3ad0a36fee4cc`. The wrapper exposes the current `tree-sitter-language` `LANGUAGE` constant shape used by Nudge's other grammar crates while avoiding vendored generated parser sources in the parent repository.

This intentionally does not add Markdown fenced-code support. The cross-thread surface is only the shared `Language::Mermaid` parser/query plumbing; a Markdown implementation can reuse that parser later when it owns fenced-block extraction.

Adding a submodule also exposed that `nudge check` was walking third-party submodule sources and dogfooding first-party rules against them. Check mode now skips Git submodule directories during recursive file collection, with a regression test.

## Testing steps performed

- `cargo test -p nudge mermaid -- --nocapture`
  - Result: 2 Mermaid unit tests and 3 Mermaid integration tests passed.
- `cargo test -p nudge check -- --nocapture`
  - Result: 15 check-related integration tests passed, including `check_skips_git_submodule_directories`.
- `cargo clean -p tree-sitter-mermaid && cargo test -p tree-sitter-mermaid`
  - Result: wrapper crate rebuilt from the submodule source and 1 unit test passed.
- `cargo +nightly fmt --all --check`
  - Result: passed.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
  - Result: passed.
- `cargo run -p nudge -- validate examples/rules/mermaid.yaml`
  - Result: example Mermaid rule parsed and printed successfully.
- `cargo run -p nudge -- check`
  - Result: `Checked 65 files against 7 rules`.
- `cargo test --workspace`
  - Result: 101 nudge unit tests, 3 nudge main tests, 131 integration tests, 1 tree-sitter-mermaid unit test, 1 nudge doctest, and 0 tree-sitter-mermaid doctests passed.

## Configuration changes after merge

Clone/update commands need to initialize the submodule when building from source:

```bash
git submodule update --init --recursive
```

No runtime configuration or rule schema migration is required.

## Notes

The parent repository no longer vendors the generated Mermaid `parser.c` and `node-types.json`; those live in the pinned upstream submodule. The handwritten Nudge surface is limited to the grammar wrapper, language enum wiring, docs, example rule, focused regression tests, and the check-mode submodule traversal fix.