### PR TITLE
Support exclusion globs in file matchers

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -203,6 +203,19 @@ rules:
                 (#eq? @method "unwrap"))
 ```
 
+Use an ordered `file` list to exclude generated or vendored files from one
+rule without hiding them from other tools:
+
+```yaml
+file:
+  - "**/*.rs"
+  - "!**/*.gen.rs"
+```
+
+The same exclusions apply when the rule runs through live Write and Edit
+hooks. A list must contain at least one positive pattern, and the last matching
+pattern wins.
+
 For deterministic command rewrites, keep using `action: substitute` in hook
 mode. Pair it with a separate file-based block rule only when there is a real
 file-state invariant that CI can verify.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -165,6 +165,21 @@ local setup, hook responses, and learned incident notes.
 
 Copyable starter rules live in `examples/rules/`.
 
+### Exclude Files From One Rule
+
+`file` accepts one glob or an ordered list. In a list, patterns prefixed with
+`!` exclude matching paths. Later patterns override earlier ones, so a later
+positive pattern can include a path again.
+
+```yaml
+file:
+  - "**/*.ts"
+  - "!**/*.gen.ts"
+```
+
+This exclusion applies to live Write and Edit hooks and to `nudge check`. The
+list must contain at least one positive pattern.
+
 ## Use Nudge
 
 Use your agent normally. Nudge runs through hooks.

--- a/packages/nudge/skills/nudge/references/ci.md
+++ b/packages/nudge/skills/nudge/references/ci.md
@@ -120,6 +120,18 @@ rules:
                 (#eq? @method "unwrap"))
 ```
 
+Use an ordered `file` list to exclude generated or vendored files from one
+rule:
+
+```yaml
+file:
+  - "**/*.rs"
+  - "!**/*.gen.rs"
+```
+
+The same exclusions apply to live Write and Edit hooks. A list must contain at
+least one positive pattern, and the last matching pattern wins.
+
 ## Validation
 
 After adding or changing a CI gate:

--- a/packages/nudge/skills/nudge/references/rule-writing.md
+++ b/packages/nudge/skills/nudge/references/rule-writing.md
@@ -73,6 +73,21 @@ Important defaults:
 - `on` is a list; any matcher can trigger the rule.
 - `target` defaults to raw file content with `kind: Content`.
 
+## File Patterns
+
+`file` accepts one glob or an ordered list. In a list, patterns prefixed with
+`!` exclude matching paths. The last matching pattern wins, which permits a
+later positive pattern to include a path again.
+
+```yaml
+file:
+  - "**/*.ts"
+  - "!**/*.gen.ts"
+```
+
+The list must contain at least one positive pattern. Exclusions apply in live
+Write and Edit hooks and in `nudge check`.
+
 ## Hooks And Tools
 
 Use `PreToolUse` when matching an attempted operation:

--- a/packages/nudge/src/rules/schema.rs
+++ b/packages/nudge/src/rules/schema.rs
@@ -269,7 +269,8 @@ pub struct PreToolUseWriteMatcher {
     hook: MustBe!("PreToolUse"),
     tool: MustBe!("Write"),
 
-    /// Glob pattern for files to match.
+    /// Glob pattern or ordered include and exclusion patterns for files to
+    /// match.
     ///
     /// When the path of the file being written to by the agent matches this
     /// pattern, the rule is triggered.
@@ -296,7 +297,8 @@ pub struct PreToolUseEditMatcher {
     hook: MustBe!("PreToolUse"),
     tool: MustBe!("Edit"),
 
-    /// Glob pattern for files to match.
+    /// Glob pattern or ordered include and exclusion patterns for files to
+    /// match.
     ///
     /// When the path of the file being edited by the agent matches this
     /// pattern, the rule is triggered.

--- a/packages/nudge/src/rules/schema/path.rs
+++ b/packages/nudge/src/rules/schema/path.rs
@@ -1,30 +1,116 @@
-use std::{path::Path, sync::LazyLock};
+use std::{fmt, path::Path, sync::LazyLock};
 
-use derive_more::Display;
 use glob::Pattern;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, ser::SerializeSeq};
 
-/// Match on a glob pattern.
-#[derive(Debug, Clone, Display)]
-#[display("{_0}")]
-pub struct GlobMatcher(Pattern);
+/// Match paths against ordered include and exclusion glob patterns.
+#[derive(Debug, Clone)]
+pub struct GlobMatcher(Vec<PathPattern>);
+
+#[derive(Debug, Clone)]
+struct PathPattern {
+    pattern: Pattern,
+    effect: PatternEffect,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PatternEffect {
+    Include,
+    Exclude,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RawGlobMatcher {
+    One(String),
+    Many(Vec<String>),
+}
 
 impl GlobMatcher {
     /// Create an instance that matches any string.
     pub fn any() -> Self {
         static ANY: LazyLock<Pattern> =
             LazyLock::new(|| Pattern::new("**/*").expect("compile 'any' glob pattern"));
-        GlobMatcher(ANY.clone())
+        GlobMatcher(vec![PathPattern {
+            pattern: ANY.clone(),
+            effect: PatternEffect::Include,
+        }])
     }
 
-    /// Test whether this pattern matches a given string.
+    /// Test whether these patterns match a given string.
     pub fn is_match(&self, path: &str) -> bool {
-        self.0.matches(path)
+        self.matches_with(|pattern| pattern.matches(path))
     }
 
-    /// Test whether this pattern matches the given path.
+    /// Test whether these patterns match the given path.
     pub fn is_match_path(&self, path: &Path) -> bool {
-        self.0.matches_path(path)
+        self.matches_with(|pattern| pattern.matches_path(path))
+    }
+
+    fn matches_with(&self, matches: impl Fn(&Pattern) -> bool) -> bool {
+        self.0
+            .iter()
+            .rev()
+            .find(|entry| matches(&entry.pattern))
+            .is_some_and(|entry| entry.effect == PatternEffect::Include)
+    }
+
+    fn parse_one(raw: String) -> Result<Self, glob::PatternError> {
+        Pattern::new(&raw).map(|pattern| {
+            Self(vec![PathPattern {
+                pattern,
+                effect: PatternEffect::Include,
+            }])
+        })
+    }
+
+    fn parse_many(raw_patterns: Vec<String>) -> Result<Self, String> {
+        if raw_patterns.is_empty() {
+            return Err(String::from("path glob list must not be empty"));
+        }
+
+        let patterns = raw_patterns
+            .into_iter()
+            .map(|raw| {
+                let (effect, pattern) = match raw.strip_prefix('!') {
+                    Some("") => {
+                        return Err(String::from("path glob exclusion must include a pattern"));
+                    }
+                    Some(pattern) => (PatternEffect::Exclude, pattern),
+                    None => (PatternEffect::Include, raw.as_str()),
+                };
+
+                Pattern::new(pattern)
+                    .map(|pattern| PathPattern { pattern, effect })
+                    .map_err(|error| error.to_string())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        if !patterns
+            .iter()
+            .any(|entry| entry.effect == PatternEffect::Include)
+        {
+            return Err(String::from(
+                "path glob list must contain at least one positive pattern",
+            ));
+        }
+
+        Ok(Self(patterns))
+    }
+}
+
+impl fmt::Display for GlobMatcher {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (index, entry) in self.0.iter().enumerate() {
+            if index > 0 {
+                formatter.write_str(", ")?;
+            }
+            if entry.effect == PatternEffect::Exclude {
+                formatter.write_str("!")?;
+            }
+            entry.pattern.fmt(formatter)?;
+        }
+        Ok(())
     }
 }
 
@@ -39,10 +125,10 @@ impl<'de> Deserialize<'de> for GlobMatcher {
     where
         D: Deserializer<'de>,
     {
-        let s = String::deserialize(deserializer)?;
-        Pattern::new(&s)
-            .map(GlobMatcher)
-            .map_err(serde::de::Error::custom)
+        match RawGlobMatcher::deserialize(deserializer)? {
+            RawGlobMatcher::One(raw) => Self::parse_one(raw).map_err(serde::de::Error::custom),
+            RawGlobMatcher::Many(raw) => Self::parse_many(raw).map_err(serde::de::Error::custom),
+        }
     }
 }
 
@@ -51,6 +137,24 @@ impl Serialize for GlobMatcher {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.0.to_string())
+        if let [entry] = self.0.as_slice()
+            && entry.effect == PatternEffect::Include
+        {
+            return serializer.serialize_str(&entry.pattern.to_string());
+        }
+
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for entry in &self.0 {
+            let pattern = entry.pattern.to_string();
+            if entry.effect == PatternEffect::Exclude {
+                sequence.serialize_element(&format_args!("!{pattern}"))?;
+            } else {
+                sequence.serialize_element(&pattern)?;
+            }
+        }
+        sequence.end()
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/packages/nudge/src/rules/schema/path/tests.rs
+++ b/packages/nudge/src/rules/schema/path/tests.rs
@@ -1,0 +1,106 @@
+use std::path::Path;
+
+use pretty_assertions::assert_eq as pretty_assert_eq;
+
+use super::GlobMatcher;
+
+#[test]
+fn scalar_glob_preserves_literal_leading_bang() {
+    let matcher = serde_yaml::from_str::<GlobMatcher>("'!important.ts'").expect("valid glob");
+
+    assert!(matcher.is_match("!important.ts"));
+    assert!(!matcher.is_match("important.ts"));
+}
+
+#[test]
+fn ordered_patterns_exclude_and_reinclude_paths() {
+    let matcher = serde_yaml::from_str::<GlobMatcher>(
+        r#"
+            - "**/*.ts"
+            - "!**/*.gen.ts"
+            - "src/kept.gen.ts"
+        "#,
+    )
+    .expect("valid ordered globs");
+
+    assert!(matcher.is_match_path(Path::new("src/main.ts")));
+    assert!(matcher.is_match_path(Path::new("/repo/src/main.ts")));
+    assert!(!matcher.is_match_path(Path::new("src/routeTree.gen.ts")));
+    assert!(!matcher.is_match_path(Path::new("/repo/src/routeTree.gen.ts")));
+    assert!(matcher.is_match_path(Path::new("src/kept.gen.ts")));
+    assert!(!matcher.is_match_path(Path::new("src/main.js")));
+}
+
+#[test]
+fn later_positive_pattern_overrides_earlier_exclusion() {
+    let matcher = serde_yaml::from_str::<GlobMatcher>(
+        r#"
+            - "!vendor/**"
+            - "**/*.ts"
+        "#,
+    )
+    .expect("valid ordered globs");
+
+    assert!(matcher.is_match_path(Path::new("vendor/main.ts")));
+}
+
+#[test]
+fn empty_and_all_negative_lists_are_rejected() {
+    let empty = serde_yaml::from_str::<GlobMatcher>("[]").expect_err("empty list must fail");
+    let all_negative = serde_yaml::from_str::<GlobMatcher>(
+        r#"
+            - "!**/*.gen.ts"
+        "#,
+    )
+    .expect_err("all-negative list must fail");
+    let bare_exclusion =
+        serde_yaml::from_str::<GlobMatcher>("- '!' ").expect_err("bare exclusion must fail");
+
+    assert!(empty.to_string().contains("must not be empty"));
+    assert!(
+        all_negative
+            .to_string()
+            .contains("must contain at least one positive pattern")
+    );
+    assert!(
+        bare_exclusion
+            .to_string()
+            .contains("exclusion must include a pattern")
+    );
+}
+
+#[test]
+fn invalid_patterns_are_rejected() {
+    let scalar = serde_yaml::from_str::<GlobMatcher>("'['").expect_err("invalid scalar must fail");
+    let list = serde_yaml::from_str::<GlobMatcher>(
+        r#"
+            - "**/*.ts"
+            - "!["
+        "#,
+    )
+    .expect_err("invalid exclusion must fail");
+
+    assert!(scalar.to_string().contains("Pattern syntax error"));
+    assert!(list.to_string().contains("Pattern syntax error"));
+}
+
+#[test]
+fn serialization_keeps_scalars_and_ordered_lists() {
+    let scalar = serde_yaml::from_str::<GlobMatcher>("'**/*.rs'").expect("valid scalar glob");
+    let list = serde_yaml::from_str::<GlobMatcher>(
+        r#"
+            - "**/*.ts"
+            - "!**/*.gen.ts"
+        "#,
+    )
+    .expect("valid glob list");
+
+    pretty_assert_eq!(
+        serde_yaml::to_string(&scalar).expect("serialize scalar"),
+        "'**/*.rs'\n"
+    );
+    pretty_assert_eq!(
+        serde_yaml::to_string(&list).expect("serialize list"),
+        "- '**/*.ts'\n- '!**/*.gen.ts'\n"
+    );
+}

--- a/packages/nudge/tests/it/main.rs
+++ b/packages/nudge/tests/it/main.rs
@@ -19,6 +19,7 @@ mod markdown_target;
 mod message_content;
 mod multiple_rules;
 mod non_rust_files;
+mod path_exclusions;
 mod setup;
 mod skills;
 mod syntax_tree;

--- a/packages/nudge/tests/it/path_exclusions.rs
+++ b/packages/nudge/tests/it/path_exclusions.rs
@@ -1,0 +1,123 @@
+//! Integration tests for ordered file include and exclusion globs.
+
+use std::fs;
+use std::io::Write as _;
+use std::process::{Command, Stdio};
+
+use pretty_assertions::assert_eq as pretty_assert_eq;
+use tempfile::TempDir;
+
+use crate::{edit_hook, nudge_binary, write_hook};
+
+const CONFIG: &str = r#"
+version: 1
+rules:
+  - name: no-any
+    message: "Remove the explicit any."
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file:
+          - "**/*.ts"
+          - "!**/*.gen.ts"
+        content:
+          - kind: Regex
+            pattern: "as any"
+      - hook: PreToolUse
+        tool: Edit
+        file:
+          - "**/*.ts"
+          - "!**/*.gen.ts"
+        new_content:
+          - kind: Regex
+            pattern: "as any"
+"#;
+
+#[test]
+fn hooks_skip_excluded_write_and_edit_paths() {
+    let dir = configured_project();
+
+    for input in [
+        write_hook("src/routeTree.gen.ts", "value as any"),
+        edit_hook("src/routeTree.gen.ts", "value", "value as any"),
+    ] {
+        let (exit_code, output) = run_nudge(&dir, &["claude", "hook"], Some(&input));
+        pretty_assert_eq!(exit_code, 0, "excluded hook should pass: {output}");
+        assert!(
+            output.is_empty(),
+            "excluded hook should be silent: {output}"
+        );
+    }
+
+    for input in [
+        write_hook("src/main.ts", "value as any"),
+        edit_hook("src/main.ts", "value", "value as any"),
+    ] {
+        let (exit_code, output) = run_nudge(&dir, &["claude", "hook"], Some(&input));
+        pretty_assert_eq!(
+            exit_code,
+            0,
+            "matching hook should return a decision: {output}"
+        );
+        assert!(
+            output.contains(r#""permissionDecision":"deny""#),
+            "matching hook should interrupt: {output}"
+        );
+    }
+}
+
+#[test]
+fn check_skips_excluded_files_per_rule() {
+    let dir = configured_project();
+    fs::create_dir_all(dir.path().join("src")).expect("create source directory");
+    fs::write(dir.path().join("src/main.ts"), "value as any\n").expect("write checked file");
+    fs::write(
+        dir.path().join("src/routeTree.gen.ts"),
+        "generated as any\n",
+    )
+    .expect("write excluded file");
+
+    let (exit_code, output) = run_nudge(&dir, &["check"], None);
+
+    pretty_assert_eq!(
+        exit_code,
+        1,
+        "included violation should fail check: {output}"
+    );
+    assert!(output.contains("src\\main.ts") || output.contains("src/main.ts"));
+    assert!(
+        !output.contains("routeTree.gen.ts"),
+        "excluded file was checked: {output}"
+    );
+}
+
+fn configured_project() -> TempDir {
+    let dir = TempDir::new().expect("create temp directory");
+    fs::write(dir.path().join(".nudge.yaml"), CONFIG).expect("write Nudge config");
+    dir
+}
+
+fn run_nudge(dir: &TempDir, args: &[&str], stdin: Option<&str>) -> (i32, String) {
+    let mut child = Command::new(nudge_binary())
+        .args(args)
+        .current_dir(dir.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("run nudge");
+
+    if let Some(stdin) = stdin {
+        child
+            .stdin
+            .as_mut()
+            .expect("open stdin")
+            .write_all(stdin.as_bytes())
+            .expect("write stdin");
+    }
+
+    let output = child.wait_with_output().expect("wait for nudge");
+    let mut combined = String::from_utf8_lossy(&output.stdout).to_string();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    (output.status.code().unwrap_or(-1), combined)
+}


### PR DESCRIPTION
## Why this change

Fixes #67.

File-scoped rules currently apply to every path matched by one positive glob. Generated and vendored files can contain constructs that are invalid for handwritten code, forcing users to hide those files from every ignore-aware tool or accept false hook interruptions.

## What changed

- Accept a scalar glob or an ordered glob list in Write and Edit `file` matchers.
- Treat list entries prefixed with `!` as exclusions, with the last matching pattern winning.
- Reject empty and all-negative lists while preserving existing scalar behavior.
- Apply the same matcher to live hooks and `nudge check`.
- Document exclusions in the user guides and bundled Nudge skill references.

## Testing

- `cargo +nightly fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --all-targets`
- `cargo run -q -p nudge --no-default-features -- validate`
- `cargo run -q -p nudge --no-default-features -- check <changed paths>`
- `cargo test -p nudge --test it path_exclusions`
- `cargo test --all-features -- --test-threads=1 --skip release_workflow_checks_out_repo_before_generating_release_notes` (268 passed)

The excluded test is an existing Windows-only line-ending failure: it searches the CRLF checkout of `.github/workflows/release.yml` for an LF-only job marker. CI runs the complete suite on Linux.

Co-authored-by: Codex <noreply@openai.com>