### PR TITLE
Fix tag release note generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,6 +338,10 @@ jobs:
             contents: write
 
         steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
             - name: Download all artifacts
               uses: actions/download-artifact@v4
               with:

--- a/packages/nudge/tests/it/install_script.rs
+++ b/packages/nudge/tests/it/install_script.rs
@@ -103,6 +103,39 @@ fn release_workflow_builds_ort_limited_targets_without_embeddings() {
     );
 }
 
+#[test]
+fn release_workflow_checks_out_repo_before_generating_release_notes() {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("packages dir")
+        .parent()
+        .expect("repo root");
+    let workflow_path = repo_root.join(".github/workflows/release.yml");
+    let workflow = fs::read_to_string(&workflow_path).expect("read release workflow");
+    let release_job = release_job(&workflow).expect("release job");
+
+    let checkout = release_job
+        .find("- uses: actions/checkout@v4")
+        .expect("release job should checkout the repository");
+    let generated_notes = release_job
+        .find("--generate-notes")
+        .expect("release job should create generated notes");
+
+    assert!(
+        checkout < generated_notes,
+        "gh release create --generate-notes needs a git checkout before release creation"
+    );
+    assert!(
+        release_job[checkout..generated_notes].contains("fetch-depth: 0"),
+        "generated notes should have full git history available"
+    );
+}
+
+fn release_job(workflow: &str) -> Option<&str> {
+    let start = workflow.find("\n    release:\n")? + 1;
+    Some(&workflow[start..])
+}
+
 fn target_embeddings(workflow: &str, target: &str) -> Option<bool> {
     let start = workflow.find(&format!("- target: {target}"))?;
     let rest = &workflow[start..];


### PR DESCRIPTION
**Why this change**

- Tag-triggered releases build, sign, notarize, package, and upload artifacts before the publish job creates the GitHub Release.
- The `v0.4.1` tag run reached that publish job successfully, then failed at `gh release create --generate-notes` with `fatal: not a git repository`.
- The release job downloaded artifacts into a fresh runner workspace but never checked out the repository, so GitHub CLI could not inspect git metadata while generating release notes.
- This adds a full-history checkout to the publish-only release job before release creation, preserving the existing artifact flow while making generated notes work on future tags.
- A static regression test now asserts that the release job checks out the repository with `fetch-depth: 0` before invoking `--generate-notes`.

**Testing steps performed**

```text
actionlint
# no output

cargo fmt --all -- --check
# exit 0; rustfmt emitted the existing stable-channel wrap_comments warnings

cargo test -p nudge --test it install_script
running 4 tests
test install_script::release_workflow_checks_out_repo_before_generating_release_notes ... ok
test install_script::shell_installer_keeps_musl_release_artifacts_available ... ok
test install_script::powershell_installer_fails_closed_when_checksum_verification_is_unavailable ... ok
test install_script::release_workflow_builds_ort_limited_targets_without_embeddings ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 139 filtered out

cargo run -p nudge -- check .github/workflows/release.yml packages/nudge/tests/it/install_script.rs
✓ Checked 1 files against 7 rules
  - .nudge.yaml: 7 rules
```

Generated with [Codex](https://openai.com/codex)
