### PR TITLE
Add Markdown code block targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@ nudge check         - Check project files against rules (CI/linter mode)
 - `src/rules.rs` - Rule loading from config files
 - `src/rules/schema.rs` - Rule schema facade and hook matcher types
 - `src/rules/schema/` - Focused matcher implementations for content, glob paths, project state, tree-sitter syntax, and URLs
+- `src/rules/schema/target.rs` - File content targets, including raw content and Markdown code-block extraction
 - `src/snippet.rs` - Code snippet rendering for rule violations (uses `annotate-snippets`)
 
 ### How Nudge Communicates
@@ -108,6 +109,12 @@ The response type is determined by the hook type:
 - `UserPromptSubmit` rules always **continue** (inject guidance into the conversation)
 - `PermissionRequest` is parsed but always **passes through** until Nudge has a permission-specific rule surface
 - `Delete` is normalized but not yet matchable from YAML rules
+
+Write/Edit file rules evaluate a file content `target` before applying content
+matchers. `target: { kind: Content }` is the default raw-content behavior.
+`target: { kind: MarkdownCodeBlock, language: rust }` evaluates matchers inside
+matching fenced Markdown code blocks and translates match spans back to the
+physical Markdown file for snippets and `nudge check` line numbers.
 
 ## Keeping Documentation in Sync
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,6 +422,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +680,7 @@ dependencies = [
  "itertools",
  "monostate",
  "pretty_assertions",
+ "pulldown-cmark",
  "regex",
  "serde",
  "serde_json",
@@ -763,6 +773,25 @@ checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quote"
@@ -1220,6 +1249,12 @@ dependencies = [
  "cc",
  "tree-sitter-language",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/README.md
+++ b/README.md
@@ -108,6 +108,32 @@ content:
     timeout_ms: 10000
 ```
 
+### Markdown Code Blocks
+
+File rules can choose which part of a matched file is checked with `target`.
+The default is `target: { kind: Content }`, which evaluates matchers against
+the raw file content. For Markdown files, use `MarkdownCodeBlock` to evaluate
+the same Regex, SyntaxTree, or External matchers against fenced code blocks for
+a specific language:
+
+```yaml
+on:
+  - hook: PreToolUse
+    tool: Write
+    file: "**/*.md"
+    target:
+      kind: MarkdownCodeBlock
+      language: rust
+    content:
+      - kind: SyntaxTree
+        language: rust
+        query: "(let_declaration type: (_) @type)"
+```
+
+All content matchers in a Markdown code-block target must match the same fenced
+block. Snippets and `nudge check` line numbers point back to the physical
+Markdown file.
+
 For the full rule syntax and copy-pasteable examples, run `nudge claude docs` or `nudge codex docs`.
 
 ### Rule Writing Is Iterative
@@ -197,9 +223,10 @@ nudge check || exit 1
 `nudge check` evaluates file-based block rules for `PreToolUse` Write/Edit
 matchers, including Regex, SyntaxTree, and External content matchers. It
 supports SyntaxTree rules for Rust, TypeScript, JavaScript, Python, Go, Java,
-C#, Kotlin, and Haskell. Hook-only behavior such as Bash substitutions,
-WebFetch, UserPromptSubmit reminders, permissions, delete events, and
-workflows still belongs to live hook mode.
+C#, Kotlin, and Haskell. It also supports `target: { kind: MarkdownCodeBlock }`
+for fenced code blocks inside Markdown files. Hook-only behavior such as Bash
+substitutions, WebFetch, UserPromptSubmit reminders, permissions, delete
+events, and workflows still belongs to live hook mode.
 
 Example output when violations are found:
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -62,6 +62,8 @@ Check mode evaluates provider-independent file rules:
 | `kind: Regex` content matchers | Yes | Capture groups and message interpolation work. |
 | `kind: SyntaxTree` content matchers | Yes | Uses the configured tree-sitter language. |
 | `kind: External` content matchers | Yes | The file body is piped to stdin. A non-zero command exit means the rule matched. |
+| `target: { kind: Content }` | Yes | Default behavior. Matchers evaluate the raw file body. |
+| `target: { kind: MarkdownCodeBlock }` | Yes | Matchers evaluate fenced Markdown code blocks for the configured language. |
 | `action: block` | Yes | Violations are printed and the command exits `1`. |
 | `action: substitute` | No | Substitutions need a live Bash hook payload and provider `updatedInput`. |
 | `PreToolUse` `Bash` | No | Bash rules inspect commands, not files. |
@@ -73,6 +75,35 @@ Check mode evaluates provider-independent file rules:
 
 Check mode scans files as UTF-8 text. Files that cannot be read as text are
 skipped at debug log level, so keep rules targeted with `file` globs.
+
+## File Content Targets
+
+Write/Edit file rules evaluate `target: { kind: Content }` by default. This
+checks the raw file body, which is the right target for ordinary source files.
+
+For Markdown files, `target: { kind: MarkdownCodeBlock, language: rust }`
+extracts fenced code blocks with a matching info string and evaluates all
+content matchers against each block body. A rule matches only when all content
+matchers match the same fenced block. Reported file paths and line numbers
+still refer to the physical Markdown file:
+
+```yaml
+version: 1
+rules:
+  - name: no-rust-lhs-type-annotations-in-docs
+    message: "Use inferred local types in this Rust example."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.md"
+        target:
+          kind: MarkdownCodeBlock
+          language: rust
+        content:
+          - kind: SyntaxTree
+            language: rust
+            query: "(let_declaration type: (_) @type)"
+```
 
 ## Supported Syntax Languages
 

--- a/examples/rules/markdown.yaml
+++ b/examples/rules/markdown.yaml
@@ -1,0 +1,48 @@
+# Nudge rules for Markdown files and embedded code examples.
+#
+# These rules demonstrate file content targets. The default target is
+# `kind: Content`, which checks the raw file body. `kind: MarkdownCodeBlock`
+# checks fenced code blocks for one language inside a Markdown file.
+
+version: 1
+
+rules:
+  - name: no-rust-lhs-type-annotations-in-docs
+    description: Use inferred local types in Rust Markdown examples
+    message: "Use type inference instead of left-hand type annotations in this Rust code block, then retry."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.md"
+        target:
+          kind: MarkdownCodeBlock
+          language: rust
+        content:
+          - kind: SyntaxTree
+            language: rust
+            query: |
+              (let_declaration type: (_) @type)
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.md"
+        target:
+          kind: MarkdownCodeBlock
+          language: rust
+        new_content:
+          - kind: SyntaxTree
+            language: rust
+            query: |
+              (let_declaration type: (_) @type)
+
+  - name: no-todo-in-markdown
+    description: Resolve TODO markers anywhere in Markdown prose or code
+    message: "Resolve this TODO before continuing."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.md"
+        target:
+          kind: Content
+        content:
+          - kind: Regex
+            pattern: "TODO"

--- a/packages/nudge/Cargo.toml
+++ b/packages/nudge/Cargo.toml
@@ -21,6 +21,7 @@ directories = "6.0.0"
 glob = "0.3.3"
 monostate = "1.0.2"
 regex = "1.12.2"
+pulldown-cmark = "0.13.4"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.145", features = ["preserve_order"] }
 serde_yaml = "0.9.34"

--- a/packages/nudge/src/agent/claude.rs
+++ b/packages/nudge/src/agent/claude.rs
@@ -1,6 +1,9 @@
 //! Claude Code hook adapter.
 
-use std::{env, path::PathBuf};
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
 
 use color_eyre::eyre::{Context, OptionExt, Result};
 use serde_json::Value;
@@ -24,11 +27,11 @@ pub fn parse_hook(raw: Value) -> Result<Vec<NudgeHook>> {
     match event {
         "PreToolUse" => Ok(vec![NudgeHook::PreToolUse(PreToolUse {
             tool_input: raw.get("tool_input").cloned().unwrap_or(Value::Null),
-            tool: tool_use(&raw)?,
+            tool: tool_use(&raw, &context)?,
             context,
         })]),
         "PermissionRequest" => Ok(vec![NudgeHook::PermissionRequest(PermissionRequest {
-            tool: tool_use(&raw)?,
+            tool: tool_use(&raw, &context)?,
             context,
         })]),
         "UserPromptSubmit" => Ok(vec![NudgeHook::UserPromptSubmit(UserPromptSubmit {
@@ -59,7 +62,7 @@ fn context(raw: &Value, agent: AgentKind) -> Result<HookContext> {
     })
 }
 
-fn tool_use(raw: &Value) -> Result<ToolUse> {
+fn tool_use(raw: &Value, context: &HookContext) -> Result<ToolUse> {
     let tool_name = string_field(raw, "tool_name")?;
     let input = raw.get("tool_input").cloned().unwrap_or(Value::Null);
 
@@ -68,13 +71,22 @@ fn tool_use(raw: &Value) -> Result<ToolUse> {
             file_path: path_field(&input, "file_path")?,
             content: string_field(&input, "content")?.to_string(),
         })),
-        "Edit" => Ok(ToolUse::Edit(EditInput {
-            file_path: path_field(&input, "file_path")?,
-            old_string: string_field(&input, "old_string")
+        "Edit" => {
+            let file_path = path_field(&input, "file_path")?;
+            let old_string = string_field(&input, "old_string")
                 .unwrap_or_default()
-                .to_string(),
-            new_string: string_field(&input, "new_string")?.to_string(),
-        })),
+                .to_string();
+            let new_string = string_field(&input, "new_string")?.to_string();
+            let post_edit_content =
+                post_edit_content(&context.cwd, &file_path, &old_string, &new_string);
+
+            Ok(ToolUse::Edit(EditInput {
+                file_path,
+                old_string,
+                new_string,
+                post_edit_content,
+            }))
+        }
         "Delete" => Ok(ToolUse::Delete(DeleteInput {
             file_path: path_field(&input, "file_path")?,
         })),
@@ -91,6 +103,28 @@ fn tool_use(raw: &Value) -> Result<ToolUse> {
             input,
         }),
     }
+}
+
+fn post_edit_content(
+    cwd: &Path,
+    file_path: &Path,
+    old_string: &str,
+    new_string: &str,
+) -> Option<String> {
+    if old_string.is_empty() {
+        return None;
+    }
+
+    let path = if file_path.is_absolute() {
+        file_path.to_path_buf()
+    } else {
+        cwd.join(file_path)
+    };
+
+    let current = fs::read_to_string(path).ok()?;
+    current
+        .contains(old_string)
+        .then(|| current.replacen(old_string, new_string, 1))
 }
 
 fn string_field<'a>(value: &'a Value, field: &str) -> Result<&'a str> {

--- a/packages/nudge/src/cmd/check.rs
+++ b/packages/nudge/src/cmd/check.rs
@@ -13,7 +13,9 @@ use color_eyre::eyre::{Context, Result};
 use glob::Pattern;
 use ignore::WalkBuilder;
 
-use nudge::rules::{self, ContentMatcher, GlobMatcher, Hook, PreToolUseMatcher, Rule, RuleAction};
+use nudge::rules::{
+    self, ContentMatcher, FileContentTarget, GlobMatcher, Hook, PreToolUseMatcher, Rule, RuleAction,
+};
 
 #[derive(Args, Clone, Debug)]
 pub struct Config {
@@ -42,6 +44,8 @@ struct FileRule<'a> {
     pattern: &'a GlobMatcher,
     /// The content matchers to apply.
     matchers: ContentMatcherSet<'a>,
+    /// The part of the file content to evaluate.
+    target: &'a FileContentTarget,
     /// Reference to the parent rule.
     rule: &'a Rule,
 }
@@ -103,11 +107,13 @@ fn file_rules_for_rule(rule: &Rule) -> impl Iterator<Item = FileRule<'_>> {
             Hook::PreToolUse(PreToolUseMatcher::Write(matcher)) => Some(FileRule {
                 pattern: &matcher.file,
                 matchers: ContentMatcherSet::Write(&matcher.content),
+                target: &matcher.target,
                 rule,
             }),
             Hook::PreToolUse(PreToolUseMatcher::Edit(matcher)) => Some(FileRule {
                 pattern: &matcher.file,
                 matchers: ContentMatcherSet::Edit(&matcher.new_content),
+                target: &matcher.target,
                 rule,
             }),
             _ => None,
@@ -163,13 +169,10 @@ fn check_file(file: &Path, file_rules: &[FileRule<'_>]) -> (Vec<Issue>, bool) {
 
 fn rule_issues(file: &Path, content: &str, file_rule: &FileRule<'_>) -> Vec<Issue> {
     let matchers = file_rule.matchers.as_slice();
-    if matchers.is_empty() || !matchers.iter().all(|m| m.is_match(content)) {
-        return Vec::new();
-    }
-
-    matchers
-        .iter()
-        .flat_map(|matcher| matcher.matches_with_context(content))
+    file_rule
+        .target
+        .evaluate(content, matchers)
+        .into_iter()
         .map(|m| {
             let line = byte_offset_to_line(content, m.span.start);
             let message = nudge::template::interpolate(file_rule.rule.message(), &m.captures);

--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -52,6 +52,8 @@ const DOCS: &str = cstr!("\
         <yellow>- hook: PreToolUse</yellow>          <dim># PreToolUse or UserPromptSubmit</dim>
           <yellow>tool: Write</yellow>               <dim># Write, Edit, WebFetch, or Bash (PreToolUse only)</dim>
           <yellow>file: \"**/*.rs\"</yellow>           <dim># Glob pattern for file path</dim>
+          <yellow>target:</yellow>                    <dim># Optional. Default: kind: Content</dim>
+            <yellow>kind: Content</yellow>
           <yellow>content:</yellow>                   <dim># Patterns to match (Write tool)</dim>
             <yellow>- kind: Regex</yellow>
               <yellow>pattern: \"your-regex\"</yellow>
@@ -61,6 +63,8 @@ const DOCS: &str = cstr!("\
         <yellow>- hook: PreToolUse</yellow>          <dim># Same rule can match multiple scenarios</dim>
           <yellow>tool: Edit</yellow>
           <yellow>file: \"**/*.rs\"</yellow>
+          <yellow>target:</yellow>                    <dim># Optional. Also supports MarkdownCodeBlock</dim>
+            <yellow>kind: Content</yellow>
           <yellow>new_content:</yellow>              <dim># Patterns to match (Edit tool)</dim>
             <yellow>- kind: Regex</yellow>
               <yellow>pattern: \"your-regex\"</yellow>
@@ -92,6 +96,30 @@ const DOCS: &str = cstr!("\
 
   <green>Delete</green>     Normalized internally for file deletion, but not yet matchable
              in YAML rules.
+
+<bold>File Content Targets (Write/Edit only)</bold>
+
+  File rules evaluate <cyan>target:</cyan> before running <cyan>content:</cyan> or <cyan>new_content:</cyan>.
+
+  <green>Content</green>            Default. Match against the raw Write content or Edit replacement.
+  <green>MarkdownCodeBlock</green>  Match fenced Markdown code blocks for one language. All content
+                       matchers must match the same fenced block.
+
+  <white>Markdown Rust code-block example:</white>
+    <yellow>- hook: PreToolUse</yellow>
+      <yellow>tool: Write</yellow>
+      <yellow>file: \"**/*.md\"</yellow>
+      <yellow>target:</yellow>
+        <yellow>kind: MarkdownCodeBlock</yellow>
+        <yellow>language: rust</yellow>
+      <yellow>content:</yellow>
+        <yellow>- kind: SyntaxTree</yellow>
+          <yellow>language: rust</yellow>
+          <yellow>query: \"(let_declaration type: (_) @type)\"</yellow>
+
+  <dim>Markdown code-block snippets and check-mode line numbers point back to</dim>
+  <dim>the physical Markdown file. The language comes from the first code-fence</dim>
+  <dim>info-string word, such as ```rust or ```ts.</dim>
 
 <bold>Provider Support</bold>
 
@@ -386,6 +414,25 @@ const DOCS: &str = cstr!("\
                   <yellow>body: (block</yellow>
                     <yellow>(use_declaration</yellow>
                       <yellow>argument: (scoped_identifier) @path)))</yellow>
+
+  <cyan>Block Rust patterns inside Markdown code blocks</cyan>
+
+    <dim># The target limits matching to fenced Rust blocks in Markdown files.</dim>
+
+    <yellow>- name: no-rust-lhs-type-annotations-in-docs</yellow>
+      <yellow>description: Use inferred local types in Rust Markdown examples</yellow>
+      <yellow>message: \"Use type inference in this Rust code block, then retry.\"</yellow>
+      <yellow>on:</yellow>
+        <yellow>- hook: PreToolUse</yellow>
+          <yellow>tool: Write</yellow>
+          <yellow>file: \"**/*.md\"</yellow>
+          <yellow>target:</yellow>
+            <yellow>kind: MarkdownCodeBlock</yellow>
+            <yellow>language: rust</yellow>
+          <yellow>content:</yellow>
+            <yellow>- kind: SyntaxTree</yellow>
+              <yellow>language: rust</yellow>
+              <yellow>query: \"(let_declaration type: (_) @type)\"</yellow>
 
   <cyan>Enforce markdown table formatting (External)</cyan>
 

--- a/packages/nudge/src/hook.rs
+++ b/packages/nudge/src/hook.rs
@@ -142,8 +142,12 @@ pub struct EditInput {
     /// Replaced content or matched pre-patch content.
     pub old_string: String,
 
-    /// Full post-edit content.
+    /// Replacement content supplied by the provider.
     pub new_string: String,
+
+    /// Full post-edit file content, when the provider or adapter can recover
+    /// it.
+    pub post_edit_content: Option<String>,
 }
 
 /// Normalized delete input.

--- a/packages/nudge/src/hook/apply_patch.rs
+++ b/packages/nudge/src/hook/apply_patch.rs
@@ -54,6 +54,7 @@ pub fn parse(command: &str, cwd: &Path) -> Result<Vec<ToolUse>> {
             changes.push(ToolUse::Edit(EditInput {
                 file_path: update.move_to.unwrap_or_else(|| path.into()),
                 old_string: update.old_string,
+                post_edit_content: Some(new_string.clone()),
                 new_string,
             }));
             index = next;

--- a/packages/nudge/src/hook/evaluate.rs
+++ b/packages/nudge/src/hook/evaluate.rs
@@ -10,8 +10,9 @@ use crate::{
         WriteInput, response::HookOutcome,
     },
     rules::{
-        ContentMatcher, PreToolUseBashMatcher, PreToolUseEditMatcher, PreToolUseWebFetchMatcher,
+        FileContentTarget, PreToolUseBashMatcher, PreToolUseWebFetchMatcher,
         PreToolUseWriteMatcher, Rule, RuleAction, UrlMatcher, UserPromptSubmitMatcher,
+        evaluate_all_matched,
     },
     snippet::{Annotation, Match, Source},
 };
@@ -165,23 +166,41 @@ fn updated_tool_input(tool_input: &Value, command: &str) -> Value {
 }
 
 fn evaluate_pretooluse(payload: &PreToolUse, rules: &[Rule]) -> Vec<String> {
+    let mut file_annotations = Vec::<(String, Vec<Annotation>)>::new();
     let annotations = rules
         .iter()
         .filter(|rule| rule.action == RuleAction::Block)
         .flat_map(|rule| match &payload.tool {
-            ToolUse::Write(input) => annotate_write(rule, input),
-            ToolUse::Edit(input) => annotate_edit(rule, input),
+            ToolUse::Write(input) => {
+                push_file_annotations(
+                    &mut file_annotations,
+                    &input.content,
+                    annotate_write(rule, input),
+                );
+                Vec::new()
+            }
+            ToolUse::Edit(input) => {
+                for (source, annotations) in edit_annotation_groups(rule, input) {
+                    push_file_annotations(&mut file_annotations, source, annotations);
+                }
+                Vec::new()
+            }
             ToolUse::WebFetch(input) => annotate_webfetch(rule, input),
             ToolUse::Bash(input) => annotate_bash(rule, payload, input),
             ToolUse::Delete(_) | ToolUse::Other { .. } => Vec::new(),
         })
         .collect_vec();
 
-    if annotations.is_empty() {
-        return Vec::new();
+    let mut rendered = file_annotations
+        .into_iter()
+        .map(|(source, annotations)| Source::from(source).annotate(annotations))
+        .collect_vec();
+
+    if !annotations.is_empty() {
+        rendered.push(source_for_tool(&payload.tool).annotate(annotations));
     }
 
-    vec![source_for_tool(&payload.tool).annotate(annotations)]
+    rendered
 }
 
 fn evaluate_userpromptsubmit(payload: &UserPromptSubmit, rules: &[Rule]) -> Vec<String> {
@@ -215,10 +234,42 @@ fn annotate_write(rule: &Rule, input: &WriteInput) -> Vec<Annotation> {
         .pipe_matches(rule)
 }
 
-fn annotate_edit(rule: &Rule, input: &EditInput) -> Vec<Annotation> {
+fn push_file_annotations(
+    groups: &mut Vec<(String, Vec<Annotation>)>,
+    source: &str,
+    annotations: Vec<Annotation>,
+) {
+    if annotations.is_empty() {
+        return;
+    }
+
+    if let Some((_, existing_annotations)) = groups
+        .iter_mut()
+        .find(|(existing_source, _)| existing_source == source)
+    {
+        existing_annotations.extend(annotations);
+        return;
+    }
+
+    groups.push((source.to_string(), annotations));
+}
+
+fn edit_annotation_groups<'a>(
+    rule: &Rule,
+    input: &'a EditInput,
+) -> impl Iterator<Item = (&'a str, Vec<Annotation>)> {
     rule.hooks_pretooluse_edit()
-        .flat_map(|matcher| evaluate_edit(input, matcher))
-        .pipe_matches(rule)
+        .filter(|matcher| matcher.file.is_match_path(&input.file_path))
+        .filter_map(move |matcher| {
+            let source = source_for_edit(input, &matcher.target);
+            let annotations = matcher
+                .target
+                .evaluate(source, &matcher.new_content)
+                .into_iter()
+                .pipe_matches(rule);
+
+            (!annotations.is_empty()).then_some((source, annotations))
+        })
 }
 
 fn annotate_webfetch(rule: &Rule, input: &WebFetchInput) -> Vec<Annotation> {
@@ -235,17 +286,19 @@ fn annotate_bash(rule: &Rule, payload: &PreToolUse, input: &BashInput) -> Vec<An
 
 fn evaluate_write(input: &WriteInput, matcher: &PreToolUseWriteMatcher) -> Vec<Match> {
     if matcher.file.is_match_path(&input.file_path) {
-        evaluate_all_matched(&input.content, &matcher.content)
+        matcher.target.evaluate(&input.content, &matcher.content)
     } else {
         Vec::new()
     }
 }
 
-fn evaluate_edit(input: &EditInput, matcher: &PreToolUseEditMatcher) -> Vec<Match> {
-    if matcher.file.is_match_path(&input.file_path) {
-        evaluate_all_matched(&input.new_string, &matcher.new_content)
-    } else {
-        Vec::new()
+fn source_for_edit<'a>(input: &'a EditInput, target: &FileContentTarget) -> &'a str {
+    match target {
+        FileContentTarget::Content => &input.new_string,
+        FileContentTarget::MarkdownCodeBlock { .. } => input
+            .post_edit_content
+            .as_deref()
+            .unwrap_or(&input.new_string),
     }
 }
 
@@ -284,20 +337,6 @@ fn source_for_tool(tool: &ToolUse) -> Source {
         ToolUse::WebFetch(input) => Source::from(&input.url),
         ToolUse::Bash(input) => Source::from(&input.command),
     }
-}
-
-/// Evaluate all content matchers and return matches only if every matcher
-/// matched.
-fn evaluate_all_matched(content: &str, matchers: &[ContentMatcher]) -> Vec<Match> {
-    let mut matches = Vec::new();
-    for matcher in matchers {
-        let matcher_matches = matcher.matches_with_context(content);
-        if matcher_matches.is_empty() {
-            return Vec::new();
-        }
-        matches.extend(matcher_matches);
-    }
-    matches
 }
 
 /// Evaluate all URL matchers and return matches only if every matcher matched.

--- a/packages/nudge/src/rules/schema.rs
+++ b/packages/nudge/src/rules/schema.rs
@@ -13,12 +13,14 @@ pub use content::{ContentMatcher, RegexMatcher};
 pub use path::GlobMatcher;
 pub use project_state::ProjectStateMatcher;
 pub use syntax::{Language, TreeSitterQuery};
+pub use target::{FileContentTarget, evaluate_all_matched};
 pub use url::UrlMatcher;
 
 mod content;
 mod path;
 mod project_state;
 mod syntax;
+mod target;
 mod url;
 
 /// A rule configuration file.
@@ -268,6 +270,10 @@ pub struct PreToolUseWriteMatcher {
     #[serde(default)]
     pub file: GlobMatcher,
 
+    /// The part of the file content to evaluate.
+    #[serde(default)]
+    pub target: FileContentTarget,
+
     /// Regex patterns for content to match.
     ///
     /// When the content being written by the agent matches all of these
@@ -290,6 +296,10 @@ pub struct PreToolUseEditMatcher {
     /// pattern, the rule is triggered.
     #[serde(default)]
     pub file: GlobMatcher,
+
+    /// The part of the edited content to evaluate.
+    #[serde(default)]
+    pub target: FileContentTarget,
 
     /// Regex patterns for new content to match.
     ///

--- a/packages/nudge/src/rules/schema/target.rs
+++ b/packages/nudge/src/rules/schema/target.rs
@@ -1,0 +1,246 @@
+//! File-content target selection for Write/Edit rules.
+
+use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag, TagEnd};
+use serde::{Deserialize, Serialize};
+
+use crate::{snippet::Match, template::Captures};
+
+use super::{ContentMatcher, Language};
+
+/// The part of a matched file that content matchers evaluate.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(tag = "kind", deny_unknown_fields)]
+pub enum FileContentTarget {
+    /// Evaluate matchers against the raw file content.
+    #[default]
+    Content,
+
+    /// Evaluate matchers against fenced Markdown code blocks for one language.
+    MarkdownCodeBlock {
+        /// The language named by the fenced code block info string.
+        language: Language,
+    },
+}
+
+impl FileContentTarget {
+    /// Evaluate all matchers against this target and return translated matches.
+    pub fn evaluate(&self, content: &str, matchers: &[ContentMatcher]) -> Vec<Match> {
+        match self {
+            FileContentTarget::Content => evaluate_all_matched(content, matchers),
+            FileContentTarget::MarkdownCodeBlock { language } => markdown_code_blocks(content)
+                .into_iter()
+                .enumerate()
+                .filter(|(_, block)| language.matches_markdown_info_word(&block.language))
+                .flat_map(|(index, block)| {
+                    let mut matches = evaluate_all_matched(block.source, matchers);
+                    for m in &mut matches {
+                        m.span.start += block.body_start;
+                        m.span.end += block.body_start;
+                        m.captures.extend(Captures::from_iter([
+                            (String::from("markdown_language"), block.language.clone()),
+                            (String::from("markdown_info"), block.info.clone()),
+                            (
+                                String::from("markdown_block_start_line"),
+                                block.start_line.to_string(),
+                            ),
+                            (String::from("markdown_block_index"), index.to_string()),
+                        ]));
+                    }
+                    matches
+                })
+                .collect(),
+        }
+    }
+}
+
+/// Evaluate all content matchers and return matches only if every matcher
+/// matched the same target string.
+pub fn evaluate_all_matched(content: &str, matchers: &[ContentMatcher]) -> Vec<Match> {
+    let mut matches = Vec::new();
+    for matcher in matchers {
+        let matcher_matches = matcher.matches_with_context(content);
+        if matcher_matches.is_empty() {
+            return Vec::new();
+        }
+        matches.extend(matcher_matches);
+    }
+    matches
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MarkdownCodeBlock<'a> {
+    source: &'a str,
+    body_start: usize,
+    language: String,
+    info: String,
+    start_line: usize,
+}
+
+fn markdown_code_blocks(markdown: &str) -> Vec<MarkdownCodeBlock<'_>> {
+    let mut blocks = Vec::new();
+    let mut current = None::<OpenCodeBlock>;
+
+    for (event, range) in Parser::new_ext(markdown, Options::empty()).into_offset_iter() {
+        match event {
+            Event::Start(Tag::CodeBlock(CodeBlockKind::Fenced(info))) => {
+                let info = info.trim().to_string();
+                let language = info
+                    .split_whitespace()
+                    .next()
+                    .map(normalize_markdown_language)
+                    .unwrap_or_default();
+                current = Some(OpenCodeBlock {
+                    info,
+                    language,
+                    body_start: range.end,
+                    body_end: range.end,
+                    start_line: byte_offset_to_line(markdown, range.start),
+                });
+            }
+            Event::Text(_) => {
+                if let Some(block) = &mut current {
+                    block.body_start = block.body_start.min(range.start);
+                    block.body_end = block.body_end.max(range.end);
+                }
+            }
+            Event::End(TagEnd::CodeBlock) => {
+                if let Some(block) = current.take()
+                    && !block.language.is_empty()
+                    && block.body_start <= block.body_end
+                    && block.body_end <= markdown.len()
+                {
+                    blocks.push(MarkdownCodeBlock {
+                        source: &markdown[block.body_start..block.body_end],
+                        body_start: block.body_start,
+                        language: block.language,
+                        info: block.info,
+                        start_line: block.start_line,
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    blocks
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OpenCodeBlock {
+    info: String,
+    language: String,
+    body_start: usize,
+    body_end: usize,
+    start_line: usize,
+}
+
+fn normalize_markdown_language(word: &str) -> String {
+    word.trim()
+        .trim_start_matches("{.")
+        .trim_start_matches('.')
+        .trim_end_matches('}')
+        .to_ascii_lowercase()
+}
+
+fn byte_offset_to_line(content: &str, offset: usize) -> usize {
+    content[..offset.min(content.len())]
+        .chars()
+        .filter(|&c| c == '\n')
+        .count()
+        + 1
+}
+
+impl Language {
+    fn matches_markdown_info_word(self, word: &str) -> bool {
+        matches!(
+            (self, word),
+            (Language::Rust, "rust" | "rs")
+                | (Language::TypeScript, "typescript" | "ts" | "tsx")
+                | (Language::JavaScript, "javascript" | "js" | "jsx")
+                | (Language::Python, "python" | "py")
+                | (Language::Go, "go" | "golang")
+                | (Language::Java, "java")
+                | (Language::CSharp, "csharp" | "c-sharp" | "cs")
+                | (Language::Kotlin, "kotlin" | "kt" | "kts")
+                | (Language::Haskell, "haskell" | "hs")
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{rules::TreeSitterQuery, snippet::Span};
+    use pretty_assertions::assert_eq as pretty_assert_eq;
+
+    use super::*;
+
+    fn regex(pattern: &str) -> ContentMatcher {
+        serde_yaml::from_str(&format!(
+            r#"
+kind: Regex
+pattern: "{pattern}"
+"#
+        ))
+        .expect("valid regex matcher")
+    }
+
+    #[test]
+    fn content_target_preserves_raw_content_matching() {
+        let target = FileContentTarget::Content;
+        let matches = target.evaluate("one TODO\n", &[regex("TODO")]);
+
+        pretty_assert_eq!(matches.len(), 1);
+        pretty_assert_eq!(matches[0].span, Span { start: 4, end: 8 });
+    }
+
+    #[test]
+    fn markdown_code_block_target_matches_inside_one_fence() {
+        let target = FileContentTarget::MarkdownCodeBlock {
+            language: Language::Rust,
+        };
+        let markdown = "# Example\n\n```rust\nfn main() {\n    let value: usize = 1;\n}\n```\n";
+        let matches = target.evaluate(
+            markdown,
+            &[ContentMatcher::SyntaxTree {
+                language: Language::Rust,
+                query: TreeSitterQuery::new(
+                    Language::Rust,
+                    "(let_declaration pattern: (identifier) @binding type: (_) @type)",
+                )
+                .expect("valid query"),
+                suggestion: None,
+            }],
+        );
+
+        pretty_assert_eq!(matches.len(), 1);
+        pretty_assert_eq!(matches[0].captures["binding"], "value");
+        pretty_assert_eq!(matches[0].captures["markdown_language"], "rust");
+        pretty_assert_eq!(matches[0].captures["markdown_block_start_line"], "3");
+        pretty_assert_eq!(
+            &markdown[matches[0].span.start..matches[0].span.end],
+            "value: usize"
+        );
+    }
+
+    #[test]
+    fn markdown_code_block_target_requires_all_matchers_in_same_fence() {
+        let target = FileContentTarget::MarkdownCodeBlock {
+            language: Language::Rust,
+        };
+        let markdown = "```rust\nfn first() {}\n```\n\n```rust\nlet second: usize = 1;\n```\n";
+        let matches = target.evaluate(markdown, &[regex("first"), regex("second")]);
+
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn markdown_code_block_target_respects_language_aliases() {
+        let target = FileContentTarget::MarkdownCodeBlock {
+            language: Language::TypeScript,
+        };
+        let markdown = "```tsx\nvalue!\n```\n";
+        let matches = target.evaluate(markdown, &[regex("value!")]);
+
+        pretty_assert_eq!(matches.len(), 1);
+    }
+}

--- a/packages/nudge/tests/it/main.rs
+++ b/packages/nudge/tests/it/main.rs
@@ -14,6 +14,7 @@ mod edit_tool;
 mod external;
 mod inline_imports;
 mod install_script;
+mod markdown_target;
 mod message_content;
 mod multiple_rules;
 mod non_rust_files;

--- a/packages/nudge/tests/it/markdown_target.rs
+++ b/packages/nudge/tests/it/markdown_target.rs
@@ -1,0 +1,257 @@
+//! Integration tests for Markdown code-block file targets.
+
+use std::fs;
+use std::io::Write as _;
+use std::process::{Command, Stdio};
+
+use pretty_assertions::assert_eq as pretty_assert_eq;
+use tempfile::TempDir;
+
+use crate::nudge_binary;
+
+const RUST_LHS_TYPE_RULES: &str = r#"
+version: 1
+rules:
+  - name: no-rust-lhs-type-in-markdown
+    description: Use inferred local types in Rust examples
+    message: "{{ $suggestion }}"
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.md"
+        target:
+          kind: MarkdownCodeBlock
+          language: rust
+        content:
+          - kind: SyntaxTree
+            language: rust
+            query: "(let_declaration pattern: (identifier) @binding type: (_) @type)"
+            suggestion: "Remove {{ $type }} from {{ $binding }} in this Markdown Rust block."
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.md"
+        target:
+          kind: MarkdownCodeBlock
+          language: rust
+        new_content:
+          - kind: SyntaxTree
+            language: rust
+            query: "(let_declaration pattern: (identifier) @binding type: (_) @type)"
+            suggestion: "Remove {{ $type }} from {{ $binding }} in this Markdown Rust block."
+"#;
+
+fn setup_config(rules_yaml: &str) -> TempDir {
+    let dir = TempDir::new().expect("create temp dir");
+    fs::write(dir.path().join(".nudge.yaml"), rules_yaml).expect("write config");
+    dir
+}
+
+fn run_hook_in_dir(dir: &TempDir, input: String) -> (i32, String) {
+    let mut child = Command::new(nudge_binary())
+        .args(["claude", "hook"])
+        .current_dir(dir.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("run nudge hook");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(input.as_bytes())
+        .expect("write hook input");
+
+    let output = child.wait_with_output().expect("wait for nudge hook");
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = if stdout.trim().is_empty() {
+        stderr.trim().to_string()
+    } else {
+        stdout.trim().to_string()
+    };
+
+    (exit_code, combined)
+}
+
+fn run_nudge_in_dir(dir: &TempDir, args: &[&str]) -> (i32, String, String) {
+    let output = Command::new(nudge_binary())
+        .args(args)
+        .current_dir(dir.path())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run nudge");
+
+    (
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
+}
+
+fn write_hook(cwd: &str, file_path: &str, content: &str) -> String {
+    serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "test",
+        "transcript_path": "/tmp/test",
+        "permission_mode": "default",
+        "cwd": cwd,
+        "tool_name": "Write",
+        "tool_use_id": "123",
+        "tool_input": {
+            "file_path": file_path,
+            "content": content
+        }
+    })
+    .to_string()
+}
+
+fn edit_hook(cwd: &str, file_path: &str, old_string: &str, new_string: &str) -> String {
+    serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "test",
+        "transcript_path": "/tmp/test",
+        "permission_mode": "default",
+        "cwd": cwd,
+        "tool_name": "Edit",
+        "tool_use_id": "123",
+        "tool_input": {
+            "file_path": file_path,
+            "old_string": old_string,
+            "new_string": new_string
+        }
+    })
+    .to_string()
+}
+
+#[test]
+fn markdown_code_block_target_blocks_write_inside_matching_language_fence() {
+    let dir = setup_config(RUST_LHS_TYPE_RULES);
+    let markdown = r#"# Guide
+
+This prose says `let fake: usize = 1;` but should not matter.
+
+```python
+value: int = 1
+```
+
+```rust
+fn demo() {
+    let value: usize = 1;
+}
+```
+"#;
+
+    let input = write_hook(&dir.path().display().to_string(), "docs/guide.md", markdown);
+    let (exit_code, output) = run_hook_in_dir(&dir, input);
+
+    pretty_assert_eq!(exit_code, 0, "expected hook command success: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected Markdown Rust block denial, got: {output}"
+    );
+    assert!(
+        output.contains("Remove usize from value in this Markdown Rust block."),
+        "expected capture interpolation from Rust code block, got: {output}"
+    );
+    assert!(
+        output.contains("let value: usize = 1;"),
+        "expected snippet from physical Markdown content, got: {output}"
+    );
+}
+
+#[test]
+fn markdown_code_block_target_reconstructs_claude_edit_context() {
+    let dir = setup_config(RUST_LHS_TYPE_RULES);
+    fs::create_dir_all(dir.path().join("docs")).expect("create docs dir");
+    fs::write(
+        dir.path().join("docs/guide.md"),
+        r#"# Guide
+
+```rust
+fn demo() {
+    let value = 1;
+}
+```
+"#,
+    )
+    .expect("write markdown");
+
+    let input = edit_hook(
+        &dir.path().display().to_string(),
+        "docs/guide.md",
+        "let value = 1;",
+        "let value: usize = 1;",
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, input);
+
+    pretty_assert_eq!(exit_code, 0, "expected hook command success: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected denial after reconstructing Markdown edit context, got: {output}"
+    );
+    assert!(
+        output.contains("let value: usize = 1;"),
+        "expected snippet from reconstructed Markdown file, got: {output}"
+    );
+}
+
+#[test]
+fn markdown_code_block_target_reports_physical_lines_in_check_mode() {
+    let dir = setup_config(RUST_LHS_TYPE_RULES);
+    fs::create_dir_all(dir.path().join("docs")).expect("create docs dir");
+    fs::write(
+        dir.path().join("docs/guide.md"),
+        "# Guide\n\nText.\n\n```rust\nfn demo() {\n    let value: usize = 1;\n}\n```\n",
+    )
+    .expect("write markdown");
+
+    let (exit_code, stdout, stderr) = run_nudge_in_dir(&dir, &["check", "docs/guide.md"]);
+
+    pretty_assert_eq!(exit_code, 1, "expected check failure, stderr: {stderr}");
+    assert!(
+        stdout.contains("docs/guide.md:7 [no-rust-lhs-type-in-markdown]"),
+        "expected physical Markdown line for Rust block issue, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Remove usize from value in this Markdown Rust block."),
+        "expected interpolated check message, got: {stdout}"
+    );
+}
+
+#[test]
+fn explicit_content_target_preserves_raw_content_matching() {
+    let dir = setup_config(
+        r#"
+version: 1
+rules:
+  - name: raw-content-target
+    message: "Raw content matched."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.md"
+        target:
+          kind: Content
+        content:
+          - kind: Regex
+            pattern: "TODO"
+"#,
+    );
+
+    let input = write_hook(
+        &dir.path().display().to_string(),
+        "docs/guide.md",
+        "TODO outside any code block\n",
+    );
+    let (exit_code, output) = run_hook_in_dir(&dir, input);
+
+    pretty_assert_eq!(exit_code, 0, "expected hook command success: {output}");
+    assert!(
+        output.contains(r#""permissionDecision":"deny""#),
+        "expected explicit Content target to match raw Markdown content, got: {output}"
+    );
+}


### PR DESCRIPTION
## Why this change

Nudge needs Markdown support that can apply existing language-aware rules to fenced code examples without treating the entire Markdown document as that language. This PR adds explicit file content targets so rule authors can keep the current raw-content behavior with `target: { kind: Content }` and opt into embedded code evaluation with `target: { kind: MarkdownCodeBlock, language: rust }`.

The Markdown target evaluates all content matchers within the same fenced block and translates match spans back to the physical Markdown file, so hook snippets and `nudge check` line numbers point at the document users actually edited. Claude Edit normalization now carries reconstructed post-edit file content when available, which lets Markdown block rules see the surrounding fence even when the provider only sends a replacement string.

## What changed

- Added `FileContentTarget` with `Content` and `MarkdownCodeBlock` variants.
- Added Markdown fenced-code extraction using `pulldown-cmark` source ranges.
- Updated hook and check evaluation to run file matchers through targets and preserve source-aware snippets.
- Added Claude/Codex post-edit content support for Markdown-targeted Edit rules.
- Added unit and integration coverage for Write, Edit, check mode, same-block matching, language aliases, and explicit `Content` targets.
- Updated README, CI docs, generated provider docs, AGENTS architecture notes, and added `examples/rules/markdown.yaml`.

## Testing steps performed

```text
cargo test -p nudge
# 103 lib tests passed, 3 main tests passed, 131 integration tests passed, 1 doctest passed

cargo clippy -p nudge --all-targets -- -D warnings
# passed

cargo +nightly fmt --all --check
# passed

cargo run -q -p nudge -- check
# passed: Checked 64 files against 7 rules

cargo run -q -p nudge -- validate examples/rules/markdown.yaml
# passed and printed the parsed Markdown example rules

cargo run -q -p nudge -- claude docs
cargo run -q -p nudge -- codex docs
# passed; both generated docs commands produced 520 lines

git diff --check
# passed
```

## Configuration changes after merge

This adds the `pulldown-cmark` Rust crate dependency for Markdown parsing. No user configuration migration is required. Existing rules keep their current behavior because omitted `target` defaults to `Content`.

## Notes

The Markdown code-block target currently matches fenced code blocks by the first info-string word, including common aliases such as `rs`, `ts`, `tsx`, `js`, `py`, `kt`, and `hs`. Markdown structure queries are intentionally out of scope for this PR; this targets embedded language rules first.