### PR TITLE
Add learned incident retrieval and skill guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,11 +33,11 @@ cargo test -p nudge test_name
 
 # Run the CLI
 cargo run -p nudge -- claude hook      # Respond to Claude hook (reads JSON from stdin)
-cargo run -p nudge -- claude setup     # Install hooks into .claude/settings.local.json
+cargo run -p nudge -- claude setup     # Install hooks and bundled skills for Claude
 cargo run -p nudge -- claude docs      # Print rule writing documentation
 cargo run -p nudge -- claude skills install # Install bundled Claude skills
 cargo run -p nudge -- codex hook       # Respond to Codex hook (reads JSON from stdin)
-cargo run -p nudge -- codex setup      # Install hooks into .codex/hooks.json
+cargo run -p nudge -- codex setup      # Install hooks and bundled skills for Codex
 cargo run -p nudge -- codex docs       # Print rule writing documentation
 cargo run -p nudge -- codex skills install # Install bundled Codex skills
 cargo run -p nudge -- learn add        # Record a repo-local learned incident note
@@ -66,11 +66,11 @@ decides to publish crates.io artifacts.
 
 ```
 nudge claude hook   - Receives hook JSON on stdin, evaluates rules, outputs response
-nudge claude setup  - Writes hook configuration to .claude/settings.local.json
+nudge claude setup  - Writes hook configuration and installs bundled skills for Claude
 nudge claude docs   - Prints documentation for writing rules
 nudge claude skills install - Installs bundled skills into .claude/skills
 nudge codex hook    - Receives hook JSON on stdin, evaluates rules, outputs response
-nudge codex setup   - Writes hook configuration to .codex/hooks.json
+nudge codex setup   - Writes hook configuration and installs bundled skills for Codex
 nudge codex docs    - Prints documentation for writing rules
 nudge codex skills install - Installs bundled skills into .agents/skills
 nudge learn add     - Record a repo-local learned incident note in .nudge/learned

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,8 @@ cargo run -p nudge -- claude docs      # Print rule writing documentation
 cargo run -p nudge -- codex hook       # Respond to Codex hook (reads JSON from stdin)
 cargo run -p nudge -- codex setup      # Install hooks into .codex/hooks.json
 cargo run -p nudge -- codex docs       # Print rule writing documentation
+cargo run -p nudge -- learn add        # Record a repo-local learned incident note
+cargo run -p nudge -- learn search     # Search learned incident notes with BM25
 cargo run -p nudge -- test             # Test a rule against sample input
 cargo run -p nudge -- validate         # Validate rule config files
 cargo run -p nudge -- check            # Check project files against rules (for CI)
@@ -65,6 +67,9 @@ nudge claude docs   - Prints documentation for writing rules
 nudge codex hook    - Receives hook JSON on stdin, evaluates rules, outputs response
 nudge codex setup   - Writes hook configuration to .codex/hooks.json
 nudge codex docs    - Prints documentation for writing rules
+nudge learn add     - Record a repo-local learned incident note in .nudge/learned
+nudge learn list    - List repo-local learned incident notes
+nudge learn search  - Search learned incident notes with BM25
 nudge test          - Test a specific rule against sample input
 nudge validate      - Validate and display parsed rule configs
 nudge check         - Check project files against rules (CI/linter mode)
@@ -78,12 +83,14 @@ nudge check         - Check project files against rules (CI/linter mode)
 - `src/hook/evaluate.rs` - Provider-neutral rule evaluation
 - `src/hook/response.rs` - Provider-specific response rendering
 - `src/hook/apply_patch.rs` - Codex apply_patch normalization
+- `src/learn.rs` - Repo-local learned incident notes and BM25 retrieval
 - `src/cmd/claude/hook.rs` - Hook command: deserializes input, evaluates rules, emits response
 - `src/cmd/claude/setup.rs` - Setup command: configures hooks in settings.local.json
 - `src/cmd/claude/docs.rs` - Docs command: prints rule writing guide
 - `src/cmd/codex/hook.rs` - Hook command: deserializes input, evaluates rules, emits response
 - `src/cmd/codex/setup.rs` - Setup command: configures hooks in hooks.json
 - `src/cmd/codex/docs.rs` - Docs command: prints rule writing guide
+- `src/cmd/learn.rs` - CLI for adding, listing, and searching learned notes
 - `src/cmd/test.rs` - Test command: test a rule against sample input
 - `src/cmd/validate.rs` - Validate command: parse and display rule configs
 - `src/cmd/check.rs` - Check command: validate project files against rules for CI
@@ -99,6 +106,7 @@ When Nudge has something to share, it responds in one of three ways:
 
 - **Passthrough**: Nothing to note. Carry on!
 - **Continue**: For UserPromptSubmit hooks, Nudge injects context as plain text
+- **Learned context**: For UserPromptSubmit hooks, Nudge searches `.nudge/learned/*.md` with BM25 and injects the most relevant incident notes when the prompt resembles a known scenario. For supported PreToolUse command surfaces, learned context can be surfaced as an allow-with-context warning.
 - **Interrupt**: For PreToolUse hooks, Nudge blocks the operation and explains what to fix
 - **Warning**: For provider inputs that look like supported PreToolUse surfaces but cannot be inspected (currently Codex apply_patch parse failures), Nudge allows the operation and tells the model to report the warning to the user
 - **Substitute**: For deterministic PreToolUse Bash rules, Nudge rewrites the command and lets it proceed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,8 @@ cargo run -p nudge -- codex hook       # Respond to Codex hook (reads JSON from 
 cargo run -p nudge -- codex setup      # Install hooks into .codex/hooks.json
 cargo run -p nudge -- codex docs       # Print rule writing documentation
 cargo run -p nudge -- learn add        # Record a repo-local learned incident note
-cargo run -p nudge -- learn search     # Search learned incident notes with BM25
+cargo run -p nudge -- learn search     # Search learned incident notes
+cargo run -p nudge -- learn embeddings # Manage local learned-note embeddings
 cargo run -p nudge -- test             # Test a rule against sample input
 cargo run -p nudge -- validate         # Validate rule config files
 cargo run -p nudge -- check            # Check project files against rules (for CI)
@@ -69,7 +70,8 @@ nudge codex setup   - Writes hook configuration to .codex/hooks.json
 nudge codex docs    - Prints documentation for writing rules
 nudge learn add     - Record a repo-local learned incident note in .nudge/learned
 nudge learn list    - List repo-local learned incident notes
-nudge learn search  - Search learned incident notes with BM25
+nudge learn search  - Search learned incident notes with BM25 or configured local embeddings
+nudge learn embeddings - Enable, rebuild, or inspect local learned-note embeddings
 nudge test          - Test a specific rule against sample input
 nudge validate      - Validate and display parsed rule configs
 nudge check         - Check project files against rules (CI/linter mode)
@@ -84,6 +86,7 @@ nudge check         - Check project files against rules (CI/linter mode)
 - `src/hook/response.rs` - Provider-specific response rendering
 - `src/hook/apply_patch.rs` - Codex apply_patch normalization
 - `src/learn.rs` - Repo-local learned incident notes and BM25 retrieval
+- `src/learn/embeddings.rs` - Local FastEmbed embedding cache and hybrid retrieval
 - `src/cmd/claude/hook.rs` - Hook command: deserializes input, evaluates rules, emits response
 - `src/cmd/claude/setup.rs` - Setup command: configures hooks in settings.local.json
 - `src/cmd/claude/docs.rs` - Docs command: prints rule writing guide
@@ -106,7 +109,7 @@ When Nudge has something to share, it responds in one of three ways:
 
 - **Passthrough**: Nothing to note. Carry on!
 - **Continue**: For UserPromptSubmit hooks, Nudge injects context as plain text
-- **Learned context**: For UserPromptSubmit hooks, Nudge searches `.nudge/learned/*.md` with BM25 and injects the most relevant incident notes when the prompt resembles a known scenario. For supported PreToolUse command surfaces, learned context can be surfaced as an allow-with-context warning.
+- **Learned context**: For UserPromptSubmit hooks, Nudge searches `.nudge/learned/*.md` with BM25, or hybrid BM25 plus local embeddings when `learn.embeddings.enabled` is set in `.nudge.yaml` or `.nudge.yml`, and injects the most relevant incident notes when the prompt resembles a known scenario. For supported PreToolUse command surfaces, learned context can be surfaced as an allow-with-context warning.
 - **Interrupt**: For PreToolUse hooks, Nudge blocks the operation and explains what to fix
 - **Warning**: For provider inputs that look like supported PreToolUse surfaces but cannot be inspected (currently Codex apply_patch parse failures), Nudge allows the operation and tells the model to report the warning to the user
 - **Substitute**: For deterministic PreToolUse Bash rules, Nudge rewrites the command and lets it proceed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,11 +35,14 @@ cargo test -p nudge test_name
 cargo run -p nudge -- claude hook      # Respond to Claude hook (reads JSON from stdin)
 cargo run -p nudge -- claude setup     # Install hooks into .claude/settings.local.json
 cargo run -p nudge -- claude docs      # Print rule writing documentation
+cargo run -p nudge -- claude skills install # Install bundled Claude skills
 cargo run -p nudge -- codex hook       # Respond to Codex hook (reads JSON from stdin)
 cargo run -p nudge -- codex setup      # Install hooks into .codex/hooks.json
 cargo run -p nudge -- codex docs       # Print rule writing documentation
+cargo run -p nudge -- codex skills install # Install bundled Codex skills
 cargo run -p nudge -- learn add        # Record a repo-local learned incident note
 cargo run -p nudge -- learn search     # Search learned incident notes
+cargo run -p nudge -- learn docs       # Print the bundled learnings skill
 cargo run -p nudge -- learn embeddings # Manage local learned-note embeddings
 cargo run -p nudge -- test             # Test a rule against sample input
 cargo run -p nudge -- validate         # Validate rule config files
@@ -65,12 +68,15 @@ decides to publish crates.io artifacts.
 nudge claude hook   - Receives hook JSON on stdin, evaluates rules, outputs response
 nudge claude setup  - Writes hook configuration to .claude/settings.local.json
 nudge claude docs   - Prints documentation for writing rules
+nudge claude skills install - Installs bundled skills into .claude/skills
 nudge codex hook    - Receives hook JSON on stdin, evaluates rules, outputs response
 nudge codex setup   - Writes hook configuration to .codex/hooks.json
 nudge codex docs    - Prints documentation for writing rules
+nudge codex skills install - Installs bundled skills into .agents/skills
 nudge learn add     - Record a repo-local learned incident note in .nudge/learned
 nudge learn list    - List repo-local learned incident notes
 nudge learn search  - Search learned incident notes with BM25 or configured local embeddings
+nudge learn docs    - Print the bundled learnings skill contents
 nudge learn embeddings - Enable, rebuild, or inspect local learned-note embeddings
 nudge test          - Test a specific rule against sample input
 nudge validate      - Validate and display parsed rule configs
@@ -87,16 +93,20 @@ nudge check         - Check project files against rules (CI/linter mode)
 - `src/hook/apply_patch.rs` - Codex apply_patch normalization
 - `src/learn.rs` - Repo-local learned incident notes and BM25 retrieval
 - `src/learn/embeddings.rs` - Local FastEmbed embedding cache and hybrid retrieval
+- `src/skills.rs` - Bundled skill assets and installation helpers
 - `src/cmd/claude/hook.rs` - Hook command: deserializes input, evaluates rules, emits response
 - `src/cmd/claude/setup.rs` - Setup command: configures hooks in settings.local.json
 - `src/cmd/claude/docs.rs` - Docs command: prints rule writing guide
+- `src/cmd/claude/skills.rs` - Skills command: installs bundled skills into .claude/skills
 - `src/cmd/codex/hook.rs` - Hook command: deserializes input, evaluates rules, emits response
 - `src/cmd/codex/setup.rs` - Setup command: configures hooks in hooks.json
 - `src/cmd/codex/docs.rs` - Docs command: prints rule writing guide
+- `src/cmd/codex/skills.rs` - Skills command: installs bundled skills into .agents/skills
 - `src/cmd/learn.rs` - CLI for adding, listing, and searching learned notes
 - `src/cmd/test.rs` - Test command: test a rule against sample input
 - `src/cmd/validate.rs` - Validate command: parse and display rule configs
 - `src/cmd/check.rs` - Check command: validate project files against rules for CI
+- `packages/nudge/skills/nudge-learnings/` - Source files for the bundled learnings skill compiled into the binary
 - `src/rules.rs` - Rule loading from config files
 - `src/rules/schema.rs` - Rule schema facade and hook matcher types
 - `src/rules/schema/` - Focused matcher implementations for content, glob paths, project state, tree-sitter syntax, and URLs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +39,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "annotate-snippets"
@@ -72,7 +92,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -83,8 +103,26 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
@@ -102,10 +140,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "2.10.0"
+name = "base64"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bon"
@@ -123,7 +188,7 @@ version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e9d642a7e3a318e37c2c9427b5a6a48aa1ad55dcd986f3034ab2239045a645"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -140,6 +205,33 @@ checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -253,12 +345,112 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -287,13 +479,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -312,12 +538,82 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn",
 ]
 
@@ -351,10 +647,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "directories"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
@@ -368,7 +683,27 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -376,6 +711,21 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -390,8 +740,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
 name = "eyre"
@@ -401,6 +757,22 @@ checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
+]
+
+[[package]]
+name = "fastembed"
+version = "5.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6a4d483ea0f1a37e39387a8d2e6f8da60c66d635384b05215dc2faadd0a72b1"
+dependencies = [
+ "anyhow",
+ "hf-hub",
+ "ndarray",
+ "ort",
+ "safetensors",
+ "serde",
+ "serde_json",
+ "tokenizers",
 ]
 
 [[package]]
@@ -416,10 +788,120 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getopts"
@@ -479,10 +961,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "heck"
@@ -491,10 +999,255 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hf-hub"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
+dependencies = [
+ "dirs",
+ "http",
+ "indicatif",
+ "libc",
+ "log",
+ "native-tls",
+ "rand",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "ureq",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "ignore"
@@ -529,6 +1282,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +1302,12 @@ checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -557,6 +1329,17 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -587,10 +1370,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "lzma-rust2"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
+
+[[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
 name = "matchers"
@@ -602,10 +1419,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -620,6 +1453,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl 0.1.18",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -628,9 +1484,20 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb4cc965c89dd0615a9e822ff8002f7633d2466143d51bd58693e4b2c75aabad"
 dependencies = [
- "monostate-impl",
+ "monostate-impl 1.0.2",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -642,6 +1509,38 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
 ]
 
 [[package]]
@@ -660,7 +1559,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -674,17 +1573,19 @@ dependencies = [
  "color-print",
  "derive_more",
  "directories",
+ "fastembed",
  "glob",
  "ignore",
  "indoc",
  "itertools",
- "monostate",
+ "monostate 1.0.2",
  "pretty_assertions",
  "pulldown-cmark",
  "regex",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "shell-words",
  "simple_test_case",
  "tap",
@@ -704,6 +1605,39 @@ dependencies = [
  "tree-sitter-typescript",
  "walkdir",
  "xshell",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -728,10 +1662,99 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+dependencies = [
+ "ndarray",
+ "ort-sys",
+ "smallvec",
+ "tracing",
+ "ureq",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+dependencies = [
+ "hmac-sha256",
+ "lzma-rust2",
+ "ureq",
+]
 
 [[package]]
 name = "owo-colors"
@@ -740,10 +1763,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -809,6 +1898,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools",
+ "rayon",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +2004,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,7 +2085,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -889,12 +2136,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "safetensors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+dependencies = [
+ "hashbrown",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -948,6 +2238,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,6 +2260,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -982,6 +2295,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "simple_test_case"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,10 +2312,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "streaming-iterator"
@@ -1011,6 +2381,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,6 +2395,47 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1037,7 +2454,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1068,6 +2485,172 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools",
+ "log",
+ "macro_rules_attribute",
+ "monostate 0.1.18",
+ "onig",
+ "paste",
+ "rand",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1251,6 +2834,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1261,6 +2856,15 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -1281,10 +2885,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "cookie_store",
+ "der",
+ "flate2",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1299,6 +2981,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,6 +3000,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -1324,19 +3027,185 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1348,10 +3217,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xshell"
@@ -1373,3 +3312,106 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ cd nudge
 cargo install --path packages/nudge
 ```
 
-### 2. Install Hooks in Your Project
+### 2. Install Hooks and Skills in Your Project
 
 Navigate to any project where you use Claude Code or Codex CLI and run the setup for the agent you use:
 
@@ -246,10 +246,10 @@ nudge claude setup
 nudge codex setup
 ```
 
-Claude setup adds Nudge to `.claude/settings.local.json`. Codex setup adds Nudge to `.codex/hooks.json`. If the target file already exists, setup first writes a non-overwriting backup next to it, such as `settings.local.json.bak` or `hooks.json.bak.1`, and prints the backup path. You can verify with `/hooks` in the relevant agent.
+Claude setup adds Nudge to `.claude/settings.local.json` and installs the bundled learnings skill to `.claude/skills/nudge-learnings`. Codex setup adds Nudge to `.codex/hooks.json` and installs the skill to `.agents/skills/nudge-learnings`. If the target hook file already exists, setup first writes a non-overwriting backup next to it, such as `settings.local.json.bak` or `hooks.json.bak.1`, and prints the backup path. You can verify hooks with `/hooks` in the relevant agent.
 
 > [!NOTE]
-> Hook configuration is loaded when agent sessions start, so restart open Claude Code or Codex sessions after setup. Future changes to rules are internal to Nudge and therefore do not need an agent restart.
+> Hook and skill configuration is loaded when agent sessions start, so restart open Claude Code or Codex sessions after setup. Future changes to rules are internal to Nudge and therefore do not need an agent restart.
 
 ### 3. Use Your Agent Normally
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ When something matches a rule you've defined:
 - **Interrupt** (PreToolUse rules): Nudge catches the issue *before* it's written and explains what to fix
 - **Substitute** (PreToolUse Bash rules): Nudge rewrites simple deterministic commands, lets the tool proceed, and tells the model what changed
 - **Continue** (UserPromptSubmit rules): Nudge injects context into the conversation to guide the agent
-- **Learned context**: Nudge searches `.nudge/learned/*.md` with BM25 and proactively surfaces relevant incident notes
+- **Learned context**: Nudge searches `.nudge/learned/*.md` with BM25, or hybrid BM25 plus local embeddings when enabled, and proactively surfaces relevant incident notes
 - **Passthrough**: No rules matched, everything proceeds normally
 
 ## Example Rules
@@ -78,6 +78,31 @@ nudge learn list
 ```
 
 During `UserPromptSubmit`, Nudge searches the current prompt against learned notes and injects the top relevant matches as plain context. For supported command surfaces such as Bash and WebFetch, Nudge can also surface learned context as an allow-with-context warning when a tool input resembles a known incident.
+
+### Local Embeddings
+
+BM25 is always available and requires no model. For semantic matching across different wording, enable local embeddings in project config:
+
+```bash
+nudge learn embeddings enable
+nudge learn embeddings status
+nudge learn embeddings reindex
+```
+
+This writes config like:
+
+```yaml
+version: 1
+rules: []
+learn:
+  embeddings:
+    enabled: true
+    model: BGESmallENV15
+```
+
+Nudge also reads `.nudge.yml` if that is your project convention. The compiled Nudge binary includes local embedding support; config decides whether a project uses it.
+
+Model files and vector indexes are stored in the user-level Nudge cache directory selected by the OS through the `directories` crate. They are not stored in the repo because vectors are derived from repo notes, can reveal note content, and change when the model or chunking changes. Learned Markdown notes stay in the repo; generated embedding artifacts stay in user cache.
 
 ## Writing Effective Rules
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nudge
 
-Nudge is a **collaborative memory layer** for agent hooks. It remembers the coding conventions, patterns, and preferences that matter to you so Claude Code or Codex CLI can focus on solving your actual problem instead of tracking a mental checklist of stylistic details.
+Nudge is a **collaborative memory layer** for agent hooks. It remembers the coding conventions, patterns, preferences, and hard-won debugging lessons that matter to you so Claude Code or Codex CLI can focus on solving your actual problem instead of tracking a mental checklist.
 
 Think of Nudge as a helpful tap on the shoulder: *"Hey, remember this codebase uses turbofish syntax"* rather than a guard checking badges at the door.
 
@@ -28,6 +28,7 @@ When something matches a rule you've defined:
 - **Interrupt** (PreToolUse rules): Nudge catches the issue *before* it's written and explains what to fix
 - **Substitute** (PreToolUse Bash rules): Nudge rewrites simple deterministic commands, lets the tool proceed, and tells the model what changed
 - **Continue** (UserPromptSubmit rules): Nudge injects context into the conversation to guide the agent
+- **Learned context**: Nudge searches `.nudge/learned/*.md` with BM25 and proactively surfaces relevant incident notes
 - **Passthrough**: No rules matched, everything proceeds normally
 
 ## Example Rules
@@ -44,6 +45,39 @@ These are the rules Nudge uses on its own codebase (yes, we dogfood):
 | No `.unwrap()`       | Use `.expect("...")` with a descriptive message             |
 
 Other Attune codebases of course have other rules.
+
+## Learned Incident Notes
+
+Rules are best for deterministic conventions. Learned notes are for the repo-local "we have seen this before" moments: bugs, failed approaches, root causes, and fixes that future agents should not rediscover from scratch.
+
+Add a note after a debugging session:
+
+```bash
+nudge learn add --title "Expo Metro resolver cache" --body "
+What went wrong: Expo could not resolve modules after a dependency update.
+
+Fix: clear the Metro cache and restart the dev server.
+
+Verification: expo start completed and the app loaded.
+"
+```
+
+Or pipe a Markdown note:
+
+```bash
+cat incident.md | nudge learn add
+```
+
+Notes live in `.nudge/learned/*.md` as plain Markdown. They do not require tags, trigger phrases, or glob metadata. Nudge indexes the title and body dynamically with BM25, which works well for exact error strings, command names, file paths, package names, and stack trace fragments.
+
+Search manually:
+
+```bash
+nudge learn search expo metro cannot resolve module
+nudge learn list
+```
+
+During `UserPromptSubmit`, Nudge searches the current prompt against learned notes and injects the top relevant matches as plain context. For supported command surfaces such as Bash and WebFetch, Nudge can also surface learned context as an allow-with-context warning when a tool input resembles a known incident.
 
 ## Writing Effective Rules
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,19 @@ Search manually:
 ```bash
 nudge learn search expo metro cannot resolve module
 nudge learn list
+nudge learn docs
 ```
 
 During `UserPromptSubmit`, Nudge searches the current prompt against learned notes and injects the top relevant matches as plain context. For supported command surfaces such as Bash and WebFetch, Nudge can also surface learned context as an allow-with-context warning when a tool input resembles a known incident.
+
+Install the bundled `nudge-learnings` skill so agents know how to use the learn command and how to record useful notes:
+
+```bash
+nudge claude skills install
+nudge codex skills install
+```
+
+Claude installs to `.claude/skills/nudge-learnings`. Codex installs to `.agents/skills/nudge-learnings`. The skill uses progressive disclosure: its `SKILL.md` tells the agent to read the BM25 or local-embeddings reference depending on project config.
 
 ### Local Embeddings
 

--- a/packages/nudge/Cargo.toml
+++ b/packages/nudge/Cargo.toml
@@ -18,6 +18,7 @@ clap = { version = "4.5.53", features = ["env", "derive", "cargo"] }
 color-eyre = "0.6.5"
 color-print = "0.3.7"
 directories = "6.0.0"
+fastembed = { version = "5.16.1", default-features = false, features = ["hf-hub-native-tls", "ort-download-binaries-native-tls"] }
 glob = "0.3.3"
 monostate = "1.0.2"
 regex = "1.12.2"
@@ -25,6 +26,7 @@ pulldown-cmark = "0.13.4"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.145", features = ["preserve_order"] }
 serde_yaml = "0.9.34"
+sha2 = "0.10.9"
 shell-words = "1.1"
 tap = "1.0.1"
 tracing = "0.1.41"

--- a/packages/nudge/skills/nudge-learnings/SKILL.md
+++ b/packages/nudge/skills/nudge-learnings/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: nudge-learnings
+description: Use when working in a repository that uses Nudge learned incident notes, when Nudge surfaces learned repo knowledge, when the user asks to search/list/record learnings, or after fixing a repo-specific bug that future agents should not rediscover. Guides use of `nudge learn add`, `nudge learn search`, `nudge learn list`, and local embedding status.
+---
+
+# Nudge Learnings
+
+Before using learned notes, choose the retrieval guide:
+
+1. Run `nudge learn embeddings status`, or inspect `.nudge.yaml` / `.nudge.yml` for `learn.embeddings.enabled`.
+2. If embeddings are enabled, read [references/embeddings.md](references/embeddings.md).
+3. Otherwise, read [references/bm25.md](references/bm25.md).
+
+When Nudge surfaces learned context, treat it as repo memory from a previous debugging session. Read the cited note, decide whether it applies to the current situation, and reuse the fix or explain why the case differs.

--- a/packages/nudge/skills/nudge-learnings/references/bm25.md
+++ b/packages/nudge/skills/nudge-learnings/references/bm25.md
@@ -1,0 +1,66 @@
+# Nudge Learnings Without Embeddings
+
+Use this guide when `nudge learn embeddings status` reports disabled, or no `learn.embeddings.enabled: true` appears in `.nudge.yaml` / `.nudge.yml`.
+
+## Retrieval behavior
+
+Nudge uses BM25 lexical search over `.nudge/learned/*.md`. Exact repo terms matter: package names, commands, error fragments, paths, tool names, environment names, and framework names.
+
+Search before repeating debugging work:
+
+```bash
+nudge learn search expo metro cannot resolve module
+nudge learn search cargo lock fastembed windows
+nudge learn list
+```
+
+If the first search misses, retry with concrete words copied from the error or command output. Prefer several focused searches over one vague sentence.
+
+## Acting on surfaced context
+
+When hook context says "Nudge found learned repo knowledge":
+
+1. Read the cited note path under `.nudge/learned`.
+2. Compare the note's symptoms, environment, and fix to the current task.
+3. Apply the fix when it matches.
+4. If it does not match, say briefly why and continue investigating.
+
+Do not route around a relevant note. It exists because an earlier agent already burned time there.
+
+## Recording a learning
+
+Record a note after you fix a repo-specific issue that another agent could plausibly hit again:
+
+```bash
+nudge learn add --title "Expo Metro resolver cache" --body "What went wrong: Expo could not resolve modules after a dependency update.
+
+Fix: clear the Metro cache and restart the dev server.
+
+Verification: expo start completed and the app loaded."
+```
+
+For longer notes, pipe Markdown:
+
+```bash
+cat incident.md | nudge learn add
+```
+
+Use this structure:
+
+```markdown
+# Short specific title
+
+## What went wrong
+
+Name the command, tool, package, path, error, and symptoms.
+
+## Fix
+
+Give the exact fix and any caveats.
+
+## Verification
+
+State the command or observation that proved the fix worked.
+```
+
+Because BM25 is lexical, include the real words a future agent will search for.

--- a/packages/nudge/skills/nudge-learnings/references/embeddings.md
+++ b/packages/nudge/skills/nudge-learnings/references/embeddings.md
@@ -1,0 +1,78 @@
+# Nudge Learnings With Local Embeddings
+
+Use this guide when `nudge learn embeddings status` reports enabled, or `.nudge.yaml` / `.nudge.yml` sets `learn.embeddings.enabled: true`.
+
+## Retrieval behavior
+
+Nudge uses hybrid retrieval: BM25 plus local semantic embeddings. Semantic search can match paraphrases, but concrete repo terms still improve ranking.
+
+Search with natural symptoms first:
+
+```bash
+nudge learn search "Expo fails after dependency update and Metro cannot resolve modules"
+nudge learn search "the local embedding model keeps rebuilding the vector index"
+nudge learn list
+```
+
+If results look stale after editing many notes, rebuild the user-level vector cache:
+
+```bash
+nudge learn embeddings reindex
+```
+
+Check cache and model state:
+
+```bash
+nudge learn embeddings status
+```
+
+Model files and vectors live in the user-level Nudge cache. The repo stores the Markdown notes, not the generated vectors.
+
+## Acting on surfaced context
+
+When hook context says "Nudge found learned repo knowledge":
+
+1. Read the cited note path under `.nudge/learned`.
+2. Compare the note's symptoms, environment, and fix to the current task.
+3. Apply the fix when it matches.
+4. If it does not match, say briefly why and continue investigating.
+
+Embeddings can surface notes with different wording, so verify applicability before applying a fix.
+
+## Recording a learning
+
+Write notes in plain language. You do not need tags or trigger phrases, but include exact repo terms alongside the story:
+
+```bash
+nudge learn add --title "Expo Metro resolver cache" --body "What went wrong: Expo could not resolve modules after a dependency update.
+
+Fix: clear the Metro cache and restart the dev server.
+
+Verification: expo start completed and the app loaded."
+```
+
+For longer notes, pipe Markdown:
+
+```bash
+cat incident.md | nudge learn add
+```
+
+Use this structure:
+
+```markdown
+# Short specific title
+
+## What went wrong
+
+Describe the failure in normal debugging language. Include commands, packages, paths, and errors.
+
+## Fix
+
+Give the exact fix and caveats.
+
+## Verification
+
+State the command or observation that proved the fix worked.
+```
+
+After bulk importing or heavily editing notes, run `nudge learn embeddings reindex`.

--- a/packages/nudge/src/cmd.rs
+++ b/packages/nudge/src/cmd.rs
@@ -6,6 +6,7 @@ pub mod codex;
 pub(crate) mod json_hooks;
 pub mod learn;
 pub(crate) mod setup_command;
+pub(crate) mod skill_install;
 pub mod syntaxtree;
 pub mod test;
 pub mod validate;

--- a/packages/nudge/src/cmd.rs
+++ b/packages/nudge/src/cmd.rs
@@ -4,6 +4,7 @@ pub mod check;
 pub mod claude;
 pub mod codex;
 pub(crate) mod json_hooks;
+pub mod learn;
 pub(crate) mod setup_command;
 pub mod syntaxtree;
 pub mod test;

--- a/packages/nudge/src/cmd/claude.rs
+++ b/packages/nudge/src/cmd/claude.rs
@@ -7,6 +7,7 @@ use tracing::instrument;
 pub mod docs;
 pub mod hook;
 pub mod setup;
+pub mod skills;
 
 #[derive(Args, Clone, Debug)]
 pub struct Config {
@@ -25,6 +26,9 @@ enum Commands {
 
     /// Show documentation for writing Nudge rules.
     Docs(docs::Config),
+
+    /// Install bundled skills into .claude/skills.
+    Skills(skills::Config),
 }
 
 #[instrument]
@@ -33,5 +37,6 @@ pub fn main(config: Config) -> Result<()> {
         Commands::Hook(config) => hook::main(config),
         Commands::Setup(config) => setup::main(config),
         Commands::Docs(config) => docs::main(config),
+        Commands::Skills(config) => skills::main(config),
     }
 }

--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -56,6 +56,10 @@ const DOCS: &str = cstr!("\
     <cyan>nudge claude skills install</cyan>   <dim># Install .claude/skills/nudge-learnings</dim>
     <cyan>nudge codex skills install</cyan>    <dim># Install .agents/skills/nudge-learnings</dim>
 
+  <cyan>nudge claude setup</cyan> and <cyan>nudge codex setup</cyan> install the bundled
+  learnings skill by default. Use the skills commands directly when reinstalling
+  only the skill files.
+
   Nudge indexes note titles and bodies dynamically with BM25 by default. When
   <cyan>learn.embeddings.enabled: true</cyan> is set in <cyan>.nudge.yaml</cyan> or
   <cyan>.nudge.yml</cyan>, Nudge also uses local FastEmbed embeddings and stores both

--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -31,7 +31,8 @@ const DOCS: &str = cstr!("\
 
     <cyan>$CONFIG_DIR/rules.yaml</cyan>        <dim>User-level rules</dim>
     <cyan>.nudge.yaml</cyan>                   <dim>Project root</dim>
-    <cyan>.nudge/**/*.yaml</cyan>              <dim>Project directory</dim>
+    <cyan>.nudge.yml</cyan>                    <dim>Project root</dim>
+    <cyan>.nudge/**/*.{yaml,yml}</cyan>        <dim>Project directory</dim>
 
   <dim>$CONFIG_DIR by platform:</dim>
     <dim>Linux:</dim>   <cyan>~/.config/nudge</cyan>
@@ -49,12 +50,18 @@ const DOCS: &str = cstr!("\
     <cyan>cat incident.md | nudge learn add</cyan>
     <cyan>nudge learn search expo metro cannot resolve module</cyan>
     <cyan>nudge learn list</cyan>
+    <cyan>nudge learn embeddings enable</cyan> <dim># Project opt-in semantic search</dim>
+    <cyan>nudge learn embeddings status</cyan>
 
-  Nudge indexes note titles and bodies dynamically with BM25. During
-  <green>UserPromptSubmit</green>, it searches the prompt and injects the top relevant
-  incident notes as conversation context. For supported command surfaces such as
-  <green>Bash</green> and <green>WebFetch</green>, learned context can also surface as an
-  allow-with-context warning.
+  Nudge indexes note titles and bodies dynamically with BM25 by default. When
+  <cyan>learn.embeddings.enabled: true</cyan> is set in <cyan>.nudge.yaml</cyan> or
+  <cyan>.nudge.yml</cyan>, Nudge also uses local FastEmbed embeddings and stores both
+  model files and vector indexes in the user-level Nudge cache directory.
+
+  During <green>UserPromptSubmit</green>, Nudge searches the prompt and injects the top
+  relevant incident notes as conversation context. For supported command surfaces
+  such as <green>Bash</green> and <green>WebFetch</green>, learned context can also surface
+  as an allow-with-context warning.
 
 <bold>Rule Format</bold>
 

--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -38,6 +38,24 @@ const DOCS: &str = cstr!("\
     <dim>macOS:</dim>   <cyan>~/Library/Application Support/com.attunehq.nudge</cyan>
     <dim>Windows:</dim> <cyan>%APPDATA%\\attunehq\\nudge</cyan>
 
+<bold>Learned Incident Notes</bold>
+
+  Rules are for deterministic conventions. Learned notes are for repo-local
+  debugging incidents: what went wrong, root cause, fix, and verification.
+
+  Store notes as plain Markdown in <cyan>.nudge/learned/*.md</cyan>:
+
+    <cyan>nudge learn add --title \"Expo Metro resolver cache\" --body \"What went wrong...\"</cyan>
+    <cyan>cat incident.md | nudge learn add</cyan>
+    <cyan>nudge learn search expo metro cannot resolve module</cyan>
+    <cyan>nudge learn list</cyan>
+
+  Nudge indexes note titles and bodies dynamically with BM25. During
+  <green>UserPromptSubmit</green>, it searches the prompt and injects the top relevant
+  incident notes as conversation context. For supported command surfaces such as
+  <green>Bash</green> and <green>WebFetch</green>, learned context can also surface as an
+  allow-with-context warning.
+
 <bold>Rule Format</bold>
 
   <yellow>version: 1</yellow>

--- a/packages/nudge/src/cmd/claude/docs.rs
+++ b/packages/nudge/src/cmd/claude/docs.rs
@@ -50,8 +50,11 @@ const DOCS: &str = cstr!("\
     <cyan>cat incident.md | nudge learn add</cyan>
     <cyan>nudge learn search expo metro cannot resolve module</cyan>
     <cyan>nudge learn list</cyan>
+    <cyan>nudge learn docs</cyan>              <dim># Print the bundled learnings skill</dim>
     <cyan>nudge learn embeddings enable</cyan> <dim># Project opt-in semantic search</dim>
     <cyan>nudge learn embeddings status</cyan>
+    <cyan>nudge claude skills install</cyan>   <dim># Install .claude/skills/nudge-learnings</dim>
+    <cyan>nudge codex skills install</cyan>    <dim># Install .agents/skills/nudge-learnings</dim>
 
   Nudge indexes note titles and bodies dynamically with BM25 by default. When
   <cyan>learn.embeddings.enabled: true</cyan> is set in <cyan>.nudge.yaml</cyan> or

--- a/packages/nudge/src/cmd/claude/hook.rs
+++ b/packages/nudge/src/cmd/claude/hook.rs
@@ -6,8 +6,8 @@ use clap::Args;
 use color_eyre::{Result, eyre::Context};
 use nudge::{
     agent::{AgentKind, claude},
-    hook::{evaluate::evaluate_hooks, response},
-    rules,
+    hook::{NudgeHook, evaluate::evaluate_hooks_with_learnings, response},
+    learn, rules,
 };
 use tracing::instrument;
 
@@ -21,5 +21,22 @@ pub fn main(_config: Config) -> Result<()> {
     let hooks = claude::parse_hook(raw).context("parse Claude hook event")?;
 
     let rules = rules::load_all().context("load rules")?;
-    response::emit(AgentKind::Claude, evaluate_hooks(&hooks, &rules))
+    let root = hook_root(&hooks);
+    let learned_notes = learn::load_all(root).context("load learned notes")?;
+    response::emit(
+        AgentKind::Claude,
+        evaluate_hooks_with_learnings(root, &hooks, &rules, &learned_notes),
+    )
+}
+
+fn hook_root(hooks: &[NudgeHook]) -> &std::path::Path {
+    hooks
+        .iter()
+        .find_map(|hook| match hook {
+            NudgeHook::PreToolUse(payload) => Some(payload.context.cwd.as_path()),
+            NudgeHook::PermissionRequest(payload) => Some(payload.context.cwd.as_path()),
+            NudgeHook::UserPromptSubmit(payload) => Some(payload.context.cwd.as_path()),
+            _ => None,
+        })
+        .unwrap_or_else(|| std::path::Path::new("."))
 }

--- a/packages/nudge/src/cmd/claude/hook.rs
+++ b/packages/nudge/src/cmd/claude/hook.rs
@@ -23,9 +23,10 @@ pub fn main(_config: Config) -> Result<()> {
     let rules = rules::load_all().context("load rules")?;
     let root = hook_root(&hooks);
     let learned_notes = learn::load_all(root).context("load learned notes")?;
+    let learn_config = learn::load_config().context("load learn config")?;
     response::emit(
         AgentKind::Claude,
-        evaluate_hooks_with_learnings(root, &hooks, &rules, &learned_notes),
+        evaluate_hooks_with_learnings(root, &hooks, &rules, &learned_notes, &learn_config),
     )
 }
 

--- a/packages/nudge/src/cmd/claude/setup.rs
+++ b/packages/nudge/src/cmd/claude/setup.rs
@@ -14,7 +14,7 @@ use serde::Serialize;
 use serde_json::{Value, json};
 use tracing::instrument;
 
-use crate::cmd::{json_hooks, setup_command};
+use crate::cmd::{json_hooks, setup_command, skill_install};
 
 #[derive(Args, Clone, Debug)]
 pub struct Config {
@@ -25,6 +25,10 @@ pub struct Config {
     /// Skip the CLAUDE.md prompt (don't add Nudge context).
     #[arg(long)]
     skip_claude_md: bool,
+
+    /// Skip installing bundled Nudge skills.
+    #[arg(long)]
+    skip_skills: bool,
 }
 
 /// The section we add to CLAUDE.md to help Claude understand Nudge's role.
@@ -151,6 +155,11 @@ pub fn main(config: Config) -> Result<()> {
     }
     println!();
 
+    if !config.skip_skills {
+        skill_install::install_nudge_learnings("Claude", &dotclaude.join("skills"))?;
+        println!();
+    }
+
     if !config.skip_claude_md {
         let project_root = dotclaude
             .parent()
@@ -161,6 +170,7 @@ pub fn main(config: Config) -> Result<()> {
     println!("Next steps:");
     println!("1. Run /hooks in Claude Code to verify hooks are registered");
     println!("2. Use claude --debug to see hook execution logs");
+    println!("3. Restart Claude Code so hooks and skills are loaded");
 
     Ok(())
 }

--- a/packages/nudge/src/cmd/claude/setup.rs
+++ b/packages/nudge/src/cmd/claude/setup.rs
@@ -31,11 +31,11 @@ pub struct Config {
 const CLAUDE_MD_SECTION: &str = r#"
 ## Nudge
 
-This project uses [Nudge](https://github.com/attunehq/nudge), a collaborative partner that helps you remember coding conventions. Nudge watches your `Write` and `Edit` operations and reminds you about patterns and preferences that matter here—so you can focus on the actual problem instead of tracking stylistic details.
+This project uses [Nudge](https://github.com/attunehq/nudge), a collaborative partner that helps you remember coding conventions and learned debugging incidents. Nudge watches supported hook surfaces, reminds you about patterns and preferences that matter here, and surfaces relevant notes from `.nudge/learned`, so you can focus on the actual problem instead of rediscovering old fixes.
 
-**Nudge is on your side.** When it sends you a message, it's not a reprimand—it's a colleague tapping you on the shoulder. The messages are direct (sometimes blunt) because that's what cuts through when you're focused. Trust the feedback and adjust; if a rule feels wrong, mention it so we can fix the rule.
+**Nudge is on your side.** When it sends you a message, it's not a reprimand. It's a colleague tapping you on the shoulder. The messages are direct (sometimes blunt) because that's what cuts through when you're focused. Trust the feedback and adjust; if a rule feels wrong, mention it so we can fix the rule.
 
-**Writing new rules:** If the user asks you to add or modify Nudge rules, run `nudge claude docs` to see the rule format, template variables, and guidelines for writing effective messages.
+**Writing new rules or notes:** If the user asks you to add or modify Nudge rules, run `nudge claude docs` to see the rule format, template variables, and guidelines for writing effective messages. If you resolve a repo-specific bug that future agents may hit again, record it with `nudge learn add`.
 "#;
 
 /// Configures a hook in Claude Code's settings.

--- a/packages/nudge/src/cmd/claude/skills.rs
+++ b/packages/nudge/src/cmd/claude/skills.rs
@@ -1,0 +1,38 @@
+//! Install bundled Nudge skills for Claude Code.
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+use color_eyre::Result;
+
+use crate::cmd::skill_install;
+
+#[derive(Args, Clone, Debug)]
+pub struct Config {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand, Clone, Debug)]
+enum Commands {
+    /// Install the bundled Nudge learnings skill.
+    Install(InstallConfig),
+}
+
+#[derive(Args, Clone, Debug)]
+struct InstallConfig {
+    /// Path to the .claude directory.
+    #[arg(long, default_value = ".claude")]
+    claude_dir: PathBuf,
+}
+
+pub fn main(config: Config) -> Result<()> {
+    match config.command {
+        Commands::Install(config) => install(config),
+    }
+}
+
+fn install(config: InstallConfig) -> Result<()> {
+    skill_install::install_nudge_learnings("Claude", &config.claude_dir.join("skills"))?;
+    Ok(())
+}

--- a/packages/nudge/src/cmd/codex.rs
+++ b/packages/nudge/src/cmd/codex.rs
@@ -7,6 +7,7 @@ use tracing::instrument;
 pub mod docs;
 pub mod hook;
 pub mod setup;
+pub mod skills;
 
 #[derive(Args, Clone, Debug)]
 pub struct Config {
@@ -24,6 +25,9 @@ enum Commands {
 
     /// Show documentation for writing Nudge rules.
     Docs(docs::Config),
+
+    /// Install bundled skills into .agents/skills.
+    Skills(skills::Config),
 }
 
 #[instrument]
@@ -32,5 +36,6 @@ pub fn main(config: Config) -> Result<()> {
         Commands::Hook(config) => hook::main(config),
         Commands::Setup(config) => setup::main(config),
         Commands::Docs(config) => docs::main(config),
+        Commands::Skills(config) => skills::main(config),
     }
 }

--- a/packages/nudge/src/cmd/codex/hook.rs
+++ b/packages/nudge/src/cmd/codex/hook.rs
@@ -23,9 +23,10 @@ pub fn main(_config: Config) -> Result<()> {
     let rules = rules::load_all().context("load rules")?;
     let root = hook_root(&hooks);
     let learned_notes = learn::load_all(root).context("load learned notes")?;
+    let learn_config = learn::load_config().context("load learn config")?;
     response::emit(
         AgentKind::Codex,
-        evaluate_hooks_with_learnings(root, &hooks, &rules, &learned_notes),
+        evaluate_hooks_with_learnings(root, &hooks, &rules, &learned_notes, &learn_config),
     )
 }
 

--- a/packages/nudge/src/cmd/codex/hook.rs
+++ b/packages/nudge/src/cmd/codex/hook.rs
@@ -6,8 +6,8 @@ use clap::Args;
 use color_eyre::{Result, eyre::Context};
 use nudge::{
     agent::{AgentKind, codex},
-    hook::{evaluate::evaluate_hooks, response},
-    rules,
+    hook::{NudgeHook, evaluate::evaluate_hooks_with_learnings, response},
+    learn, rules,
 };
 use tracing::instrument;
 
@@ -21,5 +21,22 @@ pub fn main(_config: Config) -> Result<()> {
     let hooks = codex::parse_hook(raw).context("parse Codex hook event")?;
 
     let rules = rules::load_all().context("load rules")?;
-    response::emit(AgentKind::Codex, evaluate_hooks(&hooks, &rules))
+    let root = hook_root(&hooks);
+    let learned_notes = learn::load_all(root).context("load learned notes")?;
+    response::emit(
+        AgentKind::Codex,
+        evaluate_hooks_with_learnings(root, &hooks, &rules, &learned_notes),
+    )
+}
+
+fn hook_root(hooks: &[NudgeHook]) -> &std::path::Path {
+    hooks
+        .iter()
+        .find_map(|hook| match hook {
+            NudgeHook::PreToolUse(payload) => Some(payload.context.cwd.as_path()),
+            NudgeHook::PermissionRequest(payload) => Some(payload.context.cwd.as_path()),
+            NudgeHook::UserPromptSubmit(payload) => Some(payload.context.cwd.as_path()),
+            _ => None,
+        })
+        .unwrap_or_else(|| std::path::Path::new("."))
 }

--- a/packages/nudge/src/cmd/codex/setup.rs
+++ b/packages/nudge/src/cmd/codex/setup.rs
@@ -7,17 +7,21 @@ use std::{
 };
 
 use clap::Args;
-use color_eyre::eyre::{Context, Result};
+use color_eyre::eyre::{Context, OptionExt, Result};
 use serde_json::{Value, json};
 use tracing::instrument;
 
-use crate::cmd::{json_hooks, setup_command};
+use crate::cmd::{json_hooks, setup_command, skill_install};
 
 #[derive(Args, Clone, Debug)]
 pub struct Config {
     /// Path to the .codex directory.
     #[arg(long, default_value = ".codex")]
     codex_dir: PathBuf,
+
+    /// Skip installing bundled Nudge skills.
+    #[arg(long)]
+    skip_skills: bool,
 }
 
 #[instrument]
@@ -28,11 +32,22 @@ pub fn main(config: Config) -> Result<()> {
         .codex_dir
         .canonicalize()
         .with_context(|| format!("canonicalize codex dir: {:?}", config.codex_dir))?;
+    let project_root = dotcodex
+        .parent()
+        .ok_or_eyre("get parent directory of .codex")?;
+
+    if !config.skip_skills {
+        skill_install::install_nudge_learnings(
+            "Codex",
+            &project_root.join(".agents").join("skills"),
+        )?;
+        println!();
+    }
 
     let inline_config = dotcodex.join("config.toml");
     if inline_config_has_hooks(&inline_config)? {
         eprintln!(
-            "warning: {} already contains inline Codex hooks. Nudge setup skipped because safe TOML hook merging is out of scope. Move hooks to .codex/hooks.json or merge Nudge manually.",
+            "warning: {} already contains inline Codex hooks. Nudge hook setup skipped because safe TOML hook merging is out of scope. Move hooks to .codex/hooks.json or merge Nudge manually.",
             inline_config.display()
         );
         return Ok(());
@@ -97,6 +112,7 @@ pub fn main(config: Config) -> Result<()> {
     println!(
         "4. If hooks do not appear, check that the project .codex/ layer is trusted and [features].hooks has not been disabled."
     );
+    println!("5. The bundled Nudge learnings skill will load in new Codex sessions.");
 
     Ok(())
 }

--- a/packages/nudge/src/cmd/codex/skills.rs
+++ b/packages/nudge/src/cmd/codex/skills.rs
@@ -1,0 +1,38 @@
+//! Install bundled Nudge skills for Codex.
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+use color_eyre::Result;
+
+use crate::cmd::skill_install;
+
+#[derive(Args, Clone, Debug)]
+pub struct Config {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand, Clone, Debug)]
+enum Commands {
+    /// Install the bundled Nudge learnings skill.
+    Install(InstallConfig),
+}
+
+#[derive(Args, Clone, Debug)]
+struct InstallConfig {
+    /// Path to the .agents directory.
+    #[arg(long, default_value = ".agents")]
+    agents_dir: PathBuf,
+}
+
+pub fn main(config: Config) -> Result<()> {
+    match config.command {
+        Commands::Install(config) => install(config),
+    }
+}
+
+fn install(config: InstallConfig) -> Result<()> {
+    skill_install::install_nudge_learnings("Codex", &config.agents_dir.join("skills"))?;
+    Ok(())
+}

--- a/packages/nudge/src/cmd/learn.rs
+++ b/packages/nudge/src/cmd/learn.rs
@@ -7,7 +7,10 @@ use std::{
 
 use clap::{Args, Subcommand};
 use color_eyre::eyre::{Context, OptionExt, Result, bail};
-use nudge::learn::{self, AddNote, LearnConfig};
+use nudge::{
+    learn::{self, AddNote, LearnConfig},
+    skills,
+};
 use serde_yaml::{Mapping, Value};
 
 #[derive(Args, Clone, Debug)]
@@ -26,6 +29,9 @@ enum Commands {
 
     /// Search learned incident notes.
     Search(SearchConfig),
+
+    /// Print the bundled Nudge learnings skill.
+    Docs(DocsConfig),
 
     /// Manage local semantic embeddings for learned notes.
     Embeddings(EmbeddingsConfig),
@@ -63,6 +69,9 @@ struct SearchConfig {
     #[arg(long, default_value_t = 0.0)]
     min_score: f64,
 }
+
+#[derive(Args, Clone, Debug)]
+struct DocsConfig {}
 
 #[derive(Args, Clone, Debug)]
 struct EmbeddingsConfig {
@@ -104,6 +113,7 @@ pub fn main(config: Config) -> Result<()> {
         Commands::Add(config) => add(config),
         Commands::List(config) => list(config),
         Commands::Search(config) => search(config),
+        Commands::Docs(config) => docs(config),
         Commands::Embeddings(config) => embeddings(config),
     }
 }
@@ -166,6 +176,11 @@ fn search(config: SearchConfig) -> Result<()> {
     }
 
     println!("{}", learn::render_search_results(root, &results));
+    Ok(())
+}
+
+fn docs(_config: DocsConfig) -> Result<()> {
+    println!("{}", skills::render_nudge_learnings_docs());
     Ok(())
 }
 

--- a/packages/nudge/src/cmd/learn.rs
+++ b/packages/nudge/src/cmd/learn.rs
@@ -1,0 +1,119 @@
+//! Manage repo-local learned knowledge.
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+use color_eyre::eyre::{Context, Result};
+use nudge::learn::{self, AddNote};
+
+#[derive(Args, Clone, Debug)]
+pub struct Config {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand, Clone, Debug)]
+enum Commands {
+    /// Add a learned incident note to .nudge/learned.
+    Add(AddConfig),
+
+    /// List learned incident notes.
+    List(ListConfig),
+
+    /// Search learned incident notes with BM25.
+    Search(SearchConfig),
+}
+
+#[derive(Args, Clone, Debug)]
+struct AddConfig {
+    /// Short note title. If omitted, Nudge uses the first Markdown H1.
+    #[arg(long)]
+    title: Option<String>,
+
+    /// Learned note body.
+    #[arg(long, conflicts_with = "body_file")]
+    body: Option<String>,
+
+    /// Read the learned note body from a file.
+    #[arg(long, conflicts_with = "body")]
+    body_file: Option<PathBuf>,
+}
+
+#[derive(Args, Clone, Debug)]
+struct ListConfig {}
+
+#[derive(Args, Clone, Debug)]
+struct SearchConfig {
+    /// Query text.
+    #[arg(required = true)]
+    query: Vec<String>,
+
+    /// Maximum number of results to show.
+    #[arg(long, default_value_t = learn::default_search_limit())]
+    limit: usize,
+
+    /// Minimum BM25 score to display.
+    #[arg(long, default_value_t = 0.0)]
+    min_score: f64,
+}
+
+pub fn main(config: Config) -> Result<()> {
+    match config.command {
+        Commands::Add(config) => add(config),
+        Commands::List(config) => list(config),
+        Commands::Search(config) => search(config),
+    }
+}
+
+fn add(config: AddConfig) -> Result<()> {
+    let body = learn::read_body(config.body, config.body_file)?;
+    let path = learn::add(
+        std::path::Path::new("."),
+        AddNote {
+            title: config.title,
+            body,
+        },
+    )?;
+
+    println!("Added learned note: {}", path.display());
+    Ok(())
+}
+
+fn list(_config: ListConfig) -> Result<()> {
+    let root = std::path::Path::new(".");
+    let notes = learn::load_all(root).context("load learned notes")?;
+    if notes.is_empty() {
+        println!("No learned notes found in {}.", learn::LEARNED_DIR);
+        return Ok(());
+    }
+
+    for (index, note) in notes.iter().enumerate() {
+        println!(
+            "{}. {}\n   Path: {}",
+            index + 1,
+            note.title,
+            note.path.display()
+        );
+    }
+
+    Ok(())
+}
+
+fn search(config: SearchConfig) -> Result<()> {
+    let root = std::path::Path::new(".");
+    let notes = learn::load_all(root).context("load learned notes")?;
+    if notes.is_empty() {
+        println!("No learned notes found in {}.", learn::LEARNED_DIR);
+        return Ok(());
+    }
+
+    let query = config.query.join(" ");
+    let results = learn::search(&notes, &query, config.limit, config.min_score);
+    if results.is_empty() {
+        println!("No learned notes matched the query.");
+        return Ok(());
+    }
+
+    println!("{}", learn::render_search_results(root, &results));
+    Ok(())
+}

--- a/packages/nudge/src/cmd/learn.rs
+++ b/packages/nudge/src/cmd/learn.rs
@@ -1,10 +1,14 @@
 //! Manage repo-local learned knowledge.
 
-use std::path::PathBuf;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use clap::{Args, Subcommand};
-use color_eyre::eyre::{Context, Result};
-use nudge::learn::{self, AddNote};
+use color_eyre::eyre::{Context, OptionExt, Result, bail};
+use nudge::learn::{self, AddNote, LearnConfig};
+use serde_yaml::{Mapping, Value};
 
 #[derive(Args, Clone, Debug)]
 pub struct Config {
@@ -20,8 +24,11 @@ enum Commands {
     /// List learned incident notes.
     List(ListConfig),
 
-    /// Search learned incident notes with BM25.
+    /// Search learned incident notes.
     Search(SearchConfig),
+
+    /// Manage local semantic embeddings for learned notes.
+    Embeddings(EmbeddingsConfig),
 }
 
 #[derive(Args, Clone, Debug)]
@@ -52,16 +59,52 @@ struct SearchConfig {
     #[arg(long, default_value_t = learn::default_search_limit())]
     limit: usize,
 
-    /// Minimum BM25 score to display.
+    /// Minimum score to display.
     #[arg(long, default_value_t = 0.0)]
     min_score: f64,
 }
+
+#[derive(Args, Clone, Debug)]
+struct EmbeddingsConfig {
+    #[command(subcommand)]
+    command: EmbeddingsCommands,
+}
+
+#[derive(Subcommand, Clone, Debug)]
+enum EmbeddingsCommands {
+    /// Enable local embeddings in the project Nudge config and build the index.
+    Enable(EnableEmbeddingsConfig),
+
+    /// Rebuild the user-level vector cache for this project.
+    Reindex(ReindexEmbeddingsConfig),
+
+    /// Show embedding configuration and cache paths.
+    Status(StatusEmbeddingsConfig),
+}
+
+#[derive(Args, Clone, Debug)]
+struct EnableEmbeddingsConfig {
+    /// Local embedding model to use.
+    #[arg(long, default_value_t = learn::embeddings::default_model())]
+    model: String,
+
+    /// Update config without downloading the model or building vectors.
+    #[arg(long)]
+    no_reindex: bool,
+}
+
+#[derive(Args, Clone, Debug)]
+struct ReindexEmbeddingsConfig {}
+
+#[derive(Args, Clone, Debug)]
+struct StatusEmbeddingsConfig {}
 
 pub fn main(config: Config) -> Result<()> {
     match config.command {
         Commands::Add(config) => add(config),
         Commands::List(config) => list(config),
         Commands::Search(config) => search(config),
+        Commands::Embeddings(config) => embeddings(config),
     }
 }
 
@@ -108,7 +151,15 @@ fn search(config: SearchConfig) -> Result<()> {
     }
 
     let query = config.query.join(" ");
-    let results = learn::search(&notes, &query, config.limit, config.min_score);
+    let learn_config = learn::load_config().context("load learn config")?;
+    let results = learn::search_with_config(
+        root,
+        &notes,
+        &query,
+        config.limit,
+        config.min_score,
+        &learn_config,
+    )?;
     if results.is_empty() {
         println!("No learned notes matched the query.");
         return Ok(());
@@ -116,4 +167,131 @@ fn search(config: SearchConfig) -> Result<()> {
 
     println!("{}", learn::render_search_results(root, &results));
     Ok(())
+}
+
+fn embeddings(config: EmbeddingsConfig) -> Result<()> {
+    match config.command {
+        EmbeddingsCommands::Enable(config) => embeddings_enable(config),
+        EmbeddingsCommands::Reindex(config) => embeddings_reindex(config),
+        EmbeddingsCommands::Status(config) => embeddings_status(config),
+    }
+}
+
+fn embeddings_enable(config: EnableEmbeddingsConfig) -> Result<()> {
+    let model = learn::embeddings::canonical_model(&config.model)?;
+    let learn_config = LearnConfig {
+        embeddings: learn::EmbeddingConfig {
+            enabled: true,
+            model,
+        },
+    };
+    let config_path = write_project_learn_config(&learn_config)?;
+    println!(
+        "Enabled local learned-note embeddings in {}.",
+        config_path.display()
+    );
+
+    if !config.no_reindex {
+        rebuild_embeddings(&learn_config)?;
+    }
+
+    Ok(())
+}
+
+fn embeddings_reindex(_config: ReindexEmbeddingsConfig) -> Result<()> {
+    let config = learn::load_config().context("load learn config")?;
+    if !config.embeddings.enabled {
+        bail!("learn embeddings are not enabled. Run `nudge learn embeddings enable` first.");
+    }
+
+    rebuild_embeddings(&config)
+}
+
+fn embeddings_status(_config: StatusEmbeddingsConfig) -> Result<()> {
+    let root = Path::new(".");
+    let config = learn::load_config().context("load learn config")?;
+    let status = learn::embeddings::status(root, &config)?;
+
+    println!(
+        "Embeddings: {}",
+        if status.enabled {
+            "enabled"
+        } else {
+            "disabled"
+        }
+    );
+    println!("Model: {}", status.model);
+    println!("Cache: {}", status.paths.cache_dir.display());
+    println!("Model cache: {}", status.paths.model_dir.display());
+    println!("Vector index: {}", status.paths.vector_index.display());
+    println!("Vectors: {}", status.vector_count);
+
+    Ok(())
+}
+
+fn rebuild_embeddings(config: &LearnConfig) -> Result<()> {
+    let root = Path::new(".");
+    let notes = learn::load_all(root).context("load learned notes")?;
+    if notes.is_empty() {
+        let paths = learn::embeddings::ensure_model(root, config)?;
+        println!(
+            "Downloaded local embedding model. No learned notes found yet, so no vector index was built."
+        );
+        println!("Model cache: {}", paths.model_dir.display());
+        return Ok(());
+    }
+
+    let report = learn::embeddings::build_index(root, &notes, config)?;
+    println!(
+        "Built learned-note vector index with {} chunks using {}.",
+        report.chunk_count, report.model
+    );
+    println!("Model cache: {}", report.paths.model_dir.display());
+    println!("Vector index: {}", report.paths.vector_index.display());
+
+    Ok(())
+}
+
+fn write_project_learn_config(config: &LearnConfig) -> Result<PathBuf> {
+    let path = project_config_path();
+    let mut value = if path.exists() {
+        serde_yaml::from_str::<Value>(
+            &fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?,
+        )
+        .with_context(|| format!("parse {}", path.display()))?
+    } else {
+        Value::Mapping(Mapping::new())
+    };
+
+    let mapping = value
+        .as_mapping_mut()
+        .ok_or_eyre("project Nudge config must be a YAML mapping")?;
+    mapping
+        .entry(Value::String(String::from("version")))
+        .or_insert(serde_yaml::to_value(1)?);
+    mapping
+        .entry(Value::String(String::from("rules")))
+        .or_insert(Value::Sequence(Vec::new()));
+    mapping.insert(
+        Value::String(String::from("learn")),
+        serde_yaml::to_value(config).context("serialize learn config")?,
+    );
+
+    fs::write(&path, serde_yaml::to_string(&value)?)
+        .with_context(|| format!("write {}", path.display()))?;
+    Ok(path)
+}
+
+fn project_config_path() -> PathBuf {
+    let yaml = PathBuf::from(".nudge.yaml");
+    if yaml.exists() {
+        return yaml;
+    }
+
+    let yml = PathBuf::from(".nudge.yml");
+    if yml.exists() {
+        return yml;
+    }
+
+    yaml
 }

--- a/packages/nudge/src/cmd/skill_install.rs
+++ b/packages/nudge/src/cmd/skill_install.rs
@@ -1,0 +1,22 @@
+//! Shared skill installation helpers.
+
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::{Context, Result};
+use nudge::skills;
+
+pub fn install_nudge_learnings(provider: &str, skills_dir: &Path) -> Result<PathBuf> {
+    let skill_dir = skills::install_nudge_learnings_skill(skills_dir)
+        .with_context(|| format!("install {provider} Nudge learnings skill"))?;
+
+    println!(
+        "Installed {} skill to {}.",
+        skills::NUDGE_LEARNINGS_SKILL_NAME,
+        skill_dir.display()
+    );
+    println!(
+        "Use this skill when Nudge surfaces learned repo knowledge or after fixing a repo-specific issue worth recording."
+    );
+
+    Ok(skill_dir)
+}

--- a/packages/nudge/src/hook/evaluate.rs
+++ b/packages/nudge/src/hook/evaluate.rs
@@ -9,6 +9,7 @@ use crate::{
         BashInput, EditInput, NudgeHook, PreToolUse, ToolUse, UserPromptSubmit, WebFetchInput,
         WriteInput, response::HookOutcome,
     },
+    learn::{self, HookLearnedContext, LearnedNote},
     rules::{
         FileContentTarget, PreToolUseBashMatcher, PreToolUseWebFetchMatcher,
         PreToolUseWriteMatcher, Rule, RuleAction, UrlMatcher, UserPromptSubmitMatcher,
@@ -22,10 +23,21 @@ use crate::{
 /// A raw provider hook can normalize into multiple Nudge events. This happens
 /// for Codex `apply_patch`, where one tool call can touch several files.
 pub fn evaluate_hooks(hooks: &[NudgeHook], rules: &[Rule]) -> HookOutcome {
+    evaluate_hooks_with_learnings(std::path::Path::new("."), hooks, rules, &[])
+}
+
+/// Evaluate hooks against configured rules and learned repo knowledge.
+pub fn evaluate_hooks_with_learnings(
+    root: &std::path::Path,
+    hooks: &[NudgeHook],
+    rules: &[Rule],
+    learned_notes: &[LearnedNote],
+) -> HookOutcome {
     let mut pretooluse_warnings = Vec::new();
     let mut pretooluse_matches = Vec::new();
     let mut pretooluse_update = None;
     let mut user_prompt_matches = Vec::new();
+    let learned_context = learn::context_for_hooks(root, hooks, learned_notes);
 
     for hook in hooks {
         match hook {
@@ -57,27 +69,61 @@ pub fn evaluate_hooks(hooks: &[NudgeHook], rules: &[Rule]) -> HookOutcome {
     }
 
     if !pretooluse_warnings.is_empty() {
+        let additional_context = join_context(
+            pretooluse_warnings.join("\n\n"),
+            learned_context.pre_tool_use.clone(),
+        );
         return HookOutcome::AllowPreToolUseWithContext {
             system_message: String::from("Nudge allowed the operation with a warning."),
-            additional_context: pretooluse_warnings.join("\n\n"),
+            additional_context,
         };
     }
 
     if !user_prompt_matches.is_empty() {
-        return HookOutcome::AddContext {
-            context: user_prompt_matches.join("\n\n"),
-        };
+        let context = join_context(
+            user_prompt_matches.join("\n\n"),
+            learned_context.user_prompt.clone(),
+        );
+        return HookOutcome::AddContext { context };
     }
 
     if let Some(update) = pretooluse_update {
+        let additional_context =
+            join_context(update.model_context, learned_context.pre_tool_use.clone());
         return HookOutcome::UpdatePreToolUse {
             system_message: update.user_message,
-            additional_context: update.model_context,
+            additional_context,
             updated_input: update.updated_input,
         };
     }
 
+    if let HookLearnedContext {
+        user_prompt: Some(context),
+        ..
+    } = learned_context
+    {
+        return HookOutcome::AddContext { context };
+    }
+
+    if let HookLearnedContext {
+        pre_tool_use: Some(additional_context),
+        ..
+    } = learned_context
+    {
+        return HookOutcome::AllowPreToolUseWithContext {
+            system_message: String::from("Nudge found learned repo knowledge."),
+            additional_context,
+        };
+    }
+
     HookOutcome::Passthrough
+}
+
+fn join_context(primary: String, secondary: Option<String>) -> String {
+    match secondary {
+        Some(secondary) if !secondary.trim().is_empty() => format!("{primary}\n\n{secondary}"),
+        _ => primary,
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/packages/nudge/src/hook/evaluate.rs
+++ b/packages/nudge/src/hook/evaluate.rs
@@ -9,7 +9,7 @@ use crate::{
         BashInput, EditInput, NudgeHook, PreToolUse, ToolUse, UserPromptSubmit, WebFetchInput,
         WriteInput, response::HookOutcome,
     },
-    learn::{self, HookLearnedContext, LearnedNote},
+    learn::{self, HookLearnedContext, LearnConfig, LearnedNote},
     rules::{
         FileContentTarget, PreToolUseBashMatcher, PreToolUseWebFetchMatcher,
         PreToolUseWriteMatcher, Rule, RuleAction, UrlMatcher, UserPromptSubmitMatcher,
@@ -23,7 +23,13 @@ use crate::{
 /// A raw provider hook can normalize into multiple Nudge events. This happens
 /// for Codex `apply_patch`, where one tool call can touch several files.
 pub fn evaluate_hooks(hooks: &[NudgeHook], rules: &[Rule]) -> HookOutcome {
-    evaluate_hooks_with_learnings(std::path::Path::new("."), hooks, rules, &[])
+    evaluate_hooks_with_learnings(
+        std::path::Path::new("."),
+        hooks,
+        rules,
+        &[],
+        &LearnConfig::default(),
+    )
 }
 
 /// Evaluate hooks against configured rules and learned repo knowledge.
@@ -32,12 +38,13 @@ pub fn evaluate_hooks_with_learnings(
     hooks: &[NudgeHook],
     rules: &[Rule],
     learned_notes: &[LearnedNote],
+    learn_config: &LearnConfig,
 ) -> HookOutcome {
     let mut pretooluse_warnings = Vec::new();
     let mut pretooluse_matches = Vec::new();
     let mut pretooluse_update = None;
     let mut user_prompt_matches = Vec::new();
-    let learned_context = learn::context_for_hooks(root, hooks, learned_notes);
+    let learned_context = learn::context_for_hooks(root, hooks, learned_notes, learn_config);
 
     for hook in hooks {
         match hook {

--- a/packages/nudge/src/learn.rs
+++ b/packages/nudge/src/learn.rs
@@ -551,18 +551,32 @@ pub(crate) fn excerpt(note: &LearnedNote, query_terms: &HashSet<String>) -> Stri
     };
 
     let mut selected = vec![paragraphs[matching_index].clone()];
-    if let Some(fix) = paragraphs
-        .iter()
-        .enumerate()
-        .find(|(index, paragraph)| {
-            *index != matching_index && paragraph.to_lowercase().starts_with("fix")
-        })
-        .map(|(_, paragraph)| paragraph.clone())
-    {
+    if let Some(fix) = fix_excerpt(&paragraphs, matching_index) {
         selected.push(fix);
     }
 
     truncate_text(&selected.join(" "), EXCERPT_LIMIT)
+}
+
+fn fix_excerpt(paragraphs: &[String], matching_index: usize) -> Option<String> {
+    let (fix_index, fix) = paragraphs
+        .iter()
+        .enumerate()
+        .find(|(index, paragraph)| *index != matching_index && is_fix_paragraph(paragraph))?;
+
+    if fix.eq_ignore_ascii_case("fix") {
+        return paragraphs
+            .get(fix_index + 1)
+            .map(|body| format!("Fix: {body}"))
+            .or_else(|| Some(fix.clone()));
+    }
+
+    Some(fix.clone())
+}
+
+fn is_fix_paragraph(paragraph: &str) -> bool {
+    let lower = paragraph.to_lowercase();
+    lower == "fix" || lower.starts_with("fix:") || lower.starts_with("fix ")
 }
 
 fn clean_excerpt_text(text: &str) -> String {
@@ -733,5 +747,20 @@ mod tests {
             hook_context_for_query(Path::new("."), &notes, "expo", &LearnConfig::default());
 
         pretty_assert_eq!(context, None);
+    }
+
+    #[test]
+    fn excerpt_includes_fix_body_after_markdown_fix_heading() {
+        let note = note(
+            "Expo Metro Cache",
+            "## What went wrong\n\nExpo could not resolve modules after a dependency update.\n\n## Fix\n\nClear the Metro cache and restart the dev server.",
+        );
+
+        let excerpt = excerpt(&note, &query_terms("expo cannot resolve module"));
+
+        assert!(
+            excerpt.contains("Clear the Metro cache"),
+            "excerpt should include the body under the Fix heading, got: {excerpt}"
+        );
     }
 }

--- a/packages/nudge/src/learn.rs
+++ b/packages/nudge/src/learn.rs
@@ -1,0 +1,645 @@
+//! Repo-local learned knowledge storage and retrieval.
+
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    io::{self, IsTerminal, Read},
+    path::{Path, PathBuf},
+};
+
+use color_eyre::eyre::{Context, OptionExt, Result, bail};
+use itertools::Itertools;
+use walkdir::WalkDir;
+
+use crate::hook::{NudgeHook, ToolUse};
+
+pub const LEARNED_DIR: &str = ".nudge/learned";
+const DEFAULT_SEARCH_LIMIT: usize = 5;
+const HOOK_SEARCH_LIMIT: usize = 3;
+const HOOK_MIN_SCORE: f64 = 1.2;
+const HOOK_MIN_QUERY_TOKENS: usize = 3;
+const EXCERPT_LIMIT: usize = 420;
+
+/// A Markdown incident note stored under `.nudge/learned`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LearnedNote {
+    pub path: PathBuf,
+    pub title: String,
+    pub body: String,
+}
+
+/// A ranked learned-note match.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SearchResult {
+    pub path: PathBuf,
+    pub title: String,
+    pub score: f64,
+    pub excerpt: String,
+}
+
+/// Learned context gathered for hook responses.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct HookLearnedContext {
+    pub user_prompt: Option<String>,
+    pub pre_tool_use: Option<String>,
+}
+
+/// Options for adding a learned note.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AddNote {
+    pub title: Option<String>,
+    pub body: String,
+}
+
+pub fn learned_dir(root: &Path) -> PathBuf {
+    root.join(LEARNED_DIR)
+}
+
+pub fn default_search_limit() -> usize {
+    DEFAULT_SEARCH_LIMIT
+}
+
+/// Load all learned Markdown notes for a repo root.
+pub fn load_all(root: &Path) -> Result<Vec<LearnedNote>> {
+    let dir = learned_dir(root);
+    if !dir.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let mut notes = Vec::new();
+    for entry in WalkDir::new(&dir).sort_by_file_name() {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                tracing::warn!(?error, ?dir, "walking learned notes");
+                continue;
+            }
+        };
+
+        if !entry.file_type().is_file() || entry.path().extension().is_none_or(|ext| ext != "md") {
+            continue;
+        }
+
+        let body = fs::read_to_string(entry.path())
+            .with_context(|| format!("read learned note: {}", entry.path().display()))?;
+        let title = infer_title(&body).unwrap_or_else(|| {
+            entry
+                .path()
+                .file_stem()
+                .map(|stem| stem.to_string_lossy().replace('-', " "))
+                .unwrap_or_else(|| String::from("learned note"))
+        });
+
+        notes.push(LearnedNote {
+            path: entry.path().to_path_buf(),
+            title,
+            body,
+        });
+    }
+
+    Ok(notes)
+}
+
+/// Add a Markdown learned note and return the created path.
+pub fn add(root: &Path, note: AddNote) -> Result<PathBuf> {
+    let body = normalize_newlines(note.body.trim());
+    if body.trim().is_empty() {
+        bail!("learned note body cannot be empty");
+    }
+
+    let title = note
+        .title
+        .filter(|title| !title.trim().is_empty())
+        .map(|title| title.trim().to_string())
+        .or_else(|| infer_title(&body))
+        .ok_or_eyre("provide --title or start the note with a Markdown H1 heading")?;
+
+    let content = if starts_with_h1(&body) {
+        ensure_trailing_newline(&body)
+    } else {
+        format!("# {title}\n\n{}\n", body.trim())
+    };
+
+    let dir = learned_dir(root);
+    fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
+
+    let path = next_available_path(&dir, &slugify(&title));
+    fs::write(&path, content).with_context(|| format!("write learned note: {}", path.display()))?;
+
+    Ok(path)
+}
+
+/// Read a note body from a CLI argument, file, or stdin.
+pub fn read_body(body: Option<String>, body_file: Option<PathBuf>) -> Result<String> {
+    match (body, body_file) {
+        (Some(body), None) => Ok(body),
+        (None, Some(path)) => {
+            fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))
+        }
+        (None, None) => {
+            let stdin = io::stdin();
+            if stdin.is_terminal() {
+                bail!("provide --body, --body-file, or pipe note text on stdin");
+            }
+
+            let mut input = String::new();
+            stdin
+                .lock()
+                .read_to_string(&mut input)
+                .context("read note body from stdin")?;
+            Ok(input)
+        }
+        (Some(_), Some(_)) => unreachable!("clap enforces body/body_file conflicts"),
+    }
+}
+
+/// Search learned notes with a simple BM25 index built in memory.
+pub fn search(
+    notes: &[LearnedNote],
+    query: &str,
+    limit: usize,
+    min_score: f64,
+) -> Vec<SearchResult> {
+    let query_tokens = tokenize(query);
+    if notes.is_empty() || query_tokens.is_empty() || limit == 0 {
+        return Vec::new();
+    }
+
+    let query_terms = query_tokens.into_iter().collect::<HashSet<_>>();
+    let documents = notes
+        .iter()
+        .map(|note| IndexedDocument::new(note))
+        .collect_vec();
+    let average_length = documents
+        .iter()
+        .map(|document| document.length as f64)
+        .sum::<f64>()
+        / documents.len() as f64;
+    let document_frequency = document_frequency(&documents);
+
+    let mut results = notes
+        .iter()
+        .zip(documents.iter())
+        .filter_map(|(note, document)| {
+            let score = bm25_score(
+                document,
+                &query_terms,
+                &document_frequency,
+                notes.len(),
+                average_length,
+            );
+            (score >= min_score && score > 0.0).then(|| SearchResult {
+                path: note.path.clone(),
+                title: note.title.clone(),
+                score,
+                excerpt: excerpt(note, &query_terms),
+            })
+        })
+        .collect_vec();
+
+    results.sort_by(|left, right| {
+        right
+            .score
+            .total_cmp(&left.score)
+            .then_with(|| left.title.cmp(&right.title))
+    });
+    results.truncate(limit);
+    results
+}
+
+/// Build learned context for hook responses.
+pub fn context_for_hooks(
+    root: &Path,
+    hooks: &[NudgeHook],
+    notes: &[LearnedNote],
+) -> HookLearnedContext {
+    if notes.is_empty() {
+        return HookLearnedContext::default();
+    }
+
+    let user_prompt_query = hooks
+        .iter()
+        .filter_map(|hook| match hook {
+            NudgeHook::UserPromptSubmit(payload) => Some(payload.prompt.as_str()),
+            _ => None,
+        })
+        .join("\n\n");
+    let pre_tool_query = hooks
+        .iter()
+        .filter_map(|hook| match hook {
+            NudgeHook::PreToolUse(payload) => query_for_tool(&payload.tool),
+            _ => None,
+        })
+        .join("\n\n");
+
+    HookLearnedContext {
+        user_prompt: hook_context_for_query(root, notes, &user_prompt_query),
+        pre_tool_use: hook_context_for_query(root, notes, &pre_tool_query),
+    }
+}
+
+pub fn render_search_results(root: &Path, results: &[SearchResult]) -> String {
+    results
+        .iter()
+        .enumerate()
+        .map(|(index, result)| {
+            format!(
+                "{}. {}\n   Score: {:.2}\n   Path: {}\n   Excerpt: {}",
+                index + 1,
+                result.title,
+                result.score,
+                display_path(root, &result.path),
+                result.excerpt
+            )
+        })
+        .join("\n\n")
+}
+
+fn hook_context_for_query(root: &Path, notes: &[LearnedNote], query: &str) -> Option<String> {
+    let query_tokens = tokenize(query);
+    if query_tokens.len() < HOOK_MIN_QUERY_TOKENS {
+        return None;
+    }
+
+    let results = search(notes, query, HOOK_SEARCH_LIMIT, HOOK_MIN_SCORE);
+    if results.is_empty() {
+        return None;
+    }
+
+    let rendered = render_search_results(root, &results);
+    Some(format!(
+        "Nudge found learned repo knowledge that may apply. Read this before repeating old debugging work:\n\n{rendered}"
+    ))
+}
+
+fn query_for_tool(tool: &ToolUse) -> Option<String> {
+    match tool {
+        ToolUse::Bash(input) => Some(
+            [Some(input.command.as_str()), input.description.as_deref()]
+                .into_iter()
+                .flatten()
+                .join("\n"),
+        ),
+        ToolUse::WebFetch(input) => Some(
+            [Some(input.url.as_str()), input.prompt.as_deref()]
+                .into_iter()
+                .flatten()
+                .join("\n"),
+        ),
+        _ => None,
+    }
+}
+
+fn document_frequency(documents: &[IndexedDocument]) -> HashMap<String, usize> {
+    let mut frequency = HashMap::new();
+    for document in documents {
+        for term in document.term_frequency.keys() {
+            *frequency.entry(term.clone()).or_insert(0) += 1;
+        }
+    }
+    frequency
+}
+
+fn bm25_score(
+    document: &IndexedDocument,
+    query_terms: &HashSet<String>,
+    document_frequency: &HashMap<String, usize>,
+    document_count: usize,
+    average_length: f64,
+) -> f64 {
+    const K1: f64 = 1.5;
+    const B: f64 = 0.75;
+
+    query_terms
+        .iter()
+        .filter_map(|term| {
+            let term_frequency = *document.term_frequency.get(term)? as f64;
+            let document_frequency = *document_frequency.get(term).unwrap_or(&0) as f64;
+            let idf = ((document_count as f64 - document_frequency + 0.5)
+                / (document_frequency + 0.5)
+                + 1.0)
+                .ln();
+            let length_normalizer = K1
+                * (1.0 - B + B * (document.length as f64 / average_length.max(f64::MIN_POSITIVE)));
+            let score = idf * (term_frequency * (K1 + 1.0)) / (term_frequency + length_normalizer);
+            Some(score)
+        })
+        .sum()
+}
+
+#[derive(Debug, Clone)]
+struct IndexedDocument {
+    term_frequency: HashMap<String, usize>,
+    length: usize,
+}
+
+impl IndexedDocument {
+    fn new(note: &LearnedNote) -> Self {
+        let text = format!("{}\n{}\n{}", note.title, note.title, note.body);
+        let tokens = tokenize(&text);
+        let mut term_frequency = HashMap::new();
+        for token in &tokens {
+            *term_frequency.entry(token.clone()).or_insert(0) += 1;
+        }
+
+        Self {
+            term_frequency,
+            length: tokens.len(),
+        }
+    }
+}
+
+fn tokenize(text: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+
+    for character in text.chars() {
+        if character.is_alphanumeric() {
+            current.extend(character.to_lowercase());
+        } else {
+            push_token(&mut tokens, &mut current);
+        }
+    }
+    push_token(&mut tokens, &mut current);
+
+    tokens
+}
+
+fn push_token(tokens: &mut Vec<String>, current: &mut String) {
+    if current.len() >= 2 && !is_stop_word(current) {
+        tokens.push(std::mem::take(current));
+    } else {
+        current.clear();
+    }
+}
+
+fn is_stop_word(token: &str) -> bool {
+    matches!(
+        token,
+        "about"
+            | "after"
+            | "again"
+            | "also"
+            | "and"
+            | "are"
+            | "because"
+            | "been"
+            | "before"
+            | "but"
+            | "can"
+            | "could"
+            | "did"
+            | "does"
+            | "doing"
+            | "done"
+            | "for"
+            | "from"
+            | "had"
+            | "has"
+            | "have"
+            | "how"
+            | "into"
+            | "its"
+            | "let"
+            | "like"
+            | "not"
+            | "now"
+            | "once"
+            | "only"
+            | "our"
+            | "out"
+            | "over"
+            | "same"
+            | "should"
+            | "some"
+            | "than"
+            | "that"
+            | "the"
+            | "then"
+            | "there"
+            | "this"
+            | "through"
+            | "use"
+            | "was"
+            | "were"
+            | "what"
+            | "when"
+            | "where"
+            | "while"
+            | "with"
+            | "would"
+            | "you"
+            | "your"
+    )
+}
+
+fn excerpt(note: &LearnedNote, query_terms: &HashSet<String>) -> String {
+    let body_without_title = note
+        .body
+        .lines()
+        .skip_while(|line| line.trim().is_empty() || line.trim_start().starts_with("# "))
+        .join("\n");
+    let paragraphs = body_without_title
+        .split("\n\n")
+        .map(clean_excerpt_text)
+        .filter(|paragraph| !paragraph.is_empty())
+        .collect_vec();
+
+    let matching_index = paragraphs
+        .iter()
+        .position(|paragraph| {
+            let paragraph_tokens = tokenize(paragraph).into_iter().collect::<HashSet<_>>();
+            paragraph_tokens
+                .iter()
+                .any(|token| query_terms.contains(token))
+        })
+        .or_else(|| (!paragraphs.is_empty()).then_some(0));
+
+    let Some(matching_index) = matching_index else {
+        return String::new();
+    };
+
+    let mut selected = vec![paragraphs[matching_index].clone()];
+    if let Some(fix) = paragraphs
+        .iter()
+        .enumerate()
+        .find(|(index, paragraph)| {
+            *index != matching_index && paragraph.to_lowercase().starts_with("fix")
+        })
+        .map(|(_, paragraph)| paragraph.clone())
+    {
+        selected.push(fix);
+    }
+
+    truncate_text(&selected.join(" "), EXCERPT_LIMIT)
+}
+
+fn clean_excerpt_text(text: &str) -> String {
+    text.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(|line| line.trim_start_matches('#').trim())
+        .join(" ")
+}
+
+fn truncate_text(text: &str, limit: usize) -> String {
+    if text.chars().count() <= limit {
+        return text.to_string();
+    }
+
+    let mut truncated = text
+        .chars()
+        .take(limit.saturating_sub(3))
+        .collect::<String>();
+    truncated.push_str("...");
+    truncated
+}
+
+fn infer_title(body: &str) -> Option<String> {
+    body.lines()
+        .find_map(|line| line.trim().strip_prefix("# ").map(str::trim))
+        .filter(|title| !title.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            body.lines()
+                .map(str::trim)
+                .find(|line| !line.is_empty())
+                .map(|line| truncate_text(line.trim_start_matches('#').trim(), 80))
+        })
+}
+
+fn starts_with_h1(body: &str) -> bool {
+    body.lines()
+        .find(|line| !line.trim().is_empty())
+        .is_some_and(|line| line.trim_start().starts_with("# "))
+}
+
+fn ensure_trailing_newline(body: &str) -> String {
+    if body.ends_with('\n') {
+        body.to_string()
+    } else {
+        format!("{body}\n")
+    }
+}
+
+fn normalize_newlines(text: &str) -> String {
+    text.replace("\r\n", "\n").replace('\r', "\n")
+}
+
+fn slugify(title: &str) -> String {
+    let mut slug = String::new();
+    let mut previous_was_separator = false;
+
+    for character in title.chars().flat_map(char::to_lowercase) {
+        if character.is_ascii_alphanumeric() {
+            slug.push(character);
+            previous_was_separator = false;
+        } else if !previous_was_separator && !slug.is_empty() {
+            slug.push('-');
+            previous_was_separator = true;
+        }
+    }
+
+    let slug = slug.trim_matches('-');
+    if slug.is_empty() {
+        String::from("learned-note")
+    } else {
+        slug.to_string()
+    }
+}
+
+fn next_available_path(dir: &Path, slug: &str) -> PathBuf {
+    let first = dir.join(format!("{slug}.md"));
+    if !first.exists() {
+        return first;
+    }
+
+    for index in 2.. {
+        let candidate = dir.join(format!("{slug}-{index}.md"));
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+
+    unreachable!("infinite iterator returns a path")
+}
+
+fn display_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .display()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use pretty_assertions::assert_eq as pretty_assert_eq;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn note(title: &str, body: &str) -> LearnedNote {
+        LearnedNote {
+            path: PathBuf::from(format!(".nudge/learned/{}.md", slugify(title))),
+            title: title.to_string(),
+            body: format!("# {title}\n\n{body}"),
+        }
+    }
+
+    #[test]
+    fn add_writes_markdown_note_with_slug() {
+        let temp = TempDir::new().expect("temp dir");
+        let path = add(
+            temp.path(),
+            AddNote {
+                title: Some(String::from("Expo Metro Cache")),
+                body: String::from("What went wrong\n\nThe resolver used stale state."),
+            },
+        )
+        .expect("add note");
+
+        pretty_assert_eq!(path, temp.path().join(".nudge/learned/expo-metro-cache.md"));
+        let content = fs::read_to_string(path).expect("read note");
+        assert!(content.starts_with("# Expo Metro Cache\n\n"));
+        assert!(content.contains("The resolver used stale state."));
+    }
+
+    #[test]
+    fn search_ranks_specific_incident_above_unrelated_note() {
+        let notes = vec![
+            note(
+                "Expo Metro Cache",
+                "Expo failed to resolve modules until Metro cache state was cleared.",
+            ),
+            note(
+                "Rust Import Style",
+                "Move use declarations to the top of Rust modules.",
+            ),
+        ];
+
+        let results = search(
+            &notes,
+            "expo metro cannot resolve module after dependency update",
+            5,
+            0.0,
+        );
+
+        pretty_assert_eq!(results[0].title, "Expo Metro Cache");
+        assert!(
+            results
+                .iter()
+                .all(|result| result.title != "Rust Import Style"),
+            "zero-score unrelated notes should not be returned"
+        );
+    }
+
+    #[test]
+    fn hook_context_skips_tiny_queries() {
+        let notes = vec![note("Expo Metro Cache", "Clear Metro cache.")];
+        let context = hook_context_for_query(Path::new("."), &notes, "expo");
+
+        pretty_assert_eq!(context, None);
+    }
+}

--- a/packages/nudge/src/learn.rs
+++ b/packages/nudge/src/learn.rs
@@ -27,18 +27,10 @@ const HOOK_MIN_QUERY_TOKENS: usize = 3;
 const EXCERPT_LIMIT: usize = 420;
 
 /// Learned-note retrieval configuration.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct LearnConfig {
     pub embeddings: EmbeddingConfig,
-}
-
-impl Default for LearnConfig {
-    fn default() -> Self {
-        Self {
-            embeddings: EmbeddingConfig::default(),
-        }
-    }
 }
 
 /// Local embedding configuration for learned notes.
@@ -216,10 +208,7 @@ pub fn search(
     }
 
     let query_terms = query_tokens.into_iter().collect::<HashSet<_>>();
-    let documents = notes
-        .iter()
-        .map(|note| IndexedDocument::new(note))
-        .collect_vec();
+    let documents = notes.iter().map(IndexedDocument::new).collect_vec();
     let average_length = documents
         .iter()
         .map(|document| document.length as f64)

--- a/packages/nudge/src/learn.rs
+++ b/packages/nudge/src/learn.rs
@@ -9,9 +9,15 @@ use std::{
 
 use color_eyre::eyre::{Context, OptionExt, Result, bail};
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
 
-use crate::hook::{NudgeHook, ToolUse};
+use crate::{
+    hook::{NudgeHook, ToolUse},
+    rules,
+};
+
+pub mod embeddings;
 
 pub const LEARNED_DIR: &str = ".nudge/learned";
 const DEFAULT_SEARCH_LIMIT: usize = 5;
@@ -19,6 +25,38 @@ const HOOK_SEARCH_LIMIT: usize = 3;
 const HOOK_MIN_SCORE: f64 = 1.2;
 const HOOK_MIN_QUERY_TOKENS: usize = 3;
 const EXCERPT_LIMIT: usize = 420;
+
+/// Learned-note retrieval configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct LearnConfig {
+    pub embeddings: EmbeddingConfig,
+}
+
+impl Default for LearnConfig {
+    fn default() -> Self {
+        Self {
+            embeddings: EmbeddingConfig::default(),
+        }
+    }
+}
+
+/// Local embedding configuration for learned notes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct EmbeddingConfig {
+    pub enabled: bool,
+    pub model: String,
+}
+
+impl Default for EmbeddingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            model: embeddings::default_model(),
+        }
+    }
+}
 
 /// A Markdown incident note stored under `.nudge/learned`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -57,6 +95,18 @@ pub fn learned_dir(root: &Path) -> PathBuf {
 
 pub fn default_search_limit() -> usize {
     DEFAULT_SEARCH_LIMIT
+}
+
+/// Load learned-note configuration from normal Nudge config files.
+pub fn load_config() -> Result<LearnConfig> {
+    let mut config = LearnConfig::default();
+    for (_, source) in rules::load_all_configs_attributed().context("load Nudge config")? {
+        if let Some(learn) = source.learn {
+            config = learn;
+        }
+    }
+
+    Ok(config)
 }
 
 /// Load all learned Markdown notes for a repo root.
@@ -207,11 +257,29 @@ pub fn search(
     results
 }
 
+/// Search learned notes using the configured retrieval strategy.
+pub fn search_with_config(
+    root: &Path,
+    notes: &[LearnedNote],
+    query: &str,
+    limit: usize,
+    min_score: f64,
+    config: &LearnConfig,
+) -> Result<Vec<SearchResult>> {
+    if let Some(results) = embeddings::hybrid_search(root, notes, query, limit, min_score, config)?
+    {
+        return Ok(results);
+    }
+
+    Ok(search(notes, query, limit, min_score))
+}
+
 /// Build learned context for hook responses.
 pub fn context_for_hooks(
     root: &Path,
     hooks: &[NudgeHook],
     notes: &[LearnedNote],
+    config: &LearnConfig,
 ) -> HookLearnedContext {
     if notes.is_empty() {
         return HookLearnedContext::default();
@@ -233,8 +301,8 @@ pub fn context_for_hooks(
         .join("\n\n");
 
     HookLearnedContext {
-        user_prompt: hook_context_for_query(root, notes, &user_prompt_query),
-        pre_tool_use: hook_context_for_query(root, notes, &pre_tool_query),
+        user_prompt: hook_context_for_query(root, notes, &user_prompt_query, config),
+        pre_tool_use: hook_context_for_query(root, notes, &pre_tool_query, config),
     }
 }
 
@@ -255,13 +323,32 @@ pub fn render_search_results(root: &Path, results: &[SearchResult]) -> String {
         .join("\n\n")
 }
 
-fn hook_context_for_query(root: &Path, notes: &[LearnedNote], query: &str) -> Option<String> {
+fn hook_context_for_query(
+    root: &Path,
+    notes: &[LearnedNote],
+    query: &str,
+    config: &LearnConfig,
+) -> Option<String> {
     let query_tokens = tokenize(query);
     if query_tokens.len() < HOOK_MIN_QUERY_TOKENS {
         return None;
     }
 
-    let results = search(notes, query, HOOK_SEARCH_LIMIT, HOOK_MIN_SCORE);
+    let results = search_with_config(
+        root,
+        notes,
+        query,
+        HOOK_SEARCH_LIMIT,
+        HOOK_MIN_SCORE,
+        config,
+    )
+    .unwrap_or_else(|error| {
+        tracing::warn!(
+            ?error,
+            "learned-note embedding search failed; falling back to BM25"
+        );
+        search(notes, query, HOOK_SEARCH_LIMIT, HOOK_MIN_SCORE)
+    });
     if results.is_empty() {
         return None;
     }
@@ -433,7 +520,11 @@ fn is_stop_word(token: &str) -> bool {
     )
 }
 
-fn excerpt(note: &LearnedNote, query_terms: &HashSet<String>) -> String {
+pub(crate) fn query_terms(query: &str) -> HashSet<String> {
+    tokenize(query).into_iter().collect()
+}
+
+pub(crate) fn excerpt(note: &LearnedNote, query_terms: &HashSet<String>) -> String {
     let body_without_title = note
         .body
         .lines()
@@ -564,7 +655,7 @@ fn next_available_path(dir: &Path, slug: &str) -> PathBuf {
     unreachable!("infinite iterator returns a path")
 }
 
-fn display_path(root: &Path, path: &Path) -> String {
+pub(crate) fn display_path(root: &Path, path: &Path) -> String {
     path.strip_prefix(root)
         .unwrap_or(path)
         .display()
@@ -638,7 +729,8 @@ mod tests {
     #[test]
     fn hook_context_skips_tiny_queries() {
         let notes = vec![note("Expo Metro Cache", "Clear Metro cache.")];
-        let context = hook_context_for_query(Path::new("."), &notes, "expo");
+        let context =
+            hook_context_for_query(Path::new("."), &notes, "expo", &LearnConfig::default());
 
         pretty_assert_eq!(context, None);
     }

--- a/packages/nudge/src/learn/embeddings.rs
+++ b/packages/nudge/src/learn/embeddings.rs
@@ -258,10 +258,10 @@ fn load_or_build_index(
     config: &LearnConfig,
 ) -> Result<VectorIndex> {
     let paths = paths(root)?;
-    if let Some(index) = load_index(&paths.vector_index) {
-        if index_is_current(root, notes, config, &index) {
-            return Ok(index);
-        }
+    if let Some(index) =
+        load_index(&paths.vector_index).filter(|index| index_is_current(root, notes, config, index))
+    {
+        return Ok(index);
     }
 
     build_index(root, notes, config)?;

--- a/packages/nudge/src/learn/embeddings.rs
+++ b/packages/nudge/src/learn/embeddings.rs
@@ -1,0 +1,527 @@
+//! Local embedding support for learned notes.
+
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use color_eyre::eyre::{Context, OptionExt, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    learn::{LearnConfig, LearnedNote, SearchResult, display_path, search},
+    rules,
+};
+
+const INDEX_VERSION: u32 = 1;
+const DEFAULT_MODEL: &str = "BGESmallENV15";
+const DEFAULT_MODEL_NAME: &str = "BAAI/bge-small-en-v1.5";
+const SEMANTIC_WEIGHT: f64 = 2.5;
+const BM25_PREFETCH_LIMIT: usize = 50;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddingPaths {
+    pub cache_dir: PathBuf,
+    pub model_dir: PathBuf,
+    pub vector_index: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddingStatus {
+    pub enabled: bool,
+    pub model: String,
+    pub paths: EmbeddingPaths,
+    pub vector_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddingBuildReport {
+    pub model: String,
+    pub paths: EmbeddingPaths,
+    pub chunk_count: usize,
+}
+
+#[derive(Debug, Clone)]
+struct NoteChunk {
+    note_path: PathBuf,
+    title: String,
+    text: String,
+    note_hash: String,
+    chunk_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct VectorIndex {
+    version: u32,
+    project_root: String,
+    model: String,
+    chunks: Vec<VectorChunk>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct VectorChunk {
+    note_path: String,
+    title: String,
+    text: String,
+    note_hash: String,
+    chunk_id: String,
+    vector: Vec<f32>,
+}
+
+pub fn default_model() -> String {
+    DEFAULT_MODEL_NAME.to_string()
+}
+
+pub fn status(root: &Path, config: &LearnConfig) -> Result<EmbeddingStatus> {
+    let paths = paths(root)?;
+    let vector_count = load_index(&paths.vector_index)
+        .map(|index| index.chunks.len())
+        .unwrap_or(0);
+
+    Ok(EmbeddingStatus {
+        enabled: config.embeddings.enabled,
+        model: config.embeddings.model.clone(),
+        paths,
+        vector_count,
+    })
+}
+
+pub fn paths(root: &Path) -> Result<EmbeddingPaths> {
+    let dirs = rules::project_dirs().ok_or_eyre("resolve Nudge cache directory")?;
+    let cache_dir = dirs.cache_dir().join("learn");
+    let model_dir = cache_dir.join("models");
+    let vector_dir = cache_dir.join("vectors");
+    let vector_index = vector_dir.join(format!("{}.json", project_cache_key(root)));
+
+    Ok(EmbeddingPaths {
+        cache_dir,
+        model_dir,
+        vector_index,
+    })
+}
+
+pub fn build_index(
+    root: &Path,
+    notes: &[LearnedNote],
+    config: &LearnConfig,
+) -> Result<EmbeddingBuildReport> {
+    let paths = paths(root)?;
+    fs::create_dir_all(&paths.model_dir)
+        .with_context(|| format!("create model cache dir: {}", paths.model_dir.display()))?;
+    if let Some(parent) = paths.vector_index.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create vector cache dir: {}", parent.display()))?;
+    }
+
+    let chunks = chunks_for_notes(root, notes);
+    let vectors = embed_texts(
+        &config.embeddings.model,
+        &paths.model_dir,
+        chunks
+            .iter()
+            .map(|chunk| format!("passage: {}", chunk.text))
+            .collect(),
+    )?;
+    let index = VectorIndex {
+        version: INDEX_VERSION,
+        project_root: canonical_root(root),
+        model: canonical_model(&config.embeddings.model)?,
+        chunks: chunks
+            .into_iter()
+            .zip(vectors)
+            .map(|(chunk, vector)| VectorChunk {
+                note_path: display_path(root, &chunk.note_path),
+                title: chunk.title,
+                text: chunk.text,
+                note_hash: chunk.note_hash,
+                chunk_id: chunk.chunk_id,
+                vector,
+            })
+            .collect(),
+    };
+    let chunk_count = index.chunks.len();
+
+    fs::write(
+        &paths.vector_index,
+        serde_json::to_string_pretty(&index).context("serialize embedding index")?,
+    )
+    .with_context(|| format!("write vector index: {}", paths.vector_index.display()))?;
+
+    Ok(EmbeddingBuildReport {
+        model: canonical_model(&config.embeddings.model)?,
+        paths,
+        chunk_count,
+    })
+}
+
+pub fn ensure_model(root: &Path, config: &LearnConfig) -> Result<EmbeddingPaths> {
+    let paths = paths(root)?;
+    fs::create_dir_all(&paths.model_dir)
+        .with_context(|| format!("create model cache dir: {}", paths.model_dir.display()))?;
+    let _ = embed_texts(
+        &config.embeddings.model,
+        &paths.model_dir,
+        vec![String::from("query: nudge local embedding model warmup")],
+    )?;
+    Ok(paths)
+}
+
+pub fn hybrid_search(
+    root: &Path,
+    notes: &[LearnedNote],
+    query: &str,
+    limit: usize,
+    min_score: f64,
+    config: &LearnConfig,
+) -> Result<Option<Vec<SearchResult>>> {
+    if !config.embeddings.enabled {
+        return Ok(None);
+    }
+
+    hybrid_search_enabled(root, notes, query, limit, min_score, config)
+}
+
+fn hybrid_search_enabled(
+    root: &Path,
+    notes: &[LearnedNote],
+    query: &str,
+    limit: usize,
+    min_score: f64,
+    config: &LearnConfig,
+) -> Result<Option<Vec<SearchResult>>> {
+    let index = load_or_build_index(root, notes, config)?;
+    if index.chunks.is_empty() {
+        return Ok(None);
+    }
+
+    let paths = paths(root)?;
+    let query_vector = embed_texts(
+        &config.embeddings.model,
+        &paths.model_dir,
+        vec![format!("query: {query}")],
+    )?
+    .into_iter()
+    .next()
+    .ok_or_eyre("embedding model returned no query vector")?;
+
+    let mut semantic_by_path: HashMap<String, f64> = HashMap::new();
+    for chunk in &index.chunks {
+        let similarity = cosine_similarity(&query_vector, &chunk.vector);
+        semantic_by_path
+            .entry(chunk.note_path.clone())
+            .and_modify(|existing| *existing = existing.max(similarity))
+            .or_insert(similarity);
+    }
+
+    let bm25 = search(notes, query, BM25_PREFETCH_LIMIT.max(limit), 0.0);
+    let bm25_by_path = bm25
+        .iter()
+        .map(|result| (display_path(root, &result.path), result.score))
+        .collect::<HashMap<_, _>>();
+
+    let mut results = notes
+        .iter()
+        .filter_map(|note| {
+            let note_path = display_path(root, &note.path);
+            let bm25_score = bm25_by_path.get(&note_path).copied().unwrap_or(0.0);
+            let semantic_score = semantic_by_path
+                .get(&note_path)
+                .copied()
+                .unwrap_or(0.0)
+                .max(0.0);
+            let score = bm25_score + semantic_score * SEMANTIC_WEIGHT;
+            (score >= min_score && score > 0.0).then(|| SearchResult {
+                path: note.path.clone(),
+                title: note.title.clone(),
+                score,
+                excerpt: crate::learn::excerpt(note, &crate::learn::query_terms(query)),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    results.sort_by(|left, right| {
+        right
+            .score
+            .total_cmp(&left.score)
+            .then_with(|| left.title.cmp(&right.title))
+    });
+    results.truncate(limit);
+
+    Ok(Some(results))
+}
+
+fn load_or_build_index(
+    root: &Path,
+    notes: &[LearnedNote],
+    config: &LearnConfig,
+) -> Result<VectorIndex> {
+    let paths = paths(root)?;
+    if let Some(index) = load_index(&paths.vector_index) {
+        if index_is_current(root, notes, config, &index) {
+            return Ok(index);
+        }
+    }
+
+    build_index(root, notes, config)?;
+    load_index(&paths.vector_index).ok_or_eyre("read rebuilt embedding index")
+}
+
+fn load_index(path: &Path) -> Option<VectorIndex> {
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+fn index_is_current(
+    root: &Path,
+    notes: &[LearnedNote],
+    config: &LearnConfig,
+    index: &VectorIndex,
+) -> bool {
+    if index.version != INDEX_VERSION
+        || index.project_root != canonical_root(root)
+        || index.model != canonical_model(&config.embeddings.model).unwrap_or_default()
+    {
+        return false;
+    }
+
+    let expected = chunks_for_notes(root, notes)
+        .into_iter()
+        .map(|chunk| {
+            (
+                display_path(root, &chunk.note_path),
+                chunk.chunk_id,
+                chunk.note_hash,
+            )
+        })
+        .collect::<Vec<_>>();
+    let actual = index
+        .chunks
+        .iter()
+        .map(|chunk| {
+            (
+                chunk.note_path.clone(),
+                chunk.chunk_id.clone(),
+                chunk.note_hash.clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    expected == actual
+}
+
+fn embed_texts(model: &str, model_dir: &Path, texts: Vec<String>) -> Result<Vec<Vec<f32>>> {
+    use fastembed::{EmbeddingModel, TextEmbedding, TextInitOptions};
+    use std::str::FromStr;
+
+    if texts.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let model = canonical_model(model)?;
+    let model = EmbeddingModel::from_str(&model)
+        .map_err(|error| color_eyre::eyre::eyre!("unknown embedding model `{model}`: {error}"))?;
+    let mut embedder = TextEmbedding::try_new(
+        TextInitOptions::new(model)
+            .with_cache_dir(model_dir.to_path_buf())
+            .with_show_download_progress(false),
+    )
+    .map_err(|error| color_eyre::eyre::eyre!("initialize local embedding model: {error}"))?;
+
+    embedder
+        .embed(texts, None)
+        .map_err(|error| color_eyre::eyre::eyre!("generate local embeddings: {error}"))
+}
+
+pub fn canonical_model(model: &str) -> Result<String> {
+    let trimmed = model.trim();
+    let canonical = match trimmed.to_ascii_lowercase().as_str() {
+        "baai/bge-small-en-v1.5" | "bge-small-en-v1.5" | "bgesmallenv15" => DEFAULT_MODEL,
+        "sentence-transformers/all-minilm-l6-v2" | "all-minilm-l6-v2" | "allminilml6v2" => {
+            "AllMiniLML6V2"
+        }
+        "sentence-transformers/all-minilm-l6-v2-q" | "all-minilm-l6-v2-q" | "allminilml6v2q" => {
+            "AllMiniLML6V2Q"
+        }
+        _ => trimmed,
+    };
+
+    use fastembed::EmbeddingModel;
+    use std::str::FromStr;
+    EmbeddingModel::from_str(canonical)
+        .map_err(|error| color_eyre::eyre::eyre!("unknown embedding model `{model}`: {error}"))?;
+
+    Ok(canonical.to_string())
+}
+
+fn chunks_for_notes(root: &Path, notes: &[LearnedNote]) -> Vec<NoteChunk> {
+    notes
+        .iter()
+        .flat_map(|note| chunks_for_note(root, note))
+        .collect()
+}
+
+fn chunks_for_note(root: &Path, note: &LearnedNote) -> Vec<NoteChunk> {
+    let body_without_title = note
+        .body
+        .lines()
+        .skip_while(|line| line.trim().is_empty() || line.trim_start().starts_with("# "))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let note_hash = stable_hash(&note.body);
+    let mut chunks = Vec::new();
+    let mut heading = String::new();
+    let mut section = Vec::new();
+
+    for line in body_without_title.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("## ") || trimmed.starts_with("### ") {
+            push_section_chunk(root, note, &note_hash, &heading, &section, &mut chunks);
+            heading = trimmed.trim_start_matches('#').trim().to_string();
+            section.clear();
+        } else {
+            section.push(line.to_string());
+        }
+    }
+    push_section_chunk(root, note, &note_hash, &heading, &section, &mut chunks);
+
+    if chunks.is_empty() {
+        chunks.push(NoteChunk {
+            note_path: note.path.clone(),
+            title: note.title.clone(),
+            text: format!("{}\n{}", note.title, note.body.trim()),
+            note_hash,
+            chunk_id: stable_hash(&format!("{}:whole", display_path(root, &note.path))),
+        });
+    }
+
+    chunks
+}
+
+fn push_section_chunk(
+    root: &Path,
+    note: &LearnedNote,
+    note_hash: &str,
+    heading: &str,
+    section: &[String],
+    chunks: &mut Vec<NoteChunk>,
+) {
+    let section_text = section
+        .iter()
+        .map(|line| line.trim())
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+    if heading.is_empty() && section_text.is_empty() {
+        return;
+    }
+
+    let text = [note.title.as_str(), heading, section_text.as_str()]
+        .into_iter()
+        .filter(|part| !part.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let chunk_id = stable_hash(&format!(
+        "{}:{}:{}",
+        display_path(root, &note.path),
+        heading,
+        section_text
+    ));
+
+    chunks.push(NoteChunk {
+        note_path: note.path.clone(),
+        title: note.title.clone(),
+        text,
+        note_hash: note_hash.to_string(),
+        chunk_id,
+    });
+}
+
+fn cosine_similarity(left: &[f32], right: &[f32]) -> f64 {
+    if left.len() != right.len() || left.is_empty() {
+        return 0.0;
+    }
+
+    let mut dot = 0.0;
+    let mut left_norm = 0.0;
+    let mut right_norm = 0.0;
+    for (left, right) in left.iter().zip(right) {
+        let left = *left as f64;
+        let right = *right as f64;
+        dot += left * right;
+        left_norm += left * left;
+        right_norm += right * right;
+    }
+
+    dot / ((left_norm.sqrt() * right_norm.sqrt()) + f64::EPSILON)
+}
+
+fn canonical_root(root: &Path) -> String {
+    root.canonicalize()
+        .unwrap_or_else(|_| root.to_path_buf())
+        .display()
+        .to_string()
+}
+
+fn project_cache_key(root: &Path) -> String {
+    stable_hash(&canonical_root(root))
+}
+
+fn stable_hash(text: &str) -> String {
+    let digest = Sha256::digest(text.as_bytes());
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq as pretty_assert_eq;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn note(path: &str, title: &str, body: &str) -> LearnedNote {
+        LearnedNote {
+            path: PathBuf::from(path),
+            title: title.to_string(),
+            body: body.to_string(),
+        }
+    }
+
+    #[test]
+    fn chunks_notes_by_markdown_sections() {
+        let root = TempDir::new().expect("temp dir");
+        let note = note(
+            root.path()
+                .join(".nudge/learned/expo.md")
+                .to_str()
+                .expect("utf-8"),
+            "Expo cache",
+            "# Expo cache\n\n## What went wrong\n\nMetro reused stale resolver state.\n\n## Fix\n\nClear the cache.",
+        );
+
+        let chunks = chunks_for_note(root.path(), &note);
+
+        pretty_assert_eq!(chunks.len(), 2);
+        assert!(chunks[0].text.contains("What went wrong"));
+        assert!(chunks[1].text.contains("Clear the cache"));
+    }
+
+    #[test]
+    fn status_reports_configuration_without_requiring_model() {
+        let root = TempDir::new().expect("temp dir");
+        let config = LearnConfig::default();
+        let status = status(root.path(), &config).expect("status");
+
+        pretty_assert_eq!(status.enabled, false);
+        pretty_assert_eq!(status.model, DEFAULT_MODEL_NAME);
+    }
+
+    #[test]
+    fn canonical_model_accepts_hugging_face_name() {
+        pretty_assert_eq!(
+            canonical_model("BAAI/bge-small-en-v1.5").expect("canonical model"),
+            "BGESmallENV15"
+        );
+    }
+}

--- a/packages/nudge/src/lib.rs
+++ b/packages/nudge/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod agent;
 pub mod git;
 pub mod hook;
+pub mod learn;
 pub mod rules;
 pub mod snippet;
 pub mod template;

--- a/packages/nudge/src/lib.rs
+++ b/packages/nudge/src/lib.rs
@@ -5,6 +5,7 @@ pub mod git;
 pub mod hook;
 pub mod learn;
 pub mod rules;
+pub mod skills;
 pub mod snippet;
 pub mod template;
 

--- a/packages/nudge/src/main.rs
+++ b/packages/nudge/src/main.rs
@@ -28,6 +28,9 @@ enum Commands {
     /// Integration with Codex CLI.
     Codex(cmd::codex::Config),
 
+    /// Manage repo-local learned incident knowledge.
+    Learn(cmd::learn::Config),
+
     /// Display the syntax tree for code (for writing tree-sitter queries).
     Syntaxtree(cmd::syntaxtree::Config),
 
@@ -82,6 +85,7 @@ fn main() -> Result<()> {
         Commands::Check(config) => cmd::check::main(config),
         Commands::Claude(config) => cmd::claude::main(config),
         Commands::Codex(config) => cmd::codex::main(config),
+        Commands::Learn(config) => cmd::learn::main(config),
         Commands::Syntaxtree(config) => cmd::syntaxtree::main(config),
         Commands::Validate(config) => cmd::validate::main(config),
         Commands::Test(config) => cmd::test::main(config),

--- a/packages/nudge/src/rules.rs
+++ b/packages/nudge/src/rules.rs
@@ -27,7 +27,8 @@ pub fn project_dirs() -> Option<ProjectDirs> {
 /// Loading order (all additive):
 /// 1. User-level rules from `ProjectDirs::config_dir()/rules.yaml` if it exists
 /// 2. `.nudge.yaml` if it exists
-/// 3. `.nudge/` directory walked recursively, loading all `*.yaml` files
+/// 3. `.nudge.yml` if it exists
+/// 4. `.nudge/` directory walked recursively, loading all `*.yaml` and `*.yml` files
 #[tracing::instrument]
 pub fn load_all() -> Result<Vec<Rule>> {
     load_all_attributed()?
@@ -43,22 +44,39 @@ pub fn load_all() -> Result<Vec<Rule>> {
 /// Loading order (all additive):
 /// 1. User-level rules from `ProjectDirs::config_dir()/rules.yaml` if it exists
 /// 2. `.nudge.yaml` if it exists
-/// 3. `.nudge/` directory walked recursively, loading all `*.yaml` files
+/// 3. `.nudge.yml` if it exists
+/// 4. `.nudge/` directory walked recursively, loading all `*.yaml` and `*.yml` files
 #[tracing::instrument]
 pub fn load_all_attributed() -> Result<Vec<(PathBuf, Vec<Rule>)>> {
-    let mut rules = vec![];
+    load_all_configs_attributed().map(|configs| {
+        configs
+            .into_iter()
+            .map(|(path, config)| (path, config.rules))
+            .collect()
+    })
+}
+
+/// Load all Nudge configuration files from all sources.
+#[tracing::instrument]
+pub fn load_all_configs_attributed() -> Result<Vec<(PathBuf, RuleConfig)>> {
+    let mut configs = vec![];
 
     if let Some(dirs) = project_dirs() {
         let user_config = dirs.config_dir().join("rules.yaml");
-        let user_rules = load_from(&user_config)
-            .with_context(|| format!("load rules from user config: {user_config:?}"))?;
-        rules.push((user_config, user_rules));
+        if let Some(config) = load_config_from(&user_config)
+            .with_context(|| format!("load config from user config: {user_config:?}"))?
+        {
+            configs.push((user_config, config));
+        }
     }
 
-    let project_root_config = PathBuf::from(".nudge.yaml");
-    let project_root_rules = load_from(&project_root_config)
-        .with_context(|| format!("load rules from project root: {project_root_config:?}"))?;
-    rules.push((project_root_config, project_root_rules));
+    for project_root_config in [PathBuf::from(".nudge.yaml"), PathBuf::from(".nudge.yml")] {
+        if let Some(config) = load_config_from(&project_root_config)
+            .with_context(|| format!("load config from project root: {project_root_config:?}"))?
+        {
+            configs.push((project_root_config, config));
+        }
+    }
 
     let root = Path::new(".nudge");
     if root.is_dir() {
@@ -73,14 +91,16 @@ pub fn load_all_attributed() -> Result<Vec<(PathBuf, Vec<Rule>)>> {
 
             if entry.file_type().is_file() {
                 let config = entry.path().to_path_buf();
-                let config_rules = load_from(&config)
-                    .with_context(|| format!("load rules from file: {config:?}"))?;
-                rules.push((config, config_rules));
+                if let Some(config_content) = load_config_from(&config)
+                    .with_context(|| format!("load config from file: {config:?}"))?
+                {
+                    configs.push((config, config_content));
+                }
             }
         }
     }
 
-    Ok(rules)
+    Ok(configs)
 }
 
 /// Load rules from a single file.
@@ -88,14 +108,22 @@ pub fn load_all_attributed() -> Result<Vec<(PathBuf, Vec<Rule>)>> {
 // TODO: Support other file types.
 #[tracing::instrument]
 pub fn load_from(path: &Path) -> Result<Vec<Rule>> {
-    if path.extension() != Some(OsStr::new("yaml")) {
+    Ok(load_config_from(path)?
+        .map(|config| config.rules)
+        .unwrap_or_default())
+}
+
+/// Load a single Nudge config file.
+#[tracing::instrument]
+pub fn load_config_from(path: &Path) -> Result<Option<RuleConfig>> {
+    if !is_config_extension(path.extension()) {
         tracing::debug!("skipping non-yaml file");
-        return Ok(vec![]);
+        return Ok(None);
     }
 
     let content = match read_to_string(path) {
         Ok(content) => content,
-        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(vec![]),
+        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(None),
         Err(e) => return Err(e).context(format!("read config file: {path:?}")),
     };
 
@@ -103,7 +131,11 @@ pub fn load_from(path: &Path) -> Result<Vec<Rule>> {
         .with_context(|| format!("parse config file: {path:?}"))
         .with_context(|| content.header("File content:"))
         .tap(|config| tracing::debug!(?config, "parsed config file"))
-        .map(|config| config.rules)
+        .map(Some)
+}
+
+fn is_config_extension(extension: Option<&OsStr>) -> bool {
+    extension == Some(OsStr::new("yaml")) || extension == Some(OsStr::new("yml"))
 }
 
 #[cfg(test)]

--- a/packages/nudge/src/rules.rs
+++ b/packages/nudge/src/rules.rs
@@ -28,7 +28,8 @@ pub fn project_dirs() -> Option<ProjectDirs> {
 /// 1. User-level rules from `ProjectDirs::config_dir()/rules.yaml` if it exists
 /// 2. `.nudge.yaml` if it exists
 /// 3. `.nudge.yml` if it exists
-/// 4. `.nudge/` directory walked recursively, loading all `*.yaml` and `*.yml` files
+/// 4. `.nudge/` directory walked recursively, loading all `*.yaml` and `*.yml`
+///    files
 #[tracing::instrument]
 pub fn load_all() -> Result<Vec<Rule>> {
     load_all_attributed()?
@@ -45,7 +46,8 @@ pub fn load_all() -> Result<Vec<Rule>> {
 /// 1. User-level rules from `ProjectDirs::config_dir()/rules.yaml` if it exists
 /// 2. `.nudge.yaml` if it exists
 /// 3. `.nudge.yml` if it exists
-/// 4. `.nudge/` directory walked recursively, loading all `*.yaml` and `*.yml` files
+/// 4. `.nudge/` directory walked recursively, loading all `*.yaml` and `*.yml`
+///    files
 #[tracing::instrument]
 pub fn load_all_attributed() -> Result<Vec<(PathBuf, Vec<Rule>)>> {
     load_all_configs_attributed().map(|configs| {

--- a/packages/nudge/src/rules/schema.rs
+++ b/packages/nudge/src/rules/schema.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Deserializer, Serialize, de};
 
 use crate::{
     fmap_match,
+    learn::LearnConfig,
     snippet::{Annotation, Match, Span},
     template,
 };
@@ -31,7 +32,12 @@ pub struct RuleConfig {
     pub version: MustBe!(1),
 
     /// The rules defined in this file.
+    #[serde(default)]
     pub rules: Vec<Rule>,
+
+    /// Learned-note retrieval configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub learn: Option<LearnConfig>,
 }
 
 /// A single rule definition.
@@ -416,6 +422,25 @@ mod tests {
         let result = serde_yaml::from_str::<RuleConfig>(yaml);
 
         assert!(result.is_err(), "unknown top-level fields must fail");
+    }
+
+    #[test]
+    fn rule_config_accepts_learn_only_config() {
+        let yaml = r#"
+            version: 1
+            learn:
+              embeddings:
+                enabled: true
+                model: BAAI/bge-small-en-v1.5
+        "#;
+
+        let config = serde_yaml::from_str::<RuleConfig>(yaml).expect("valid learn config");
+
+        assert!(config.rules.is_empty());
+        pretty_assert_eq!(
+            config.learn.expect("learn config").embeddings.model,
+            "BAAI/bge-small-en-v1.5"
+        );
     }
 
     #[test]

--- a/packages/nudge/src/rules/schema/content.rs
+++ b/packages/nudge/src/rules/schema/content.rs
@@ -626,6 +626,75 @@ mod tests {
 
     use super::*;
 
+    fn success_command() -> Vec<String> {
+        #[cfg(windows)]
+        {
+            vec![
+                String::from("cmd"),
+                String::from("/C"),
+                String::from("exit 0"),
+            ]
+        }
+
+        #[cfg(not(windows))]
+        {
+            vec![String::from("true")]
+        }
+    }
+
+    fn failure_command() -> Vec<String> {
+        #[cfg(windows)]
+        {
+            vec![
+                String::from("cmd"),
+                String::from("/C"),
+                String::from("exit 1"),
+            ]
+        }
+
+        #[cfg(not(windows))]
+        {
+            vec![String::from("false")]
+        }
+    }
+
+    fn status_one_command() -> Vec<String> {
+        #[cfg(windows)]
+        {
+            vec![
+                String::from("cmd"),
+                String::from("/C"),
+                String::from("exit 1"),
+            ]
+        }
+
+        #[cfg(not(windows))]
+        {
+            vec![
+                String::from("test"),
+                String::from("1"),
+                String::from("-eq"),
+                String::from("0"),
+            ]
+        }
+    }
+
+    fn stdin_contains_needle_command() -> Vec<String> {
+        #[cfg(windows)]
+        {
+            vec![String::from("findstr"), String::from("needle")]
+        }
+
+        #[cfg(not(windows))]
+        {
+            vec![
+                String::from("grep"),
+                String::from("-q"),
+                String::from("needle"),
+            ]
+        }
+    }
+
     #[test]
     fn test_content_matcher_syntax_tree_deserialize() {
         let yaml = r#"
@@ -913,7 +982,7 @@ mod tests {
     #[test]
     fn test_external_is_match_when_command_fails() {
         let matcher = ContentMatcher::External {
-            command: vec![String::from("false")],
+            command: failure_command(),
             timeout_ms: DEFAULT_EXTERNAL_COMMAND_TIMEOUT_MS,
         };
         assert!(matcher.is_match("any content"));
@@ -922,7 +991,7 @@ mod tests {
     #[test]
     fn test_external_is_not_match_when_command_succeeds() {
         let matcher = ContentMatcher::External {
-            command: vec![String::from("true")],
+            command: success_command(),
             timeout_ms: DEFAULT_EXTERNAL_COMMAND_TIMEOUT_MS,
         };
         assert!(!matcher.is_match("any content"));
@@ -930,45 +999,34 @@ mod tests {
 
     #[test]
     fn test_external_matches_with_context_sets_command_capture() {
+        let command = failure_command();
+        let formatted_command = shell_words::join(&command);
         let matcher = ContentMatcher::External {
-            command: vec![String::from("false")],
+            command,
             timeout_ms: DEFAULT_EXTERNAL_COMMAND_TIMEOUT_MS,
         };
         let matches = matcher.matches_with_context("content");
         pretty_assert_eq!(matches.len(), 1);
-        pretty_assert_eq!(
-            matches[0].captures.get("command"),
-            Some(&String::from("false"))
-        );
+        pretty_assert_eq!(matches[0].captures.get("command"), Some(&formatted_command));
     }
 
     #[test]
     fn test_external_matches_with_context_formats_command_with_args() {
+        let command = status_one_command();
+        let formatted_command = shell_words::join(&command);
         let matcher = ContentMatcher::External {
-            command: vec![
-                String::from("test"),
-                String::from("1"),
-                String::from("-eq"),
-                String::from("0"),
-            ],
+            command,
             timeout_ms: DEFAULT_EXTERNAL_COMMAND_TIMEOUT_MS,
         };
         let matches = matcher.matches_with_context("content");
         pretty_assert_eq!(matches.len(), 1);
-        pretty_assert_eq!(
-            matches[0].captures.get("command"),
-            Some(&String::from("test 1 -eq 0"))
-        );
+        pretty_assert_eq!(matches[0].captures.get("command"), Some(&formatted_command));
     }
 
     #[test]
     fn test_external_passes_content_to_stdin() {
         let matcher = ContentMatcher::External {
-            command: vec![
-                String::from("grep"),
-                String::from("-q"),
-                String::from("needle"),
-            ],
+            command: stdin_contains_needle_command(),
             timeout_ms: DEFAULT_EXTERNAL_COMMAND_TIMEOUT_MS,
         };
         assert!(!matcher.is_match("haystack with needle inside"));
@@ -978,7 +1036,7 @@ mod tests {
     #[test]
     fn test_external_zero_timeout_waits_without_bounding() {
         let matcher = ContentMatcher::External {
-            command: vec![String::from("true")],
+            command: success_command(),
             timeout_ms: 0,
         };
         assert!(!matcher.is_match("any content"));
@@ -987,7 +1045,7 @@ mod tests {
     #[test]
     fn test_external_matches_with_context_sets_status_capture() {
         let matcher = ContentMatcher::External {
-            command: vec![String::from("false")],
+            command: status_one_command(),
             timeout_ms: DEFAULT_EXTERNAL_COMMAND_TIMEOUT_MS,
         };
         let matches = matcher.matches_with_context("content");

--- a/packages/nudge/src/skills.rs
+++ b/packages/nudge/src/skills.rs
@@ -1,0 +1,65 @@
+//! Bundled Nudge skills.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use color_eyre::eyre::{Context, Result};
+use itertools::Itertools;
+
+pub const NUDGE_LEARNINGS_SKILL_NAME: &str = "nudge-learnings";
+
+pub struct BundledSkillFile {
+    pub path: &'static str,
+    pub content: &'static str,
+}
+
+const NUDGE_LEARNINGS_FILES: &[BundledSkillFile] = &[
+    BundledSkillFile {
+        path: "SKILL.md",
+        content: include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/skills/nudge-learnings/SKILL.md"
+        )),
+    },
+    BundledSkillFile {
+        path: "references/bm25.md",
+        content: include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/skills/nudge-learnings/references/bm25.md"
+        )),
+    },
+    BundledSkillFile {
+        path: "references/embeddings.md",
+        content: include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/skills/nudge-learnings/references/embeddings.md"
+        )),
+    },
+];
+
+pub fn nudge_learnings_files() -> &'static [BundledSkillFile] {
+    NUDGE_LEARNINGS_FILES
+}
+
+pub fn install_nudge_learnings_skill(skills_dir: &Path) -> Result<PathBuf> {
+    let skill_dir = skills_dir.join(NUDGE_LEARNINGS_SKILL_NAME);
+    for file in nudge_learnings_files() {
+        let path = skill_dir.join(file.path);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("create skill directory: {}", parent.display()))?;
+        }
+        fs::write(&path, file.content).with_context(|| format!("write {}", path.display()))?;
+    }
+
+    Ok(skill_dir)
+}
+
+pub fn render_nudge_learnings_docs() -> String {
+    nudge_learnings_files()
+        .iter()
+        .map(|file| format!("# {}\n\n{}", file.path, file.content.trim_end_matches('\n')))
+        .join("\n\n")
+}

--- a/packages/nudge/tests/it/check.rs
+++ b/packages/nudge/tests/it/check.rs
@@ -24,17 +24,41 @@ fn run_nudge_in_dir(dir: &TempDir, args: &[&str]) -> (i32, String, String) {
     (exit_code, stdout, stderr)
 }
 
+fn yaml_command(command: &[String]) -> String {
+    serde_json::to_string(command).expect("serialize command")
+}
+
+fn required_marker_command(marker: &str) -> Vec<String> {
+    #[cfg(windows)]
+    {
+        vec![String::from("findstr"), marker.to_string()]
+    }
+
+    #[cfg(not(windows))]
+    {
+        vec![String::from("grep"), String::from("-q"), marker.to_string()]
+    }
+}
+
+fn contains_path(output: &str, path: &str) -> bool {
+    output.contains(path) || output.contains(&path.replace('/', "\\"))
+}
+
 #[test]
 fn check_runs_file_rules_without_agent_provider() {
     let dir = TempDir::new().expect("create temp dir");
+    let approved_command = required_marker_command("APPROVED");
+    let approved_command_yaml = yaml_command(&approved_command);
+    let approved_command_display = shell_words::join(&approved_command);
     fs::write(
         dir.path().join(".nudge.yaml"),
-        r#"
+        format!(
+            r#"
 version: 1
 rules:
   - name: block-todo-write
     description: Block TODO markers in committed text files
-    message: "Resolve TODO `{{ $todo }}` before commit."
+    message: "Resolve TODO `{{{{ $todo }}}}` before commit."
     on:
       - hook: PreToolUse
         tool: Write
@@ -54,14 +78,14 @@ rules:
             pattern: "FIXME"
   - name: require-approved-marker
     description: Markdown release notes require an approval marker
-    message: "Add APPROVED marker. Verify with `{{ $command }}`."
+    message: "Add APPROVED marker. Verify with `{{{{ $command }}}}`."
     on:
       - hook: PreToolUse
         tool: Write
         file: "**/*.md"
         content:
           - kind: External
-            command: ["grep", "-q", "APPROVED"]
+            command: {approved_command_yaml}
   - name: ignored-bash-substitute
     action: substitute
     on:
@@ -86,7 +110,8 @@ rules:
         prompt:
           - kind: Regex
             pattern: "release"
-"#,
+"#
+        ),
     )
     .expect("write config");
 
@@ -121,7 +146,7 @@ rules:
         "check should fail for file-rule violations, stdout: {stdout}, stderr: {stderr}"
     );
     assert!(
-        stdout.contains("src/bad.txt:1 [block-todo-write]"),
+        contains_path(&stdout, "src/bad.txt:1 [block-todo-write]"),
         "expected Write regex issue with line number, got: {stdout}"
     );
     assert!(
@@ -129,15 +154,15 @@ rules:
         "expected regex capture interpolation, got: {stdout}"
     );
     assert!(
-        stdout.contains("src/bad.txt:2 [block-fixme-edit]"),
+        contains_path(&stdout, "src/bad.txt:2 [block-fixme-edit]"),
         "expected Edit regex issue with line number, got: {stdout}"
     );
     assert!(
-        stdout.contains("docs/bad.md:1 [require-approved-marker]"),
+        contains_path(&stdout, "docs/bad.md:1 [require-approved-marker]"),
         "expected External issue with line number, got: {stdout}"
     );
     assert!(
-        stdout.contains("Verify with `grep -q APPROVED`."),
+        stdout.contains(&format!("Verify with `{approved_command_display}`.")),
         "expected External command interpolation, got: {stdout}"
     );
     assert!(

--- a/packages/nudge/tests/it/external.rs
+++ b/packages/nudge/tests/it/external.rs
@@ -22,6 +22,63 @@ fn setup_config(rules_yaml: &str) -> TempDir {
     dir
 }
 
+fn yaml_command(command: &[String]) -> String {
+    serde_json::to_string(command).expect("serialize command")
+}
+
+fn required_marker_command(marker: &str) -> Vec<String> {
+    #[cfg(windows)]
+    {
+        vec![String::from("findstr"), marker.to_string()]
+    }
+
+    #[cfg(not(windows))]
+    {
+        vec![String::from("grep"), String::from("-q"), marker.to_string()]
+    }
+}
+
+fn no_fixme_command() -> Vec<String> {
+    #[cfg(windows)]
+    {
+        vec![
+            String::from("findstr"),
+            String::from("/V"),
+            String::from("FIXME"),
+        ]
+    }
+
+    #[cfg(not(windows))]
+    {
+        vec![
+            String::from("grep"),
+            String::from("-qv"),
+            String::from("FIXME"),
+        ]
+    }
+}
+
+fn slow_command() -> Vec<String> {
+    #[cfg(windows)]
+    {
+        vec![
+            String::from("powershell.exe"),
+            String::from("-NoProfile"),
+            String::from("-Command"),
+            String::from("Start-Sleep -Seconds 20"),
+        ]
+    }
+
+    #[cfg(not(windows))]
+    {
+        vec![
+            String::from("sh"),
+            String::from("-c"),
+            String::from("sleep 20"),
+        ]
+    }
+}
+
 /// Run nudge claude hook with the given input JSON in the specified directory.
 fn run_hook_in_dir(dir: &TempDir, input: &str) -> (i32, String) {
     let mut child = Command::new(nudge_binary())
@@ -75,25 +132,28 @@ fn write_hook(file_path: &str, content: &str) -> String {
 
 #[test]
 fn test_external_triggers_when_command_fails() {
+    let command = yaml_command(&required_marker_command("REQUIRED"));
     // grep -q exits 1 when pattern is NOT found, 0 when found
     // So we want to trigger when "FORBIDDEN" is NOT in the content
     // i.e., we want to block content that doesn't contain "REQUIRED"
-    let config = r#"
+    let config = format!(
+        r#"
 version: 1
 rules:
   - name: require-header
     description: Require REQUIRED marker in file
-    message: "File must contain REQUIRED marker. Run `{{ $command }}` to verify."
+    message: "File must contain REQUIRED marker. Run `{{{{ $command }}}}` to verify."
     on:
       - hook: PreToolUse
         tool: Write
         file: "**/*.txt"
         content:
           - kind: External
-            command: ["grep", "-q", "REQUIRED"]
-"#;
+            command: {command}
+"#
+    );
 
-    let dir = setup_config(config);
+    let dir = setup_config(&config);
 
     // Content WITHOUT "REQUIRED" - grep fails (exit 1), rule triggers
     let input = write_hook("test.txt", "This file has no marker");
@@ -112,7 +172,9 @@ rules:
 
 #[test]
 fn test_external_passes_when_command_succeeds() {
-    let config = r#"
+    let command = yaml_command(&required_marker_command("REQUIRED"));
+    let config = format!(
+        r#"
 version: 1
 rules:
   - name: require-header
@@ -124,10 +186,11 @@ rules:
         file: "**/*.txt"
         content:
           - kind: External
-            command: ["grep", "-q", "REQUIRED"]
-"#;
+            command: {command}
+"#
+    );
 
-    let dir = setup_config(config);
+    let dir = setup_config(&config);
 
     // Content WITH "REQUIRED" - grep succeeds (exit 0), rule passes
     let input = write_hook("test.txt", "This file has REQUIRED marker");
@@ -142,22 +205,27 @@ rules:
 
 #[test]
 fn test_external_command_capture_interpolation() {
-    let config = r#"
+    let command = no_fixme_command();
+    let expected_command = shell_words::join(&command);
+    let command = yaml_command(&command);
+    let config = format!(
+        r#"
 version: 1
 rules:
   - name: no-fixme
     description: Block FIXME comments
-    message: "Remove FIXME comments. Debug with: {{ $command }}"
+    message: "Remove FIXME comments. Debug with: {{{{ $command }}}}"
     on:
       - hook: PreToolUse
         tool: Write
         file: "**/*.rs"
         content:
           - kind: External
-            command: ["grep", "-qv", "FIXME"]
-"#;
+            command: {command}
+"#
+    );
 
-    let dir = setup_config(config);
+    let dir = setup_config(&config);
 
     // grep -qv exits 1 if pattern IS found (inverted match)
     let input = write_hook("test.rs", "// FIXME: fix this later");
@@ -170,14 +238,16 @@ rules:
     );
     // Check that $command was interpolated
     assert!(
-        output.contains("grep -qv FIXME"),
+        output.contains(&expected_command),
         "expected command to be interpolated in message, got: {output}"
     );
 }
 
 #[test]
 fn test_external_file_pattern_filtering() {
-    let config = r#"
+    let command = yaml_command(&required_marker_command("HEADER"));
+    let config = format!(
+        r#"
 version: 1
 rules:
   - name: require-header
@@ -189,10 +259,11 @@ rules:
         file: "**/*.txt"
         content:
           - kind: External
-            command: ["grep", "-q", "HEADER"]
-"#;
+            command: {command}
+"#
+    );
 
-    let dir = setup_config(config);
+    let dir = setup_config(&config);
 
     // .rs file should not be checked (file pattern doesn't match)
     let input = write_hook("test.rs", "No header here");
@@ -244,23 +315,26 @@ rules:
 
 #[test]
 fn test_external_timeout_interrupts_promptly() {
-    let config = r#"
+    let command = yaml_command(&slow_command());
+    let config = format!(
+        r#"
 version: 1
 rules:
   - name: external-command-timeout
     description: External command must finish promptly
-    message: "External check failed: {{ $external_status }}. Command: {{ $command }}"
+    message: "External check failed: {{{{ $external_status }}}}. Command: {{{{ $command }}}}"
     on:
       - hook: PreToolUse
         tool: Write
         file: "**/*.txt"
         content:
           - kind: External
-            command: ["sh", "-c", "sleep 20"]
+            command: {command}
             timeout_ms: 100
-"#;
+"#
+    );
 
-    let dir = setup_config(config);
+    let dir = setup_config(&config);
 
     let input = write_hook("test.txt", "Any content");
     let started = Instant::now();

--- a/packages/nudge/tests/it/learn.rs
+++ b/packages/nudge/tests/it/learn.rs
@@ -132,3 +132,72 @@ fn user_prompt_hook_injects_relevant_learned_context() {
         "hook context should include the fix excerpt, got: {stdout}"
     );
 }
+
+#[test]
+fn learn_embeddings_enable_writes_project_config_without_reindex() {
+    let temp = TempDir::new().expect("temp dir");
+
+    let (exit_code, stdout, stderr) = run_nudge_in(
+        temp.path(),
+        &[
+            "learn",
+            "embeddings",
+            "enable",
+            "--model",
+            "BAAI/bge-small-en-v1.5",
+            "--no-reindex",
+        ],
+        None,
+    );
+
+    pretty_assert_eq!(exit_code, 0, "enable failed: {stderr}");
+    assert!(
+        stdout.contains("Enabled local learned-note embeddings"),
+        "enable should report config update, got: {stdout}"
+    );
+
+    let config = fs::read_to_string(temp.path().join(".nudge.yaml")).expect("read config");
+    assert!(
+        config.contains("learn:") && config.contains("enabled: true"),
+        "config should enable embeddings, got: {config}"
+    );
+    assert!(
+        config.contains("model: BGESmallENV15"),
+        "config should store the canonical model, got: {config}"
+    );
+
+    let (exit_code, stdout, stderr) =
+        run_nudge_in(temp.path(), &["learn", "embeddings", "status"], None);
+
+    pretty_assert_eq!(exit_code, 0, "status failed: {stderr}");
+    assert!(
+        stdout.contains("Embeddings: enabled") && stdout.contains("BGESmallENV15"),
+        "status should report enabled model, got: {stdout}"
+    );
+}
+
+#[test]
+fn learn_embeddings_status_reads_nudge_yml() {
+    let temp = TempDir::new().expect("temp dir");
+    fs::write(
+        temp.path().join(".nudge.yml"),
+        r#"
+version: 1
+rules: []
+learn:
+  embeddings:
+    enabled: true
+    model: all-MiniLM-L6-v2
+"#,
+    )
+    .expect("write config");
+
+    let (exit_code, stdout, stderr) =
+        run_nudge_in(temp.path(), &["learn", "embeddings", "status"], None);
+
+    pretty_assert_eq!(exit_code, 0, "status failed: {stderr}");
+    assert!(
+        stdout.contains("Embeddings: enabled") && stdout.contains("all-MiniLM-L6-v2"),
+        "status should read .nudge.yml learn config, got: {stdout}"
+    );
+}

--- a/packages/nudge/tests/it/learn.rs
+++ b/packages/nudge/tests/it/learn.rs
@@ -1,0 +1,134 @@
+//! Learned repo knowledge tests.
+
+use std::{
+    fs,
+    io::Write as _,
+    path::Path,
+    process::{Command, Stdio},
+};
+
+use crate::nudge_binary;
+use pretty_assertions::assert_eq as pretty_assert_eq;
+use serde_json::json;
+use tempfile::TempDir;
+
+fn run_nudge_in(root: &Path, args: &[&str], stdin: Option<&str>) -> (i32, String, String) {
+    let mut child = Command::new(nudge_binary())
+        .args(args)
+        .current_dir(root)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn nudge");
+
+    if let Some(stdin) = stdin {
+        child
+            .stdin
+            .as_mut()
+            .expect("stdin")
+            .write_all(stdin.as_bytes())
+            .expect("write stdin");
+    }
+    drop(child.stdin.take());
+
+    let output = child.wait_with_output().expect("wait for nudge");
+
+    (
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
+}
+
+#[test]
+fn learn_add_list_and_search_round_trip() {
+    let temp = TempDir::new().expect("temp dir");
+
+    let (exit_code, stdout, stderr) = run_nudge_in(
+        temp.path(),
+        &[
+            "learn",
+            "add",
+            "--title",
+            "Expo Metro resolver cache",
+            "--body",
+            "What went wrong: Expo could not resolve modules after a dependency update.\n\nFix: clear the Metro cache and restart the dev server.",
+        ],
+        None,
+    );
+    pretty_assert_eq!(exit_code, 0, "add failed: {stderr}");
+    assert!(
+        stdout.contains(".nudge") && stdout.contains("expo-metro-resolver-cache.md"),
+        "add should report created note path, got: {stdout}"
+    );
+    assert!(
+        temp.path()
+            .join(".nudge/learned/expo-metro-resolver-cache.md")
+            .exists(),
+        "learn add should create the note"
+    );
+
+    let (exit_code, stdout, stderr) = run_nudge_in(temp.path(), &["learn", "list"], None);
+    pretty_assert_eq!(exit_code, 0, "list failed: {stderr}");
+    assert!(
+        stdout.contains("Expo Metro resolver cache"),
+        "list should include note title, got: {stdout}"
+    );
+
+    let (exit_code, stdout, stderr) = run_nudge_in(
+        temp.path(),
+        &[
+            "learn", "search", "expo", "cannot", "resolve", "module", "metro",
+        ],
+        None,
+    );
+    pretty_assert_eq!(exit_code, 0, "search failed: {stderr}");
+    assert!(
+        stdout.contains("Expo Metro resolver cache"),
+        "search should find the learned incident, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("clear the Metro cache"),
+        "search should show a useful excerpt, got: {stdout}"
+    );
+}
+
+#[test]
+fn user_prompt_hook_injects_relevant_learned_context() {
+    let temp = TempDir::new().expect("temp dir");
+    let learned_dir = temp.path().join(".nudge/learned");
+    fs::create_dir_all(&learned_dir).expect("create learned dir");
+    fs::write(
+        learned_dir.join("expo-metro-resolver-cache.md"),
+        "# Expo Metro resolver cache\n\nWhat went wrong: Expo could not resolve modules after a dependency update.\n\nFix: clear the Metro cache and restart the dev server.\n\nVerification: expo start completed and the app loaded.",
+    )
+    .expect("write learned note");
+
+    let payload = json!({
+        "hook_event_name": "UserPromptSubmit",
+        "session_id": "test",
+        "transcript_path": temp.path().join("transcript.jsonl"),
+        "permission_mode": "default",
+        "cwd": temp.path(),
+        "prompt": "Expo is failing again after a dependency update and Metro says it cannot resolve a module."
+    })
+    .to_string();
+
+    let (exit_code, stdout, stderr) =
+        run_nudge_in(temp.path(), &["claude", "hook"], Some(&payload));
+
+    pretty_assert_eq!(exit_code, 0, "hook failed: {stderr}");
+    assert!(
+        stdout.contains("Nudge found learned repo knowledge"),
+        "hook should inject learned context, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Expo Metro resolver cache"),
+        "hook context should mention the learned note, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("clear the Metro cache"),
+        "hook context should include the fix excerpt, got: {stdout}"
+    );
+}

--- a/packages/nudge/tests/it/main.rs
+++ b/packages/nudge/tests/it/main.rs
@@ -20,6 +20,7 @@ mod message_content;
 mod multiple_rules;
 mod non_rust_files;
 mod setup;
+mod skills;
 mod syntax_tree;
 mod user_prompt;
 mod webfetch;

--- a/packages/nudge/tests/it/main.rs
+++ b/packages/nudge/tests/it/main.rs
@@ -14,6 +14,7 @@ mod edit_tool;
 mod external;
 mod inline_imports;
 mod install_script;
+mod learn;
 mod markdown_target;
 mod message_content;
 mod multiple_rules;

--- a/packages/nudge/tests/it/setup.rs
+++ b/packages/nudge/tests/it/setup.rs
@@ -62,6 +62,10 @@ fn claude_setup_help_mentions_settings_local_json() {
         !stdout.contains(".claude/hooks"),
         "help should not mention stale .claude/hooks path, got: {stdout}"
     );
+    assert!(
+        stdout.contains("--skip-skills"),
+        "help should mention skill install opt-out, got: {stdout}"
+    );
 }
 
 fn run_built_nudge_in(dir: &TempDir, args: &[&str]) -> (i32, String, String) {
@@ -81,6 +85,19 @@ fn run_built_nudge_in(dir: &TempDir, args: &[&str]) -> (i32, String, String) {
         String::from_utf8_lossy(&output.stdout).to_string(),
         String::from_utf8_lossy(&output.stderr).to_string(),
     )
+}
+
+fn assert_learnings_skill_installed(skill_dir: &Path) {
+    let skill = fs::read_to_string(skill_dir.join("SKILL.md")).expect("read SKILL.md");
+    let bm25 = fs::read_to_string(skill_dir.join("references/bm25.md")).expect("read bm25");
+    let embeddings =
+        fs::read_to_string(skill_dir.join("references/embeddings.md")).expect("read embeddings");
+
+    assert!(skill.contains("name: nudge-learnings"));
+    assert!(skill.contains("references/bm25.md"));
+    assert!(skill.contains("references/embeddings.md"));
+    assert!(bm25.contains("BM25 lexical search"));
+    assert!(embeddings.contains("hybrid retrieval"));
 }
 
 #[test]
@@ -106,6 +123,11 @@ fn claude_setup_is_idempotent_and_installs_only_handled_events() {
         !temp.path().join(".claude/settings.local.json.bak").exists(),
         "fresh setup should not create a backup"
     );
+    assert!(
+        stdout.contains("Installed nudge-learnings skill"),
+        "fresh setup should install bundled skills, got: {stdout}"
+    );
+    assert_learnings_skill_installed(&temp.path().join(".claude/skills/nudge-learnings"));
     let first =
         fs::read_to_string(temp.path().join(".claude/settings.local.json")).expect("read settings");
 
@@ -269,6 +291,11 @@ fn codex_setup_creates_hooks_json_and_is_idempotent() {
         !temp.path().join(".codex/hooks.json.bak").exists(),
         "fresh setup should not create a backup"
     );
+    assert!(
+        stdout.contains("Installed nudge-learnings skill"),
+        "fresh setup should install bundled skills, got: {stdout}"
+    );
+    assert_learnings_skill_installed(&temp.path().join(".agents/skills/nudge-learnings"));
     let first = fs::read_to_string(temp.path().join(".codex/hooks.json")).expect("read hooks");
 
     let (exit_code, _, stderr) = run_nudge(&args);
@@ -432,6 +459,7 @@ fn codex_setup_warns_and_skips_inline_toml_hooks() {
         !codex_dir.join("hooks.json").exists(),
         "setup should skip hooks.json when inline hooks exist"
     );
+    assert_learnings_skill_installed(&temp.path().join(".agents/skills/nudge-learnings"));
 }
 
 #[test]

--- a/packages/nudge/tests/it/skills.rs
+++ b/packages/nudge/tests/it/skills.rs
@@ -1,0 +1,81 @@
+//! Bundled skill installation tests.
+
+use std::{fs, path::Path, process::Command};
+
+use crate::{nudge_binary, run_nudge};
+use pretty_assertions::assert_eq as pretty_assert_eq;
+use tempfile::TempDir;
+
+fn run_nudge_in(root: &Path, args: &[&str]) -> (i32, String, String) {
+    let output = Command::new(nudge_binary())
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("run nudge");
+
+    (
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
+}
+
+#[test]
+fn learn_docs_prints_bundled_learnings_skill() {
+    let (exit_code, stdout, stderr) = run_nudge(&["learn", "docs"]);
+
+    pretty_assert_eq!(exit_code, 0, "learn docs failed: {stderr}");
+    assert!(
+        stdout.contains("# SKILL.md")
+            && stdout.contains("name: nudge-learnings")
+            && stdout.contains("references/bm25.md")
+            && stdout.contains("references/embeddings.md"),
+        "learn docs should print the bundled skill files, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("nudge learn embeddings status"),
+        "learn docs should include retrieval-mode guidance, got: {stdout}"
+    );
+}
+
+#[test]
+fn claude_skills_install_writes_progressive_learnings_skill() {
+    let temp = TempDir::new().expect("temp dir");
+
+    let (exit_code, stdout, stderr) = run_nudge_in(temp.path(), &["claude", "skills", "install"]);
+
+    pretty_assert_eq!(exit_code, 0, "skill install failed: {stderr}");
+    assert!(
+        stdout.contains("Installed nudge-learnings skill"),
+        "install should report destination, got: {stdout}"
+    );
+
+    let skill_dir = temp.path().join(".claude/skills/nudge-learnings");
+    let skill = fs::read_to_string(skill_dir.join("SKILL.md")).expect("read SKILL.md");
+    let bm25 = fs::read_to_string(skill_dir.join("references/bm25.md")).expect("read bm25");
+    let embeddings =
+        fs::read_to_string(skill_dir.join("references/embeddings.md")).expect("read embeddings");
+
+    assert!(skill.contains("references/bm25.md"));
+    assert!(skill.contains("references/embeddings.md"));
+    assert!(bm25.contains("BM25 lexical search"));
+    assert!(embeddings.contains("hybrid retrieval"));
+}
+
+#[test]
+fn codex_skills_install_writes_agents_learnings_skill() {
+    let temp = TempDir::new().expect("temp dir");
+
+    let (exit_code, stdout, stderr) = run_nudge_in(temp.path(), &["codex", "skills", "install"]);
+
+    pretty_assert_eq!(exit_code, 0, "skill install failed: {stderr}");
+    assert!(
+        stdout.contains("Installed nudge-learnings skill"),
+        "install should report destination, got: {stdout}"
+    );
+
+    let skill_dir = temp.path().join(".agents/skills/nudge-learnings");
+    assert!(skill_dir.join("SKILL.md").exists());
+    assert!(skill_dir.join("references/bm25.md").exists());
+    assert!(skill_dir.join("references/embeddings.md").exists());
+}

--- a/packages/nudge/tests/it/syntax_tree/javascript.rs
+++ b/packages/nudge/tests/it/syntax_tree/javascript.rs
@@ -214,7 +214,8 @@ fn test_javascript_syntax_tree_check_scans_js_files() {
         "expected check to report JavaScript issue, stdout: {stdout}, stderr: {stderr}"
     );
     assert!(
-        stdout.contains("src/bad.js:2 [no-loose-equality-js]"),
+        stdout.contains("src/bad.js:2 [no-loose-equality-js]")
+            || stdout.contains("src\\bad.js:2 [no-loose-equality-js]"),
         "expected check to report bad.js line 2, got: {stdout}"
     );
     assert!(

--- a/packages/nudge/tests/it/syntax_tree/typescript_end_to_end.rs
+++ b/packages/nudge/tests/it/syntax_tree/typescript_end_to_end.rs
@@ -156,7 +156,8 @@ rules:
 
     pretty_assert_eq!(exit_code, 1, "expected check to fail, output: {output}");
     assert!(
-        output.contains("src/user.ts:2 [no-exported-interfaces]"),
+        output.contains("src/user.ts:2 [no-exported-interfaces]")
+            || output.contains("src\\user.ts:2 [no-exported-interfaces]"),
         "expected TypeScript issue on the interface line, got: {output}"
     );
     assert!(


### PR DESCRIPTION
## Why this change

Nudge now supports repo-local learned incident notes so agents can avoid rediscovering bugs that another session already solved. The feature starts with plain Markdown notes in `.nudge/learned`, BM25 search, and proactive hook context. It also adds config-controlled local embeddings for semantic retrieval in release binaries, plus a bundled `nudge-learnings` skill so Claude/Codex agents know how to search, apply, and record learnings.

This turns Nudge into a lightweight repo-local "we have seen this before" layer: what went wrong, how it was fixed, and how we verified it becomes reusable context for future agents.

## What changed

- Added `nudge learn add/list/search/docs` and learned-note hook context injection.
- Added `learn.embeddings.enabled` config in `.nudge.yaml` / `.nudge.yml` and local FastEmbed hybrid retrieval.
- Stored embedding model files and vector indexes in the user-level Nudge cache instead of the repo.
- Added `nudge learn embeddings enable/status/reindex`.
- Added a bundled `nudge-learnings` skill with progressive disclosure:
  - `SKILL.md` routes based on `nudge learn embeddings status`.
  - `references/bm25.md` covers BM25-only projects.
  - `references/embeddings.md` covers local-embedding projects.
- Added `nudge claude skills install` and `nudge codex skills install`.
- Made `nudge claude setup` and `nudge codex setup` install the bundled learnings skill by default, with `--skip-skills` as an opt-out.
- Fixed a dogfood-discovered excerpt bug where Markdown notes using `## Fix` headings surfaced only the heading instead of the fix body.

## Testing Steps Performed

### Deterministic Throwaway-Repo E2E

Created a temporary git repo with `.nudge/learned/expo-metro-resolver-cache.md`, then ran the branch binary through the full packaging path:

```powershell
cargo build -p nudge
nudge learn docs
nudge claude skills install
nudge codex skills install
nudge learn search expo cannot resolve module metro
nudge learn embeddings enable --model BAAI/bge-small-en-v1.5 --no-reindex
nudge learn embeddings status
```

Key output:

```json
{
  "TempRepo": "C:\\Users\\me\\AppData\\Local\\Temp\\nudge-learnings-e2e-c659b6dd53cc470cba701a0fa3e9bf6a",
  "LearnDocsLines": 166,
  "ClaudeInstall": "Installed nudge-learnings skill to .claude\\skills\\nudge-learnings. Use this skill when Nudge surfaces learned repo knowledge or after fixing a repo-specific issue worth recording.",
  "CodexInstall": "Installed nudge-learnings skill to .agents\\skills\\nudge-learnings. Use this skill when Nudge surfaces learned repo knowledge or after fixing a repo-specific issue worth recording.",
  "Bm25SearchFirstLine": "1. Expo Metro resolver cache",
  "EmbeddingsStatus": "Embeddings: enabled | Model: BGESmallENV15"
}
```

How we know the correct action was taken:

- `nudge learn docs` printed the bundled skill content, including `name: nudge-learnings`, `references/bm25.md`, and `references/embeddings.md`.
- Both installed skill directories were checked byte-for-byte against `packages/nudge/skills/nudge-learnings`.
- BM25 search returned the expected Expo learned note.
- After the excerpt fix, the search excerpt included the actionable fix body: `Fix: Clear the Metro cache and restart the dev server.`
- Embeddings config reported enabled and canonicalized the model to `BGESmallENV15` without downloading the model because the test used `--no-reindex`.

### Actual Local Embeddings Smoke

The deterministic E2E above intentionally used `--no-reindex`, so I also ran a real local-embedding smoke in a fresh temporary project. This path initializes the FastEmbed model from the user-level cache, builds the vector index, embeds the query during search, and reindexes.

```powershell
cargo build -p nudge
nudge learn add --title "Expo Metro resolver cache" --body "<expo note>"
nudge learn add --title "Android Gradle daemon heap" --body "<android note>"
nudge learn search react app bundler cannot find new library --limit 3
nudge learn embeddings status
nudge learn embeddings enable --model BAAI/bge-small-en-v1.5
nudge learn embeddings status
nudge learn search react app bundler cannot find new library --limit 3
nudge learn embeddings reindex
nudge learn embeddings status
```

Key output:

```json
{
  "TempRepo": "C:\\Users\\me\\AppData\\Local\\Temp\\nudge-embeddings-smoke-685b2e3042504049a0aa568a2d11ad20",
  "Query": "react app bundler cannot find new library",
  "DisabledSearch": "No learned notes matched the query.",
  "Enable": [
    "Enabled local learned-note embeddings in .nudge.yaml.",
    "Built learned-note vector index with 4 chunks using BGESmallENV15.",
    "Model cache: C:\\Users\\me\\AppData\\Local\\attunehq\\nudge\\cache\\learn\\models",
    "Vector index: C:\\Users\\me\\AppData\\Local\\attunehq\\nudge\\cache\\learn\\vectors\\9c824d051227ff66f523095321e456d55ad463dade4270549ac18c076360cc1d.json"
  ],
  "StatusAfter": [
    "Embeddings: enabled",
    "Model: BGESmallENV15",
    "Vectors: 4"
  ],
  "SemanticSearchFirstResult": "1. Expo Metro resolver cache",
  "ModelCacheFileCount": 11,
  "VectorIndexExists": true,
  "VectorChunkCount": 4,
  "Reindex": "Built learned-note vector index with 4 chunks using BGESmallENV15."
}
```

How we know embeddings actually worked:

- The same synonym query returned `No learned notes matched the query.` before embeddings were enabled, so BM25 alone did not find the note.
- `nudge learn embeddings enable` built a vector index with 4 chunks and canonicalized `BAAI/bge-small-en-v1.5` to `BGESmallENV15`.
- `nudge learn embeddings status` reported `Embeddings: enabled` and `Vectors: 4`.
- The model cache directory contained 11 files under the OS-specific user-level Nudge cache.
- The vector index JSON existed in the user-level vector cache and contained 4 chunks.
- The same synonym query then ranked `Expo Metro resolver cache` first, exercising query embedding plus hybrid retrieval.
- `nudge learn embeddings reindex` rebuilt the same 4-vector index successfully.
### Default Setup Installs Skills

After making setup install skills by default, I ran a manual temp-repo smoke with the branch binary:

```powershell
cargo build -p nudge
nudge claude setup --skip-claude-md
nudge codex setup
```

Key output:

```json
{
  "TempRepo": "C:\\Users\\me\\AppData\\Local\\Temp\\nudge-setup-skills-smoke-d0525e40d11b4cf7b48fcf9ce57f03ff",
  "ClaudeSetup": "Wrote hooks configuration to ...\\.claude\\settings.local.json | Installed nudge-learnings skill to ...\\.claude\\skills\\nudge-learnings. | ... | Restart Claude Code so hooks and skills are loaded",
  "CodexSetup": "Installed nudge-learnings skill to ...\\.agents\\skills\\nudge-learnings. | Wrote hooks configuration to ...\\.codex\\hooks.json | ... | The bundled Nudge learnings skill will load in new Codex sessions.",
  "ClaudeSkill": true,
  "CodexSkill": true
}
```

How we know the correct action was taken:

- Claude setup wrote `.claude/settings.local.json` and `.claude/skills/nudge-learnings/SKILL.md`.
- Codex setup wrote `.codex/hooks.json` and `.agents/skills/nudge-learnings/SKILL.md`.
- Setup integration tests assert the installed `SKILL.md`, `references/bm25.md`, and `references/embeddings.md` contents for fresh Claude and Codex setup.
- The Codex inline-TOML skip test also asserts `.agents/skills/nudge-learnings` is installed even when hook setup skips `hooks.json`.

### Actual Codex CLI Dogfood

Created a fresh throwaway repo, installed `.agents/skills/nudge-learnings`, put the branch `target/debug` binary first on `PATH`, and ran:

```powershell
codex exec --cd <temp-repo> --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust --ephemeral --output-last-message <file> "<dogfood prompt>"
```

The prompt asked Codex to use Nudge learnings if relevant, check embeddings status, search notes, report the fix, and record a new note titled `Codex dogfood skill check`.

Key output from Codex:

```text
Used the installed `nudge-learnings` skill. Local Nudge embeddings are disabled, so BM25 search was used.

Relevant fix found: Expo/Metro can reuse stale resolver state after a dependency update. Clear the Metro cache and restart the Expo dev server, typically with `expo start -c` or `npx expo start -c`.

Added note: codex-dogfood-skill-check.md
```

Commands Codex reported running:

```powershell
Get-Content -Raw "...\.agents\skills\nudge-learnings\SKILL.md"
nudge learn embeddings status
Get-Content -Raw "...\.agents\skills\nudge-learnings\references\bm25.md"
nudge learn search expo metro cannot resolve module dependency update
Get-Content -Raw ".nudge\learned\expo-metro-resolver-cache.md"
nudge learn add --title "Codex dogfood skill check" --body "..."
```

How we know the correct action was taken:

- Codex read the installed skill router file.
- It ran `nudge learn embeddings status`, saw embeddings were disabled, and read `references/bm25.md`.
- It used BM25-style concrete query terms.
- Search output included the expected note and fix excerpt.
- The temp repo contained both `expo-metro-resolver-cache.md` and the newly added `codex-dogfood-skill-check.md`.

### Actual Claude Code Dogfood

Created another fresh throwaway repo, installed `.claude/skills/nudge-learnings`, put the branch `target/debug` binary first on `PATH`, and ran:

```powershell
claude --print --permission-mode bypassPermissions --dangerously-skip-permissions --no-session-persistence --output-format text "<dogfood prompt>"
```

The prompt asked Claude to use the installed skill, check embeddings, search notes, report the fix, and add `Claude dogfood skill check`.

Key output from Claude:

```text
Local Nudge embeddings status: Disabled. `nudge learn embeddings status` reported `Embeddings: disabled` with `Vectors: 0`, and `.nudge.yaml` has no `learn.embeddings.enabled`. Retrieval therefore uses BM25 lexical search over `.nudge/learned/*.md`.

`nudge learn search expo metro cannot resolve module` surfaced one matching note:
- `.nudge/learned/expo-metro-resolver-cache.md` - "Expo Metro resolver cache"

The note matches this scenario exactly. After a dependency update, Metro reuses stale resolver state and keeps reporting a missing module. The fix: Clear the Metro cache and restart the dev server.

Added via `nudge learn add` - titled "Claude dogfood skill check".
```

Commands Claude reported running:

```text
nudge learn embeddings status
nudge learn search expo metro cannot resolve module
nudge learn list
nudge learn add --title "Claude dogfood skill check" --body "..."
```

How we know the correct action was taken:

- Claude identified embeddings were disabled and used BM25.
- It found the correct Expo note.
- It reported the correct fix.
- The temp repo contained both `expo-metro-resolver-cache.md` and `claude-dogfood-skill-check.md`.

### Unit And Integration Suite

Focused checks:

```powershell
cargo test -p nudge learn -- --nocapture
cargo test -p nudge skills -- --nocapture
cargo test -p nudge setup -- --nocapture
```

Full suite:

```powershell
cargo test -p nudge
```

Final full-suite result:

```text
111 passed; 0 failed; 0 ignored
3 passed; 0 failed; 0 ignored
140 passed; 0 failed; 0 ignored
1 doc-test passed; 0 failed
```

Skill validation:

```powershell
quick_validate.py packages\nudge\skills\nudge-learnings
```

Output:

```text
Skill is valid!
```

I also ran an ASCII typography scan over touched files to ensure no smart quotes or em dashes slipped into docs or skill files.

## Configuration Changes After Merge

No migration is required. Existing projects continue to use BM25 learned-note retrieval by default.

To opt into semantic retrieval in a project:

```bash
nudge learn embeddings enable
```

This writes `learn.embeddings.enabled: true` in `.nudge.yaml` or `.nudge.yml`, downloads the local embedding model into the OS-specific user-level Nudge cache, and builds the project vector cache. The generated model files and vector indexes are intentionally not stored in the repo.

Agent guidance is installed by default during setup:

```bash
nudge claude setup
nudge codex setup
```

Claude setup installs `.claude/skills/nudge-learnings`. Codex setup installs `.agents/skills/nudge-learnings`. The standalone `nudge claude skills install` and `nudge codex skills install` commands remain available when only the skill files need to be reinstalled.

## Notes

The Codex and Claude dogfood runs intentionally used real command-line agents rather than only unit tests. That caught the `## Fix` excerpt issue before merge, and this PR includes the fix plus a unit test for that note style.

Co-authored-by: Codex <noreply@openai.com>