### PR TITLE
Fix release builds with optional embeddings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,11 +102,14 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    # macOS builds (both targets on macos-latest via --target)
+                    # macOS builds (both targets on macos-latest via --target).
+                    # ONNX Runtime does not publish binaries for x64 macOS in
+                    # the current feature set, so that artifact keeps BM25
+                    # learn search and omits semantic embeddings.
                     - target: x86_64-apple-darwin
                       runner: macos-latest
                       cross: false
-                      embeddings: true
+                      embeddings: false
                     - target: aarch64-apple-darwin
                       runner: macos-latest
                       cross: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,21 @@
 # Build and publish nudge releases to GitHub Releases.
 #
-# Triggered on version tags (v*). Builds binaries for all supported platforms
-# in parallel on native runners, then creates a draft GitHub Release.
+# Triggered on pull requests, main pushes, manual dry runs, and version tags
+# (v*). Builds binaries for all supported platforms in parallel on native
+# runners. Tag builds additionally sign/notarize macOS binaries and create a
+# draft GitHub Release.
 #
 # The release is created as a draft so it can be reviewed and published
 # manually when ready.
 name: Release
 
 on:
+    pull_request:
+        branches: [main]
+    merge_group:
+        types: [checks_requested]
     push:
+        branches: [main]
         tags:
             - "v*"
     workflow_dispatch:
@@ -33,6 +40,7 @@ jobs:
             version: ${{ steps.version.outputs.version }}
             tag: ${{ steps.version.outputs.tag }}
             prerelease: ${{ steps.version.outputs.prerelease }}
+            publish: ${{ steps.version.outputs.publish }}
         steps:
             - uses: actions/checkout@v4
               with:
@@ -40,17 +48,32 @@ jobs:
 
             - name: Extract version from tag
               id: version
+              env:
+                  DRY_RUN_INPUT: ${{ inputs.dry_run || 'false' }}
+                  EVENT_NAME: ${{ github.event_name }}
+                  REF: ${{ github.ref }}
+                  REF_NAME: ${{ github.ref_name }}
               run: |
-                  if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-                    TAG="${{ github.ref_name }}"
+                  PUBLISH=false
+
+                  if [[ "$DRY_RUN_INPUT" == "true" ]]; then
+                    if [[ "$REF" == refs/tags/v* ]]; then
+                      TAG="$REF_NAME"
+                    else
+                      TAG=$(git describe --always --tags)
+                    fi
                     VERSION="${TAG#v}"
-                  elif [[ "${{ inputs.dry_run }}" == "true" ]]; then
-                    # Allow dry runs on any branch using git describe
+                    echo "::notice::Dry run using version: $TAG"
+                  elif [[ "$REF" == refs/tags/v* ]]; then
+                    TAG="$REF_NAME"
+                    VERSION="${TAG#v}"
+                    PUBLISH=true
+                  elif [[ "$EVENT_NAME" == "pull_request" || "$EVENT_NAME" == "merge_group" || "$REF" == "refs/heads/main" ]]; then
                     TAG=$(git describe --always --tags)
                     VERSION="${TAG#v}"
-                    echo "::notice::Dry run on non-tag ref, using git describe version: $TAG"
+                    echo "::notice::Release dry run using version: $TAG"
                   else
-                    echo "::error::Release workflow must be triggered by a version tag (v*)"
+                    echo "::error::Release workflow must be triggered by a version tag (v*) unless it is a dry run"
                     exit 1
                   fi
 
@@ -61,10 +84,13 @@ jobs:
                     PRERELEASE=true
                   fi
 
-                  echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-                  echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-                  echo "prerelease=${PRERELEASE}" >> "$GITHUB_OUTPUT"
-                  echo "Releasing version: ${VERSION} (prerelease: ${PRERELEASE})"
+                  {
+                    echo "tag=${TAG}"
+                    echo "version=${VERSION}"
+                    echo "prerelease=${PRERELEASE}"
+                    echo "publish=${PUBLISH}"
+                  } >> "$GITHUB_OUTPUT"
+                  echo "Release version: ${VERSION} (prerelease: ${PRERELEASE}, publish: ${PUBLISH})"
 
     build:
         name: Build ${{ matrix.target }}
@@ -78,30 +104,39 @@ jobs:
                     - target: x86_64-apple-darwin
                       runner: macos-latest
                       cross: false
+                      embeddings: true
                     - target: aarch64-apple-darwin
                       runner: macos-latest
                       cross: false
+                      embeddings: true
 
                     # Linux GNU builds
                     - target: x86_64-unknown-linux-gnu
                       runner: ubuntu-latest
                       cross: false
+                      embeddings: true
                     - target: aarch64-unknown-linux-gnu
                       runner: ubuntu-latest
                       cross: true
+                      embeddings: true
 
-                    # Linux musl builds
+                    # Linux musl builds. FastEmbed's ONNX Runtime backend does
+                    # not provide musl binaries, so these keep BM25 learn
+                    # search and omit semantic embeddings.
                     - target: x86_64-unknown-linux-musl
                       runner: ubuntu-latest
                       cross: true
+                      embeddings: false
                     - target: aarch64-unknown-linux-musl
                       runner: ubuntu-latest
                       cross: true
+                      embeddings: false
 
                     # Windows build using cross (simpler than native MinGW setup)
                     - target: x86_64-pc-windows-gnu
                       runner: ubuntu-latest
                       cross: true
+                      embeddings: true
 
         steps:
             - uses: actions/checkout@v4
@@ -121,43 +156,63 @@ jobs:
             - name: Setup Rust cache
               uses: Swatinem/rust-cache@v2
               with:
-                  shared-key: release-${{ matrix.target }}
+                  # PRs exercise the release matrix early; main-branch dry runs
+                  # warm the default-branch cache that tag releases can restore.
+                  shared-key: release-${{ matrix.target }}-embeddings-${{ matrix.embeddings }}
 
             - name: Build with cargo cross
               if: matrix.cross
-              run: cargo cross build --target ${{ matrix.target }} --package nudge --release
+              env:
+                  EMBEDDINGS: ${{ matrix.embeddings }}
+                  TARGET: ${{ matrix.target }}
+              run: |
+                  args=(build --target "$TARGET" --package nudge --release)
+                  if [[ "$EMBEDDINGS" == "false" ]]; then
+                    args+=(--no-default-features)
+                  fi
+                  cargo cross "${args[@]}"
 
             - name: Build native
               if: ${{ !matrix.cross }}
-              run: cargo build --target ${{ matrix.target }} --package nudge --release
+              env:
+                  EMBEDDINGS: ${{ matrix.embeddings }}
+                  TARGET: ${{ matrix.target }}
+              run: |
+                  args=(build --target "$TARGET" --package nudge --release)
+                  if [[ "$EMBEDDINGS" == "false" ]]; then
+                    args+=(--no-default-features)
+                  fi
+                  cargo "${args[@]}"
 
             - name: Import signing certificate
-              if: runner.os == 'macOS'
+              if: needs.prepare.outputs.publish == 'true' && runner.os == 'macOS'
               env:
                   APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
                   APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
               run: |
-                  echo -n "$APPLE_CERTIFICATE_BASE64" | base64 --decode -o $RUNNER_TEMP/certificate.p12
-                  security create-keychain -p "$APPLE_CERTIFICATE_PASSWORD" $RUNNER_TEMP/build.keychain
-                  security default-keychain -s $RUNNER_TEMP/build.keychain
-                  security unlock-keychain -p "$APPLE_CERTIFICATE_PASSWORD" $RUNNER_TEMP/build.keychain
-                  security import $RUNNER_TEMP/certificate.p12 -k $RUNNER_TEMP/build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
-                  security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$APPLE_CERTIFICATE_PASSWORD" $RUNNER_TEMP/build.keychain
-                  rm $RUNNER_TEMP/certificate.p12
+                  echo -n "$APPLE_CERTIFICATE_BASE64" | base64 --decode -o "$RUNNER_TEMP/certificate.p12"
+                  security create-keychain -p "$APPLE_CERTIFICATE_PASSWORD" "$RUNNER_TEMP/build.keychain"
+                  security default-keychain -s "$RUNNER_TEMP/build.keychain"
+                  security unlock-keychain -p "$APPLE_CERTIFICATE_PASSWORD" "$RUNNER_TEMP/build.keychain"
+                  security import "$RUNNER_TEMP/certificate.p12" -k "$RUNNER_TEMP/build.keychain" -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+                  security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$APPLE_CERTIFICATE_PASSWORD" "$RUNNER_TEMP/build.keychain"
+                  rm "$RUNNER_TEMP/certificate.p12"
 
             - name: Sign macOS binary
-              if: runner.os == 'macOS'
+              if: needs.prepare.outputs.publish == 'true' && runner.os == 'macOS'
               env:
                   APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+                  TARGET: ${{ matrix.target }}
               run: |
+                  BINARY="target/${TARGET}/release/nudge"
                   codesign --sign "$APPLE_TEAM_ID" \
                            --timestamp \
                            --options=runtime \
                            --force \
-                           target/${{ matrix.target }}/release/nudge
+                           "$BINARY"
 
             - name: Store notarization credentials
-              if: runner.os == 'macOS'
+              if: needs.prepare.outputs.publish == 'true' && runner.os == 'macOS'
               env:
                   APPLE_ID: ${{ secrets.APPLE_ID }}
                   APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -169,16 +224,19 @@ jobs:
                           --password "$APPLE_APP_SPECIFIC_PASSWORD"
 
             - name: Submit for notarization
-              if: runner.os == 'macOS'
+              if: needs.prepare.outputs.publish == 'true' && runner.os == 'macOS'
+              env:
+                  TARGET: ${{ matrix.target }}
               run: |
-                  zip $RUNNER_TEMP/nudge-macos.zip target/${{ matrix.target }}/release/nudge
-                  xcrun notarytool submit $RUNNER_TEMP/nudge-macos.zip \
+                  BINARY="target/${TARGET}/release/nudge"
+                  zip "$RUNNER_TEMP/nudge-macos.zip" "$BINARY"
+                  xcrun notarytool submit "$RUNNER_TEMP/nudge-macos.zip" \
                           --keychain-profile "notarytool-password" \
                           --wait
 
             - name: Cleanup keychain
-              if: runner.os == 'macOS' && always()
-              run: security delete-keychain $RUNNER_TEMP/build.keychain || true
+              if: needs.prepare.outputs.publish == 'true' && runner.os == 'macOS' && always()
+              run: security delete-keychain "$RUNNER_TEMP/build.keychain" || true
 
             - name: Package binary
               id: package
@@ -213,18 +271,13 @@ jobs:
                   if-no-files-found: error
                   retention-days: 7
 
-    release:
-        name: Release
+    dry-run:
+        name: Release dry run
         needs: [prepare, build]
+        if: needs.prepare.outputs.publish != 'true'
         runs-on: ubuntu-latest
-        permissions:
-            contents: write
-        env:
-            GH_TOKEN: ${{ github.token }}
 
         steps:
-            - uses: actions/checkout@v4
-
             - name: Download all artifacts
               uses: actions/download-artifact@v4
               with:
@@ -233,65 +286,102 @@ jobs:
                   merge-multiple: true
 
             - name: List artifacts
-              run: ls -la artifacts/
+              run: ls -la "artifacts/"
 
             - name: Generate checksums
               working-directory: artifacts
               run: |
-                  sha256sum *.tar.gz > checksums.txt
+                  sha256sum ./*.tar.gz > checksums.txt
+                  echo "Generated checksums:"
+                  cat checksums.txt
+
+            - name: Write dry run summary
+              env:
+                  TAG: ${{ needs.prepare.outputs.tag }}
+              run: |
+                  {
+                    echo "## Dry Run - $TAG"
+                    echo ""
+                    echo "> [!NOTE]"
+                    echo "> No release created. This was a dry run."
+                    echo ""
+                    echo "### Artifacts"
+                    echo ""
+                    echo '```'
+                    ls -la artifacts/
+                    echo '```'
+                    echo ""
+                    echo "### Checksums"
+                    echo ""
+                    echo '```'
+                    cat artifacts/checksums.txt
+                    echo '```'
+                  } >> "$GITHUB_STEP_SUMMARY"
+
+    release:
+        name: Release
+        needs: [prepare, build]
+        if: needs.prepare.outputs.publish == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+
+        steps:
+            - name: Download all artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  path: artifacts
+                  pattern: nudge-*
+                  merge-multiple: true
+
+            - name: List artifacts
+              run: ls -la "artifacts/"
+
+            - name: Generate checksums
+              working-directory: artifacts
+              run: |
+                  sha256sum ./*.tar.gz > checksums.txt
                   echo "Generated checksums:"
                   cat checksums.txt
 
             - name: Create draft GitHub release
-              if: ${{ !inputs.dry_run }}
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  PRERELEASE: ${{ needs.prepare.outputs.prerelease }}
+                  TAG: ${{ needs.prepare.outputs.tag }}
               run: |
-                  gh release create ${{ needs.prepare.outputs.tag }} \
+                  RELEASE_FLAG="--latest"
+                  if [[ "$PRERELEASE" == "true" ]]; then
+                    RELEASE_FLAG="--prerelease"
+                  fi
+
+                  gh release create "$TAG" \
                     --draft \
                     --generate-notes \
-                    ${{ needs.prepare.outputs.prerelease == 'true' && '--prerelease' || '--latest' }} \
-                    --title "${{ needs.prepare.outputs.tag }}" \
+                    "$RELEASE_FLAG" \
+                    --title "$TAG" \
                     artifacts/*.tar.gz \
                     artifacts/checksums.txt
 
             - name: Write release summary
-              if: ${{ !inputs.dry_run }}
+              env:
+                  REPOSITORY: ${{ github.repository }}
+                  TAG: ${{ needs.prepare.outputs.tag }}
               run: |
-                  TAG="${{ needs.prepare.outputs.tag }}"
-
-                  echo "## Draft Release Created: $TAG" >> $GITHUB_STEP_SUMMARY
-                  echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "A draft release has been created with auto-generated release notes." >> $GITHUB_STEP_SUMMARY
-                  echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "### Next Steps" >> $GITHUB_STEP_SUMMARY
-                  echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "1. [Review the draft release](https://github.com/${{ github.repository }}/releases)" >> $GITHUB_STEP_SUMMARY
-                  echo "2. Edit release notes if needed" >> $GITHUB_STEP_SUMMARY
-                  echo "3. **Publish when ready**" >> $GITHUB_STEP_SUMMARY
-                  echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "### Checksums" >> $GITHUB_STEP_SUMMARY
-                  echo "" >> $GITHUB_STEP_SUMMARY
-                  echo '```' >> $GITHUB_STEP_SUMMARY
-                  cat artifacts/checksums.txt >> $GITHUB_STEP_SUMMARY
-                  echo '```' >> $GITHUB_STEP_SUMMARY
-
-            - name: Write dry run summary
-              if: ${{ inputs.dry_run }}
-              run: |
-                  TAG="${{ needs.prepare.outputs.tag }}"
-
-                  echo "## Dry Run - $TAG" >> $GITHUB_STEP_SUMMARY
-                  echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "> [!NOTE]" >> $GITHUB_STEP_SUMMARY
-                  echo "> No release created. This was a dry run." >> $GITHUB_STEP_SUMMARY
-                  echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "### Artifacts" >> $GITHUB_STEP_SUMMARY
-                  echo "" >> $GITHUB_STEP_SUMMARY
-                  echo '```' >> $GITHUB_STEP_SUMMARY
-                  ls -la artifacts/ >> $GITHUB_STEP_SUMMARY
-                  echo '```' >> $GITHUB_STEP_SUMMARY
-                  echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "### Checksums" >> $GITHUB_STEP_SUMMARY
-                  echo "" >> $GITHUB_STEP_SUMMARY
-                  echo '```' >> $GITHUB_STEP_SUMMARY
-                  cat artifacts/checksums.txt >> $GITHUB_STEP_SUMMARY
-                  echo '```' >> $GITHUB_STEP_SUMMARY
+                  {
+                    echo "## Draft Release Created: $TAG"
+                    echo ""
+                    echo "A draft release has been created with auto-generated release notes."
+                    echo ""
+                    echo "### Next Steps"
+                    echo ""
+                    echo "1. [Review the draft release](https://github.com/${REPOSITORY}/releases)"
+                    echo "2. Edit release notes if needed"
+                    echo "3. **Publish when ready**"
+                    echo ""
+                    echo "### Checksums"
+                    echo ""
+                    echo '```'
+                    cat artifacts/checksums.txt
+                    echo '```'
+                  } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ concurrency:
 
 env:
     CARGO_TERM_COLOR: always
+    CARGO_HTTP_TIMEOUT: "60"
+    CARGO_NET_RETRY: "10"
 
 jobs:
     prepare:
@@ -110,7 +112,10 @@ jobs:
                       cross: false
                       embeddings: true
 
-                    # Linux GNU builds
+                    # Linux GNU builds. The x64 target can link ONNX Runtime;
+                    # the arm64 cross image cannot link the current upstream
+                    # artifacts cleanly, so it keeps BM25 learn search and
+                    # omits semantic embeddings.
                     - target: x86_64-unknown-linux-gnu
                       runner: ubuntu-latest
                       cross: false
@@ -118,7 +123,7 @@ jobs:
                     - target: aarch64-unknown-linux-gnu
                       runner: ubuntu-latest
                       cross: true
-                      embeddings: true
+                      embeddings: false
 
                     # Linux musl builds. FastEmbed's ONNX Runtime backend does
                     # not provide musl binaries, so these keep BM25 learn
@@ -132,11 +137,14 @@ jobs:
                       cross: true
                       embeddings: false
 
-                    # Windows build using cross (simpler than native MinGW setup)
+                    # Windows build using cross (simpler than native MinGW
+                    # setup). ONNX Runtime does not publish binaries for this
+                    # GNU target, so this artifact keeps BM25 learn search and
+                    # omits semantic embeddings.
                     - target: x86_64-pc-windows-gnu
                       runner: ubuntu-latest
                       cross: true
-                      embeddings: true
+                      embeddings: false
 
         steps:
             - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,12 +152,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +243,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -410,32 +410,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,16 +539,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "der"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
-dependencies = [
- "pem-rfc7468",
- "zeroize",
 ]
 
 [[package]]
@@ -719,15 +683,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -808,21 +763,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -919,8 +859,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -930,9 +872,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -958,25 +902,6 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -1009,7 +934,6 @@ dependencies = [
  "indicatif",
  "libc",
  "log",
- "native-tls",
  "rand",
  "reqwest",
  "serde",
@@ -1074,7 +998,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -1098,22 +1021,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1134,11 +1042,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -1388,6 +1294,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lzma-rust2"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,12 +1345,6 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -1509,23 +1415,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1684,49 +1573,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,15 +1613,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pem-rfc7468"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
-dependencies = [
- "base64ct",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -1881,6 +1718,61 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "quote"
@@ -2011,30 +1903,27 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2044,6 +1933,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2065,6 +1955,12 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2109,6 +2005,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2153,38 +2050,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -2418,27 +2283,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2528,6 +2372,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokenizers"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2572,16 +2431,6 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -2916,10 +2765,8 @@ checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
- "der",
  "flate2",
  "log",
- "native-tls",
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
@@ -2928,7 +2775,6 @@ dependencies = [
  "socks",
  "ureq-proto",
  "utf8-zero",
- "webpki-root-certs",
  "webpki-roots",
 ]
 
@@ -2979,12 +2825,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -3115,15 +2955,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-root-certs"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3168,35 +2999,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ Install:
 curl -sSfL https://raw.githubusercontent.com/attunehq/nudge/main/scripts/install.sh | bash
 ```
 
-Release binaries support macOS, Linux, and Windows x64. Alpine and other musl
-Linux builds include BM25 learned-note search, but not local semantic
-embeddings.
+Release binaries support macOS, Linux, and Windows x64. BM25 learned-note
+search is always available. Local semantic embeddings are included on macOS and
+x64 GNU Linux; musl Linux, arm64 GNU Linux, and Windows GNU builds omit local
+semantic embeddings.
 
 Windows PowerShell:
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ curl -sSfL https://raw.githubusercontent.com/attunehq/nudge/main/scripts/install
 ```
 
 Release binaries support macOS, Linux, and Windows x64. BM25 learned-note
-search is always available. Local semantic embeddings are included on macOS and
-x64 GNU Linux; musl Linux, arm64 GNU Linux, and Windows GNU builds omit local
-semantic embeddings.
+search is always available. Local semantic embeddings are included on Apple
+Silicon macOS and x64 GNU Linux; Intel macOS, musl Linux, arm64 GNU Linux, and
+Windows GNU builds omit local semantic embeddings.
 
 Windows PowerShell:
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Install:
 curl -sSfL https://raw.githubusercontent.com/attunehq/nudge/main/scripts/install.sh | bash
 ```
 
+Release binaries support macOS, Linux, and Windows x64. Alpine and other musl
+Linux builds include BM25 learned-note search, but not local semantic
+embeddings.
+
 Windows PowerShell:
 
 ```powershell

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -99,9 +99,9 @@ cache keys, then sign/notarize macOS binaries and create the draft release.
 Supported release targets are macOS, Linux, and Windows x64. Targets whose ONNX
 Runtime artifacts are unavailable or do not link in the release cross-toolchain
 build with `--no-default-features`, which keeps BM25 learned-note search and
-omits local semantic embeddings. Keep that split for musl Linux, arm64 GNU
-Linux, and Windows GNU unless `ort`/FastEmbed support changes or Nudge grows a
-different embedding backend.
+omits local semantic embeddings. Keep that split for Intel macOS, musl Linux,
+arm64 GNU Linux, and Windows GNU unless `ort`/FastEmbed support changes or
+Nudge grows a different embedding backend.
 
 Useful focused commands:
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -96,10 +96,12 @@ actionlint
 The GitHub `Release` workflow runs as a dry-run matrix on pull requests,
 merge-queue checks, and pushes to `main`. Tag builds use the same matrix and
 cache keys, then sign/notarize macOS binaries and create the draft release.
-Supported release targets are macOS, Linux, and Windows x64. Musl Linux targets
+Supported release targets are macOS, Linux, and Windows x64. Targets whose ONNX
+Runtime artifacts are unavailable or do not link in the release cross-toolchain
 build with `--no-default-features`, which keeps BM25 learned-note search and
-omits local semantic embeddings. Keep that split unless `ort` starts publishing
-musl ONNX Runtime artifacts or Nudge grows a different embedding backend.
+omits local semantic embeddings. Keep that split for musl Linux, arm64 GNU
+Linux, and Windows GNU unless `ort`/FastEmbed support changes or Nudge grows a
+different embedding backend.
 
 Useful focused commands:
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -84,6 +84,23 @@ cargo clippy -p nudge --all-targets --all-features -- -D warnings
 cargo test -p nudge
 ```
 
+When a change touches release packaging, installer scripts, TLS/download
+dependencies, or learned embeddings, also run:
+
+```bash
+cargo build -p nudge --release
+cargo build -p nudge --no-default-features --release
+actionlint
+```
+
+The GitHub `Release` workflow runs as a dry-run matrix on pull requests,
+merge-queue checks, and pushes to `main`. Tag builds use the same matrix and
+cache keys, then sign/notarize macOS binaries and create the draft release.
+Supported release targets are macOS, Linux, and Windows x64. Musl Linux targets
+build with `--no-default-features`, which keeps BM25 learned-note search and
+omits local semantic embeddings. Keep that split unless `ort` starts publishing
+musl ONNX Runtime artifacts or Nudge grows a different embedding backend.
+
 Useful focused commands:
 
 ```bash

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -40,6 +40,10 @@ macOS or Linux:
 curl -sSfL https://raw.githubusercontent.com/attunehq/nudge/main/scripts/install.sh | bash
 ```
 
+Release binaries support macOS, Linux, and Windows x64. Alpine and other musl
+Linux builds include BM25 learned-note search, but not local semantic
+embeddings.
+
 Windows PowerShell:
 
 ```powershell
@@ -246,6 +250,12 @@ nudge learn embeddings reindex
 
 This stores Markdown notes in the repo and generated model/vector artifacts in
 the user-level Nudge cache.
+
+Run `nudge learn embeddings status` before relying on semantic retrieval. If it
+prints `Embedding support: unavailable in this binary`, BM25 learned-note search
+still works, but `enable` and `reindex` are unavailable. This is expected for
+musl Linux release binaries because FastEmbed's ONNX Runtime backend does not
+publish musl artifacts.
 
 ## CI And Programmatic Checks
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -40,9 +40,10 @@ macOS or Linux:
 curl -sSfL https://raw.githubusercontent.com/attunehq/nudge/main/scripts/install.sh | bash
 ```
 
-Release binaries support macOS, Linux, and Windows x64. Alpine and other musl
-Linux builds include BM25 learned-note search, but not local semantic
-embeddings.
+Release binaries support macOS, Linux, and Windows x64. BM25 learned-note
+search is always available. Local semantic embeddings are included on macOS and
+x64 GNU Linux; musl Linux, arm64 GNU Linux, and Windows GNU builds omit local
+semantic embeddings.
 
 Windows PowerShell:
 
@@ -254,8 +255,9 @@ the user-level Nudge cache.
 Run `nudge learn embeddings status` before relying on semantic retrieval. If it
 prints `Embedding support: unavailable in this binary`, BM25 learned-note search
 still works, but `enable` and `reindex` are unavailable. This is expected for
-musl Linux release binaries because FastEmbed's ONNX Runtime backend does not
-publish musl artifacts.
+release targets where FastEmbed's ONNX Runtime backend does not publish usable
+artifacts, currently musl Linux and Windows GNU, or where those artifacts do not
+link cleanly in the release cross-toolchain, currently arm64 GNU Linux.
 
 ## CI And Programmatic Checks
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -41,9 +41,9 @@ curl -sSfL https://raw.githubusercontent.com/attunehq/nudge/main/scripts/install
 ```
 
 Release binaries support macOS, Linux, and Windows x64. BM25 learned-note
-search is always available. Local semantic embeddings are included on macOS and
-x64 GNU Linux; musl Linux, arm64 GNU Linux, and Windows GNU builds omit local
-semantic embeddings.
+search is always available. Local semantic embeddings are included on Apple
+Silicon macOS and x64 GNU Linux; Intel macOS, musl Linux, arm64 GNU Linux, and
+Windows GNU builds omit local semantic embeddings.
 
 Windows PowerShell:
 
@@ -256,8 +256,9 @@ Run `nudge learn embeddings status` before relying on semantic retrieval. If it
 prints `Embedding support: unavailable in this binary`, BM25 learned-note search
 still works, but `enable` and `reindex` are unavailable. This is expected for
 release targets where FastEmbed's ONNX Runtime backend does not publish usable
-artifacts, currently musl Linux and Windows GNU, or where those artifacts do not
-link cleanly in the release cross-toolchain, currently arm64 GNU Linux.
+artifacts, currently Intel macOS, musl Linux, and Windows GNU, or where those
+artifacts do not link cleanly in the release cross-toolchain, currently arm64
+GNU Linux.
 
 ## CI And Programmatic Checks
 

--- a/packages/nudge/Cargo.toml
+++ b/packages/nudge/Cargo.toml
@@ -18,7 +18,7 @@ clap = { version = "4.5.53", features = ["env", "derive", "cargo"] }
 color-eyre = "0.6.5"
 color-print = "0.3.7"
 directories = "6.0.0"
-fastembed = { version = "5.16.1", default-features = false, features = ["hf-hub-native-tls", "ort-download-binaries-native-tls"] }
+fastembed = { version = "5.16.1", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"], optional = true }
 glob = "0.3.3"
 monostate = "1.0.2"
 regex = "1.12.2"
@@ -54,6 +54,10 @@ pretty_assertions = "1.4.1"
 simple_test_case = "1.3.0"
 tempfile = "3.20"
 xshell = "0.2.7"
+
+[features]
+default = ["embeddings"]
+embeddings = ["dep:fastembed"]
 
 [lints]
 workspace = true

--- a/packages/nudge/skills/nudge-learnings/SKILL.md
+++ b/packages/nudge/skills/nudge-learnings/SKILL.md
@@ -8,7 +8,8 @@ description: Use when working in a repository that uses Nudge learned incident n
 Before using learned notes, choose the retrieval guide:
 
 1. Run `nudge learn embeddings status`, or inspect `.nudge.yaml` / `.nudge.yml` for `learn.embeddings.enabled`.
-2. If embeddings are enabled, read [references/embeddings.md](references/embeddings.md).
-3. Otherwise, read [references/bm25.md](references/bm25.md).
+2. If status reports `Embedding support: unavailable in this binary`, read [references/bm25.md](references/bm25.md), even when config enables embeddings.
+3. If embeddings are enabled and support is available, read [references/embeddings.md](references/embeddings.md).
+4. Otherwise, read [references/bm25.md](references/bm25.md).
 
 When Nudge surfaces learned context, treat it as repo memory from a previous debugging session. Read the cited note, decide whether it applies to the current situation, and reuse the fix or explain why the case differs.

--- a/packages/nudge/skills/nudge-learnings/references/embeddings.md
+++ b/packages/nudge/skills/nudge-learnings/references/embeddings.md
@@ -1,6 +1,6 @@
 # Nudge Learnings With Local Embeddings
 
-Use this guide when `nudge learn embeddings status` reports enabled, or `.nudge.yaml` / `.nudge.yml` sets `learn.embeddings.enabled: true`.
+Use this guide when `nudge learn embeddings status` reports both `Embedding support: available` and `Embeddings: enabled`, or `.nudge.yaml` / `.nudge.yml` sets `learn.embeddings.enabled: true` and the current binary supports embeddings.
 
 ## Retrieval behavior
 

--- a/packages/nudge/src/cmd/learn.rs
+++ b/packages/nudge/src/cmd/learn.rs
@@ -121,7 +121,7 @@ pub fn main(config: Config) -> Result<()> {
 fn add(config: AddConfig) -> Result<()> {
     let body = learn::read_body(config.body, config.body_file)?;
     let path = learn::add(
-        std::path::Path::new("."),
+        Path::new("."),
         AddNote {
             title: config.title,
             body,
@@ -133,7 +133,7 @@ fn add(config: AddConfig) -> Result<()> {
 }
 
 fn list(_config: ListConfig) -> Result<()> {
-    let root = std::path::Path::new(".");
+    let root = Path::new(".");
     let notes = learn::load_all(root).context("load learned notes")?;
     if notes.is_empty() {
         println!("No learned notes found in {}.", learn::LEARNED_DIR);
@@ -153,7 +153,7 @@ fn list(_config: ListConfig) -> Result<()> {
 }
 
 fn search(config: SearchConfig) -> Result<()> {
-    let root = std::path::Path::new(".");
+    let root = Path::new(".");
     let notes = learn::load_all(root).context("load learned notes")?;
     if notes.is_empty() {
         println!("No learned notes found in {}.", learn::LEARNED_DIR);
@@ -193,6 +193,7 @@ fn embeddings(config: EmbeddingsConfig) -> Result<()> {
 }
 
 fn embeddings_enable(config: EnableEmbeddingsConfig) -> Result<()> {
+    learn::embeddings::ensure_available()?;
     let model = learn::embeddings::canonical_model(&config.model)?;
     let learn_config = LearnConfig {
         embeddings: learn::EmbeddingConfig {
@@ -214,6 +215,7 @@ fn embeddings_enable(config: EnableEmbeddingsConfig) -> Result<()> {
 }
 
 fn embeddings_reindex(_config: ReindexEmbeddingsConfig) -> Result<()> {
+    learn::embeddings::ensure_available()?;
     let config = learn::load_config().context("load learn config")?;
     if !config.embeddings.enabled {
         bail!("learn embeddings are not enabled. Run `nudge learn embeddings enable` first.");
@@ -228,6 +230,14 @@ fn embeddings_status(_config: StatusEmbeddingsConfig) -> Result<()> {
     let status = learn::embeddings::status(root, &config)?;
 
     println!(
+        "Embedding support: {}",
+        if status.available {
+            "available"
+        } else {
+            "unavailable in this binary"
+        }
+    );
+    println!(
         "Embeddings: {}",
         if status.enabled {
             "enabled"
@@ -240,6 +250,11 @@ fn embeddings_status(_config: StatusEmbeddingsConfig) -> Result<()> {
     println!("Model cache: {}", status.paths.model_dir.display());
     println!("Vector index: {}", status.paths.vector_index.display());
     println!("Vectors: {}", status.vector_count);
+    if status.enabled && !status.available {
+        println!(
+            "Semantic search is unavailable in this binary. BM25 learned-note search remains available."
+        );
+    }
 
     Ok(())
 }

--- a/packages/nudge/src/learn.rs
+++ b/packages/nudge/src/learn.rs
@@ -4,6 +4,7 @@ use std::{
     collections::{HashMap, HashSet},
     fs,
     io::{self, IsTerminal, Read},
+    mem::take,
     path::{Path, PathBuf},
 };
 
@@ -443,7 +444,7 @@ fn tokenize(text: &str) -> Vec<String> {
 
 fn push_token(tokens: &mut Vec<String>, current: &mut String) {
     if current.len() >= 2 && !is_stop_word(current) {
-        tokens.push(std::mem::take(current));
+        tokens.push(take(current));
     } else {
         current.clear();
     }
@@ -509,6 +510,7 @@ fn is_stop_word(token: &str) -> bool {
     )
 }
 
+#[cfg(any(feature = "embeddings", test))]
 pub(crate) fn query_terms(query: &str) -> HashSet<String> {
     tokenize(query).into_iter().collect()
 }

--- a/packages/nudge/src/learn/embeddings.rs
+++ b/packages/nudge/src/learn/embeddings.rs
@@ -1,24 +1,39 @@
 //! Local embedding support for learned notes.
 
 use std::{
-    collections::HashMap,
     fs,
     path::{Path, PathBuf},
 };
 
-use color_eyre::eyre::{Context, OptionExt, Result};
+#[cfg(feature = "embeddings")]
+use std::collections::HashMap;
+
+#[cfg(feature = "embeddings")]
+use color_eyre::eyre::Context;
+use color_eyre::eyre::{OptionExt, Result, bail};
+#[cfg(feature = "embeddings")]
+use fastembed::{EmbeddingModel, TextEmbedding, TextInitOptions};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+#[cfg(feature = "embeddings")]
+use std::str::FromStr;
 
+#[cfg(any(feature = "embeddings", test))]
+use crate::learn::display_path;
+#[cfg(feature = "embeddings")]
+use crate::learn::search;
 use crate::{
-    learn::{LearnConfig, LearnedNote, SearchResult, display_path, search},
+    learn::{LearnConfig, LearnedNote, SearchResult},
     rules,
 };
 
+#[cfg(feature = "embeddings")]
 const INDEX_VERSION: u32 = 1;
 const DEFAULT_MODEL: &str = "BGESmallENV15";
 const DEFAULT_MODEL_NAME: &str = "BAAI/bge-small-en-v1.5";
+#[cfg(feature = "embeddings")]
 const SEMANTIC_WEIGHT: f64 = 2.5;
+#[cfg(feature = "embeddings")]
 const BM25_PREFETCH_LIMIT: usize = 50;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -30,6 +45,7 @@ pub struct EmbeddingPaths {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EmbeddingStatus {
+    pub available: bool,
     pub enabled: bool,
     pub model: String,
     pub paths: EmbeddingPaths,
@@ -44,6 +60,7 @@ pub struct EmbeddingBuildReport {
 }
 
 #[derive(Debug, Clone)]
+#[cfg(any(feature = "embeddings", test))]
 struct NoteChunk {
     note_path: PathBuf,
     title: String,
@@ -74,6 +91,22 @@ pub fn default_model() -> String {
     DEFAULT_MODEL_NAME.to_string()
 }
 
+pub fn is_available() -> bool {
+    cfg!(feature = "embeddings")
+}
+
+pub fn unavailable_message() -> &'static str {
+    "semantic embeddings are not available in this nudge binary; BM25 learned-note search remains available"
+}
+
+pub fn ensure_available() -> Result<()> {
+    if is_available() {
+        Ok(())
+    } else {
+        bail!("{}", unavailable_message())
+    }
+}
+
 pub fn status(root: &Path, config: &LearnConfig) -> Result<EmbeddingStatus> {
     let paths = paths(root)?;
     let vector_count = load_index(&paths.vector_index)
@@ -81,6 +114,7 @@ pub fn status(root: &Path, config: &LearnConfig) -> Result<EmbeddingStatus> {
         .unwrap_or(0);
 
     Ok(EmbeddingStatus {
+        available: is_available(),
         enabled: config.embeddings.enabled,
         model: config.embeddings.model.clone(),
         paths,
@@ -102,6 +136,7 @@ pub fn paths(root: &Path) -> Result<EmbeddingPaths> {
     })
 }
 
+#[cfg(feature = "embeddings")]
 pub fn build_index(
     root: &Path,
     notes: &[LearnedNote],
@@ -156,6 +191,16 @@ pub fn build_index(
     })
 }
 
+#[cfg(not(feature = "embeddings"))]
+pub fn build_index(
+    _root: &Path,
+    _notes: &[LearnedNote],
+    _config: &LearnConfig,
+) -> Result<EmbeddingBuildReport> {
+    bail!("{}", unavailable_message())
+}
+
+#[cfg(feature = "embeddings")]
 pub fn ensure_model(root: &Path, config: &LearnConfig) -> Result<EmbeddingPaths> {
     let paths = paths(root)?;
     fs::create_dir_all(&paths.model_dir)
@@ -166,6 +211,11 @@ pub fn ensure_model(root: &Path, config: &LearnConfig) -> Result<EmbeddingPaths>
         vec![String::from("query: nudge local embedding model warmup")],
     )?;
     Ok(paths)
+}
+
+#[cfg(not(feature = "embeddings"))]
+pub fn ensure_model(_root: &Path, _config: &LearnConfig) -> Result<EmbeddingPaths> {
+    bail!("{}", unavailable_message())
 }
 
 pub fn hybrid_search(
@@ -180,9 +230,25 @@ pub fn hybrid_search(
         return Ok(None);
     }
 
-    hybrid_search_enabled(root, notes, query, limit, min_score, config)
+    if !is_available() {
+        tracing::warn!(
+            "learned-note embeddings are enabled in config but unavailable in this binary; falling back to BM25"
+        );
+        return Ok(None);
+    }
+
+    #[cfg(feature = "embeddings")]
+    {
+        hybrid_search_enabled(root, notes, query, limit, min_score, config)
+    }
+    #[cfg(not(feature = "embeddings"))]
+    {
+        let _ = (root, notes, query, limit, min_score, config);
+        Ok(None)
+    }
 }
 
+#[cfg(feature = "embeddings")]
 fn hybrid_search_enabled(
     root: &Path,
     notes: &[LearnedNote],
@@ -206,7 +272,7 @@ fn hybrid_search_enabled(
     .next()
     .ok_or_eyre("embedding model returned no query vector")?;
 
-    let mut semantic_by_path: HashMap<String, f64> = HashMap::new();
+    let mut semantic_by_path = HashMap::<String, f64>::new();
     for chunk in &index.chunks {
         let similarity = cosine_similarity(&query_vector, &chunk.vector);
         semantic_by_path
@@ -252,6 +318,7 @@ fn hybrid_search_enabled(
     Ok(Some(results))
 }
 
+#[cfg(feature = "embeddings")]
 fn load_or_build_index(
     root: &Path,
     notes: &[LearnedNote],
@@ -273,6 +340,7 @@ fn load_index(path: &Path) -> Option<VectorIndex> {
     serde_json::from_str(&content).ok()
 }
 
+#[cfg(feature = "embeddings")]
 fn index_is_current(
     root: &Path,
     notes: &[LearnedNote],
@@ -311,10 +379,8 @@ fn index_is_current(
     expected == actual
 }
 
+#[cfg(feature = "embeddings")]
 fn embed_texts(model: &str, model_dir: &Path, texts: Vec<String>) -> Result<Vec<Vec<f32>>> {
-    use fastembed::{EmbeddingModel, TextEmbedding, TextInitOptions};
-    use std::str::FromStr;
-
     if texts.is_empty() {
         return Ok(Vec::new());
     }
@@ -334,27 +400,38 @@ fn embed_texts(model: &str, model_dir: &Path, texts: Vec<String>) -> Result<Vec<
         .map_err(|error| color_eyre::eyre::eyre!("generate local embeddings: {error}"))
 }
 
+#[cfg(feature = "embeddings")]
 pub fn canonical_model(model: &str) -> Result<String> {
-    let trimmed = model.trim();
-    let canonical = match trimmed.to_ascii_lowercase().as_str() {
-        "baai/bge-small-en-v1.5" | "bge-small-en-v1.5" | "bgesmallenv15" => DEFAULT_MODEL,
-        "sentence-transformers/all-minilm-l6-v2" | "all-minilm-l6-v2" | "allminilml6v2" => {
-            "AllMiniLML6V2"
-        }
-        "sentence-transformers/all-minilm-l6-v2-q" | "all-minilm-l6-v2-q" | "allminilml6v2q" => {
-            "AllMiniLML6V2Q"
-        }
-        _ => trimmed,
-    };
+    let canonical = canonical_model_alias(model);
 
-    use fastembed::EmbeddingModel;
-    use std::str::FromStr;
-    EmbeddingModel::from_str(canonical)
+    EmbeddingModel::from_str(&canonical)
         .map_err(|error| color_eyre::eyre::eyre!("unknown embedding model `{model}`: {error}"))?;
 
-    Ok(canonical.to_string())
+    Ok(canonical)
 }
 
+#[cfg(not(feature = "embeddings"))]
+pub fn canonical_model(model: &str) -> Result<String> {
+    Ok(canonical_model_alias(model))
+}
+
+fn canonical_model_alias(model: &str) -> String {
+    let trimmed = model.trim();
+    match trimmed.to_ascii_lowercase().as_str() {
+        "baai/bge-small-en-v1.5" | "bge-small-en-v1.5" | "bgesmallenv15" => {
+            String::from(DEFAULT_MODEL)
+        }
+        "sentence-transformers/all-minilm-l6-v2" | "all-minilm-l6-v2" | "allminilml6v2" => {
+            String::from("AllMiniLML6V2")
+        }
+        "sentence-transformers/all-minilm-l6-v2-q" | "all-minilm-l6-v2-q" | "allminilml6v2q" => {
+            String::from("AllMiniLML6V2Q")
+        }
+        _ => trimmed.to_string(),
+    }
+}
+
+#[cfg(feature = "embeddings")]
 fn chunks_for_notes(root: &Path, notes: &[LearnedNote]) -> Vec<NoteChunk> {
     notes
         .iter()
@@ -362,6 +439,7 @@ fn chunks_for_notes(root: &Path, notes: &[LearnedNote]) -> Vec<NoteChunk> {
         .collect()
 }
 
+#[cfg(any(feature = "embeddings", test))]
 fn chunks_for_note(root: &Path, note: &LearnedNote) -> Vec<NoteChunk> {
     let body_without_title = note
         .body
@@ -399,6 +477,7 @@ fn chunks_for_note(root: &Path, note: &LearnedNote) -> Vec<NoteChunk> {
     chunks
 }
 
+#[cfg(any(feature = "embeddings", test))]
 fn push_section_chunk(
     root: &Path,
     note: &LearnedNote,
@@ -438,6 +517,7 @@ fn push_section_chunk(
     });
 }
 
+#[cfg(feature = "embeddings")]
 fn cosine_similarity(left: &[f32], right: &[f32]) -> f64 {
     if left.len() != right.len() || left.is_empty() {
         return 0.0;
@@ -503,7 +583,11 @@ mod tests {
         let chunks = chunks_for_note(root.path(), &note);
 
         pretty_assert_eq!(chunks.len(), 2);
+        pretty_assert_eq!(chunks[0].note_path, note.path);
+        pretty_assert_eq!(chunks[0].title, "Expo cache");
         assert!(chunks[0].text.contains("What went wrong"));
+        assert!(!chunks[0].note_hash.is_empty());
+        assert!(!chunks[0].chunk_id.is_empty());
         assert!(chunks[1].text.contains("Clear the cache"));
     }
 
@@ -513,6 +597,7 @@ mod tests {
         let config = LearnConfig::default();
         let status = status(root.path(), &config).expect("status");
 
+        pretty_assert_eq!(status.available, cfg!(feature = "embeddings"));
         pretty_assert_eq!(status.enabled, false);
         pretty_assert_eq!(status.model, DEFAULT_MODEL_NAME);
     }

--- a/packages/nudge/tests/it/install_script.rs
+++ b/packages/nudge/tests/it/install_script.rs
@@ -29,3 +29,56 @@ fn powershell_installer_fails_closed_when_checksum_verification_is_unavailable()
         "checksum mismatches must stop installation"
     );
 }
+
+#[test]
+fn shell_installer_keeps_musl_release_artifacts_available() {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("packages dir")
+        .parent()
+        .expect("repo root");
+    let script_path = repo_root.join("scripts/install.sh");
+    let script = fs::read_to_string(&script_path).expect("read install.sh");
+
+    assert!(
+        script.contains("os=\"$os-musl\""),
+        "the installer should continue to request musl release artifacts"
+    );
+    assert!(
+        !script.contains("Linux musl/Alpine release binaries are not currently available"),
+        "musl Linux installs should not be blocked by the installer"
+    );
+}
+
+#[test]
+fn release_workflow_builds_musl_targets_without_embeddings() {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("packages dir")
+        .parent()
+        .expect("repo root");
+    let workflow_path = repo_root.join(".github/workflows/release.yml");
+    let workflow = fs::read_to_string(&workflow_path).expect("read release workflow");
+
+    assert!(
+        workflow.contains("x86_64-unknown-linux-gnu"),
+        "release workflow should still build the supported Linux x64 GNU artifact"
+    );
+    assert!(
+        workflow.contains("aarch64-unknown-linux-gnu"),
+        "release workflow should still build the supported Linux arm64 GNU artifact"
+    );
+    assert!(
+        workflow.contains("x86_64-unknown-linux-musl"),
+        "release workflow should build the Linux x64 musl artifact"
+    );
+    assert!(
+        workflow.contains("aarch64-unknown-linux-musl"),
+        "release workflow should build the Linux arm64 musl artifact"
+    );
+    assert!(
+        workflow.contains("embeddings: false")
+            && workflow.contains("args+=(--no-default-features)"),
+        "musl release builds should disable default embedding support"
+    );
+}

--- a/packages/nudge/tests/it/install_script.rs
+++ b/packages/nudge/tests/it/install_script.rs
@@ -63,6 +63,16 @@ fn release_workflow_builds_ort_limited_targets_without_embeddings() {
     let workflow = fs::read_to_string(&workflow_path).expect("read release workflow");
 
     pretty_assert_eq!(
+        target_embeddings(&workflow, "x86_64-apple-darwin"),
+        Some(false),
+        "Intel macOS should build without embedding support until ONNX Runtime publishes that target"
+    );
+    pretty_assert_eq!(
+        target_embeddings(&workflow, "aarch64-apple-darwin"),
+        Some(true),
+        "Apple Silicon macOS should keep local semantic embeddings"
+    );
+    pretty_assert_eq!(
         target_embeddings(&workflow, "x86_64-unknown-linux-gnu"),
         Some(true),
         "Linux x64 GNU should keep local semantic embeddings"

--- a/packages/nudge/tests/it/install_script.rs
+++ b/packages/nudge/tests/it/install_script.rs
@@ -2,6 +2,8 @@
 
 use std::{fs, path::Path};
 
+use pretty_assertions::assert_eq as pretty_assert_eq;
+
 #[test]
 fn powershell_installer_fails_closed_when_checksum_verification_is_unavailable() {
     let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -51,7 +53,7 @@ fn shell_installer_keeps_musl_release_artifacts_available() {
 }
 
 #[test]
-fn release_workflow_builds_musl_targets_without_embeddings() {
+fn release_workflow_builds_ort_limited_targets_without_embeddings() {
     let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .expect("packages dir")
@@ -60,25 +62,50 @@ fn release_workflow_builds_musl_targets_without_embeddings() {
     let workflow_path = repo_root.join(".github/workflows/release.yml");
     let workflow = fs::read_to_string(&workflow_path).expect("read release workflow");
 
-    assert!(
-        workflow.contains("x86_64-unknown-linux-gnu"),
-        "release workflow should still build the supported Linux x64 GNU artifact"
+    pretty_assert_eq!(
+        target_embeddings(&workflow, "x86_64-unknown-linux-gnu"),
+        Some(true),
+        "Linux x64 GNU should keep local semantic embeddings"
+    );
+    pretty_assert_eq!(
+        target_embeddings(&workflow, "aarch64-unknown-linux-gnu"),
+        Some(false),
+        "Linux arm64 GNU should build without embedding support until ONNX Runtime links cleanly"
+    );
+    pretty_assert_eq!(
+        target_embeddings(&workflow, "x86_64-unknown-linux-musl"),
+        Some(false),
+        "Linux x64 musl should build without embedding support"
+    );
+    pretty_assert_eq!(
+        target_embeddings(&workflow, "aarch64-unknown-linux-musl"),
+        Some(false),
+        "Linux arm64 musl should build without embedding support"
+    );
+    pretty_assert_eq!(
+        target_embeddings(&workflow, "x86_64-pc-windows-gnu"),
+        Some(false),
+        "Windows GNU should build without embedding support until ONNX Runtime publishes that target"
     );
     assert!(
-        workflow.contains("aarch64-unknown-linux-gnu"),
-        "release workflow should still build the supported Linux arm64 GNU artifact"
+        workflow.contains("args+=(--no-default-features)"),
+        "feature-limited release builds should disable default embedding support"
     );
-    assert!(
-        workflow.contains("x86_64-unknown-linux-musl"),
-        "release workflow should build the Linux x64 musl artifact"
-    );
-    assert!(
-        workflow.contains("aarch64-unknown-linux-musl"),
-        "release workflow should build the Linux arm64 musl artifact"
-    );
-    assert!(
-        workflow.contains("embeddings: false")
-            && workflow.contains("args+=(--no-default-features)"),
-        "musl release builds should disable default embedding support"
-    );
+}
+
+fn target_embeddings(workflow: &str, target: &str) -> Option<bool> {
+    let start = workflow.find(&format!("- target: {target}"))?;
+    let rest = &workflow[start..];
+    let end = rest
+        .find("\n                    - target: ")
+        .unwrap_or(rest.len());
+    let target_entry = &rest[..end];
+
+    if target_entry.contains("embeddings: true") {
+        Some(true)
+    } else if target_entry.contains("embeddings: false") {
+        Some(false)
+    } else {
+        None
+    }
 }

--- a/packages/nudge/tests/it/learn.rs
+++ b/packages/nudge/tests/it/learn.rs
@@ -134,6 +134,7 @@ fn user_prompt_hook_injects_relevant_learned_context() {
 }
 
 #[test]
+#[cfg(feature = "embeddings")]
 fn learn_embeddings_enable_writes_project_config_without_reindex() {
     let temp = TempDir::new().expect("temp dir");
 
@@ -177,6 +178,28 @@ fn learn_embeddings_enable_writes_project_config_without_reindex() {
 }
 
 #[test]
+#[cfg(not(feature = "embeddings"))]
+fn learn_embeddings_enable_reports_unavailable_without_feature() {
+    let temp = TempDir::new().expect("temp dir");
+
+    let (exit_code, _stdout, stderr) = run_nudge_in(
+        temp.path(),
+        &["learn", "embeddings", "enable", "--no-reindex"],
+        None,
+    );
+
+    assert_ne!(exit_code, 0, "enable should fail without embeddings");
+    assert!(
+        stderr.contains("semantic embeddings are not available"),
+        "enable should explain unavailable support, got: {stderr}"
+    );
+    assert!(
+        !temp.path().join(".nudge.yaml").exists(),
+        "unavailable embeddings should not write config"
+    );
+}
+
+#[test]
 fn learn_embeddings_status_reads_nudge_yml() {
     let temp = TempDir::new().expect("temp dir");
     fs::write(
@@ -200,4 +223,16 @@ learn:
         stdout.contains("Embeddings: enabled") && stdout.contains("all-MiniLM-L6-v2"),
         "status should read .nudge.yml learn config, got: {stdout}"
     );
+    if cfg!(feature = "embeddings") {
+        assert!(
+            stdout.contains("Embedding support: available"),
+            "status should report embedding support, got: {stdout}"
+        );
+    } else {
+        assert!(
+            stdout.contains("Embedding support: unavailable in this binary")
+                && stdout.contains("BM25 learned-note search remains available"),
+            "status should report feature-limited support, got: {stdout}"
+        );
+    }
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -108,7 +108,7 @@ detect_platform() {
       ;;
   esac
 
-  # Check for musl instead of glibc on Linux
+  # Musl release binaries are built without local semantic embeddings.
   if [[ "$os" == "unknown-linux" ]]; then
     if [[ -e /etc/alpine-release ]] || ldd /bin/sh 2>/dev/null | grep -q musl; then
       os="$os-musl"


### PR DESCRIPTION
**Why this change**
- The first blocker was `native-tls`/OpenSSL entering the release graph through FastEmbed download features, which release cross targets could not satisfy.
- FastEmbed now uses rustls-backed download features, and local semantic embeddings live behind a Cargo feature named `embeddings` that remains enabled by default.
- The release dry-run matrix then exposed target-specific ONNX Runtime limits: musl has no downloaded ORT binaries, Windows GNU has no ORT binary artifact, Intel macOS has no ORT artifact for the current feature set, and arm64 GNU Linux does not link cleanly in the release cross-toolchain. Those release targets now build with `--no-default-features`, keeping the installer/artifact support and BM25 learned-note search while omitting local semantic embeddings.
- No-feature binaries now report `Embedding support: unavailable in this binary`, reject `enable`/`reindex` without writing unusable config, and fall back to BM25 search if project config enables embeddings.
- The release workflow now runs the real release build/package/checksum matrix as a dry run on pull requests, merge queue, and pushes to `main`. Tag builds use the same matrix and cache keys, then run the publishing-only release job with `contents: write`. Cargo network retries/timeouts are set to reduce transient crates.io flakes.

**Configuration changes after merge**
- No user config migration is required. Existing `learn.embeddings.enabled: true` config remains parseable on every build.
- Local semantic embeddings are included in Apple Silicon macOS and x64 GNU Linux release binaries.
- Intel macOS, musl Linux, arm64 GNU Linux, and Windows GNU release binaries intentionally do not support local semantic embeddings for now. Users on those binaries still get `nudge learn add/list/search` with BM25 retrieval; `nudge learn embeddings status` explains the unavailable semantic support.

**Testing steps performed**
```text
git tag --list v0.4.1
# no output

git ls-remote --tags origin v0.4.1
# no output

actionlint
# no output

cargo fmt --all -- --check
# exit 0; rustfmt emitted the existing stable-channel wrap_comments warnings

cargo clippy -p nudge --all-targets --all-features -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.01s

cargo clippy -p nudge --all-targets --no-default-features -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.29s

cargo test -p nudge
test result: ok. 111 passed; 0 failed
test result: ok. 3 passed; 0 failed
test result: ok. 142 passed; 0 failed
test result: ok. 1 passed; 0 failed

cargo test -p nudge --no-default-features
test result: ok. 111 passed; 0 failed
test result: ok. 3 passed; 0 failed
test result: ok. 142 passed; 0 failed
test result: ok. 1 passed; 0 failed

cargo test -p nudge --test it install_script
test install_script::release_workflow_builds_ort_limited_targets_without_embeddings ... ok
test result: ok. 3 passed; 0 failed; 139 filtered out

cargo build -p nudge --release
Finished `release` profile [optimized] target(s) in 6.14s

cargo build -p nudge --no-default-features --release
Finished `release` profile [optimized] target(s) in 6.43s

cargo cross build --target x86_64-unknown-linux-musl --package nudge --release --no-default-features
Build successful: x86_64-unknown-linux-musl
All build operations completed successfully!

cargo tree -p nudge --no-default-features --target all | rg -n "fastembed|ort|native-tls|openssl|rustls" || true
# no dependency matches

cargo run -p nudge -- check README.md docs/user-guide.md docs/developer-guide.md .github/workflows/release.yml packages/nudge/tests/it/install_script.rs
✓ Checked 1 files against 7 rules
```

No-feature status smoke against an enabled config:
```text
Embedding support: unavailable in this binary
Embeddings: enabled
Model: all-MiniLM-L6-v2
Vectors: 0
Semantic search is unavailable in this binary. BM25 learned-note search remains available.
```

**Surprising changes / Notes**
- The musl artifact names stay the same, so existing installers can continue resolving musl release assets.
- The Windows x64 artifact still uses the existing `x86_64-pc-windows-gnu` installer target. It is BM25-only until we move the release target to an ORT-supported Windows toolchain or swap embedding backends.
- The Intel macOS artifact still ships. It is BM25-only until ORT/FastEmbed supports that target in the current downloaded-binary feature set or Nudge swaps embedding backends.
- PR release-build CI previously caught the Windows GNU, arm64 GNU Linux, and Intel macOS ORT failures; this PR now makes those limits explicit in the matrix and docs.
