### PR TITLE
Document learn memory intent

### DIFF
--- a/.agents/skills/nudge-learnings/SKILL.md
+++ b/.agents/skills/nudge-learnings/SKILL.md
@@ -7,9 +7,11 @@ description: Use during repo debugging to search `.nudge/learned` before investi
 
 ## Purpose
 
-Nudge learnings are repo-local debugging memory. Use this skill proactively
-when a repo-specific failure might already have a recorded fix, and after
-solving a durable repo-specific issue that future agents should not rediscover.
+Nudge learnings are repo-local debugging memory, not broad agent memory. They
+live in Git with the repo, so each branch or worktree only sees the notes present
+in that checkout. Use this skill proactively when a repo-specific failure might
+already have a recorded fix, and after solving a durable repo-specific issue
+that future agents should not rediscover.
 
 ## When to use
 
@@ -19,8 +21,8 @@ solving a durable repo-specific issue that future agents should not rediscover.
 - The user asks to search, list, record, or update Nudge learnings.
 - You fixed a repo-specific issue that another agent could plausibly hit again.
 
-Do not record generic programming advice, secrets, credentials, or one-off
-observations that are unlikely to recur.
+Do not record generic programming advice, broad personal preferences, secrets,
+credentials, or one-off observations that are unlikely to recur.
 
 ## Workflow
 

--- a/.agents/skills/nudge-learnings/references/learnings.md
+++ b/.agents/skills/nudge-learnings/references/learnings.md
@@ -7,6 +7,13 @@ bug that future agents should not rediscover.
 Learned notes live in `.nudge/learned/*.md`. They are repo memory from previous
 debugging sessions, not generic advice.
 
+This is intentionally narrower than built-in agent memory. Built-in agent memory
+can help with broad user preferences, but it can also activate across unrelated
+repos, branches, or worktrees. Nudge learnings are checked into Git, so a note
+from an unmerged branch is absent from another checkout. They are also shaped as
+problem, fix, and verification, which gives retrieval concrete symptoms to match
+instead of broad project affinity.
+
 ## Choose Retrieval Guide
 
 1. Run `nudge learn embeddings status`, or inspect `.nudge.yaml` / `.nudge.yml`
@@ -41,7 +48,8 @@ spent time there.
 ## Recording A Learning
 
 Record a note after fixing a repo-specific issue another agent could plausibly
-hit again. Use this structure:
+hit again. The note should describe a recurring incident, not a broad project
+journal entry. Use this structure:
 
 ```markdown
 # Short specific title

--- a/README.md
+++ b/README.md
@@ -121,6 +121,18 @@ files under `.nudge/`. Learned notes are plain Markdown files under
 Rules are best for deterministic conventions. Learned notes are for incidents:
 what went wrong, how it was fixed, and how the fix was verified.
 
+This is intentionally narrower than built-in agent memory. Built-in Claude or
+Codex memory can be useful for broad personal preferences, but it can also
+follow an agent across repos, branches, or worktrees before the
+checked-out code supports the remembered fact. `nudge learn` stores Markdown
+notes in Git, so each checkout only sees the learnings present with that code. A
+note added on an unmerged branch does not appear in another worktree.
+
+The incident shape matters too. Notes are written as problem, fix, and
+verification instead of "anything about this project", which gives retrieval
+concrete symptoms and commands to match. That keeps learned context quieter and
+less likely to pollute unrelated tasks.
+
 ```bash
 nudge learn add --title "Expo Metro resolver cache" --body "What went wrong: Expo could not resolve modules after a dependency update.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -21,6 +21,18 @@ Learned incident notes are repo-local debugging memory. Use them for "we saw
 this failure before, here is what happened, here is the fix, and here is how we
 verified it". Notes live as plain Markdown under `.nudge/learned/*.md`.
 
+Learned incident notes are deliberately narrower than built-in agent memory.
+Built-in Claude or Codex memory is useful for facts that should follow you
+everywhere, but it can activate in the wrong repo, branch, or worktree. Nudge
+learnings live in Git with the code, so a checkout only sees the notes present in
+that checkout. If a learning was added on a branch that has not merged, another
+worktree will not see it.
+
+The note format is also part of the design. A learning should name a concrete
+problem, the fix, and the verification, not every interesting fact about a
+project. That focused shape gives retrieval sharper terms and keeps unrelated
+sessions from receiving stale context.
+
 When a match happens, Nudge can:
 
 - Interrupt a risky or convention-breaking tool call before it runs.
@@ -235,6 +247,15 @@ nudge codex skills install
 ## Learned Incident Notes
 
 Record a learning when a debugging session produces knowledge worth reusing.
+Use `learn` for repo-specific incidents whose truth should move with the code
+history: failing commands, local setup traps, dependency quirks, build
+surprises, or toolchain behavior that another agent could hit again.
+
+Do not use learned notes as a broad project journal. If the information is a
+personal preference that should apply everywhere, built-in agent memory or an
+agent profile may be the better home. If the information only makes sense for
+this repo, and especially for this version of this repo, put it under
+`.nudge/learned` so Git controls when agents can see it.
 
 ```bash
 nudge learn add --title "Expo Metro resolver cache" --body "What went wrong: Expo could not resolve modules after a dependency update.

--- a/packages/nudge/skills/nudge-learnings/SKILL.md
+++ b/packages/nudge/skills/nudge-learnings/SKILL.md
@@ -7,9 +7,11 @@ description: Use during repo debugging to search `.nudge/learned` before investi
 
 ## Purpose
 
-Nudge learnings are repo-local debugging memory. Use this skill proactively
-when a repo-specific failure might already have a recorded fix, and after
-solving a durable repo-specific issue that future agents should not rediscover.
+Nudge learnings are repo-local debugging memory, not broad agent memory. They
+live in Git with the repo, so each branch or worktree only sees the notes present
+in that checkout. Use this skill proactively when a repo-specific failure might
+already have a recorded fix, and after solving a durable repo-specific issue
+that future agents should not rediscover.
 
 ## When to use
 
@@ -19,8 +21,8 @@ solving a durable repo-specific issue that future agents should not rediscover.
 - The user asks to search, list, record, or update Nudge learnings.
 - You fixed a repo-specific issue that another agent could plausibly hit again.
 
-Do not record generic programming advice, secrets, credentials, or one-off
-observations that are unlikely to recur.
+Do not record generic programming advice, broad personal preferences, secrets,
+credentials, or one-off observations that are unlikely to recur.
 
 ## Workflow
 

--- a/packages/nudge/skills/nudge-learnings/references/learnings.md
+++ b/packages/nudge/skills/nudge-learnings/references/learnings.md
@@ -7,6 +7,13 @@ bug that future agents should not rediscover.
 Learned notes live in `.nudge/learned/*.md`. They are repo memory from previous
 debugging sessions, not generic advice.
 
+This is intentionally narrower than built-in agent memory. Built-in agent memory
+can help with broad user preferences, but it can also activate across unrelated
+repos, branches, or worktrees. Nudge learnings are checked into Git, so a note
+from an unmerged branch is absent from another checkout. They are also shaped as
+problem, fix, and verification, which gives retrieval concrete symptoms to match
+instead of broad project affinity.
+
 ## Choose Retrieval Guide
 
 1. Run `nudge learn embeddings status`, or inspect `.nudge.yaml` / `.nudge.yml`
@@ -41,7 +48,8 @@ spent time there.
 ## Recording A Learning
 
 Record a note after fixing a repo-specific issue another agent could plausibly
-hit again. Use this structure:
+hit again. The note should describe a recurring incident, not a broad project
+journal entry. Use this structure:
 
 ```markdown
 # Short specific title


### PR DESCRIPTION
## Why this change

- Nudge recently added the `learn` subcommand, but the docs did not clearly explain why a user would choose it instead of built-in Claude or Codex memory.
- Built-in agent memory can be useful for broad personal preferences, but it can also activate across the wrong repository, branch, or worktree. That can confuse an agent when remembered context does not match the checked-out code.
- `nudge learn` is intentionally narrower: learned notes are Markdown files checked into Git, so each checkout only sees the learnings present with that code. A note from an unmerged branch does not appear in another worktree.
- The docs now also explain the incident-shaped contract: learnings should describe a concrete problem, fix, and verification rather than act as a broad project journal. That shape gives retrieval sharper terms and keeps unrelated tasks from receiving stale context.
- This affects human-facing docs and the bundled agent-facing `nudge-learnings` skill so users and agents get the same framing.

## Testing steps performed

```bash
cargo test -p nudge
```

```text
test result: ok. 111 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.22s

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

test result: ok. 146 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.53s

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

```bash
git diff --check
```

```text
(no output)
```

Generated with [Codex](https://openai.com/codex)