### PR TITLE
Remove Apple release signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,7 @@
 #
 # Triggered on pull requests, main pushes, manual dry runs, and version tags
 # (v*). Builds binaries for all supported platforms in parallel on native
-# runners. Tag builds additionally sign/notarize macOS binaries and create a
-# draft GitHub Release.
+# runners. Tag builds additionally create a draft GitHub Release.
 #
 # The release is created as a draft so it can be reviewed and published
 # manually when ready.
@@ -216,60 +215,6 @@ jobs:
                     args+=(--no-default-features)
                   fi
                   cargo "${args[@]}"
-
-            - name: Import signing certificate
-              if: needs.prepare.outputs.publish == 'true' && runner.os == 'macOS'
-              env:
-                  APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
-                  APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-              run: |
-                  echo -n "$APPLE_CERTIFICATE_BASE64" | base64 --decode -o "$RUNNER_TEMP/certificate.p12"
-                  security create-keychain -p "$APPLE_CERTIFICATE_PASSWORD" "$RUNNER_TEMP/build.keychain"
-                  security default-keychain -s "$RUNNER_TEMP/build.keychain"
-                  security unlock-keychain -p "$APPLE_CERTIFICATE_PASSWORD" "$RUNNER_TEMP/build.keychain"
-                  security import "$RUNNER_TEMP/certificate.p12" -k "$RUNNER_TEMP/build.keychain" -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
-                  security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$APPLE_CERTIFICATE_PASSWORD" "$RUNNER_TEMP/build.keychain"
-                  rm "$RUNNER_TEMP/certificate.p12"
-
-            - name: Sign macOS binary
-              if: needs.prepare.outputs.publish == 'true' && runner.os == 'macOS'
-              env:
-                  APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-                  TARGET: ${{ matrix.target }}
-              run: |
-                  BINARY="target/${TARGET}/release/nudge"
-                  codesign --sign "$APPLE_TEAM_ID" \
-                           --timestamp \
-                           --options=runtime \
-                           --force \
-                           "$BINARY"
-
-            - name: Store notarization credentials
-              if: needs.prepare.outputs.publish == 'true' && runner.os == 'macOS'
-              env:
-                  APPLE_ID: ${{ secrets.APPLE_ID }}
-                  APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-                  APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-              run: |
-                  xcrun notarytool store-credentials "notarytool-password" \
-                          --apple-id "$APPLE_ID" \
-                          --team-id "$APPLE_TEAM_ID" \
-                          --password "$APPLE_APP_SPECIFIC_PASSWORD"
-
-            - name: Submit for notarization
-              if: needs.prepare.outputs.publish == 'true' && runner.os == 'macOS'
-              env:
-                  TARGET: ${{ matrix.target }}
-              run: |
-                  BINARY="target/${TARGET}/release/nudge"
-                  zip "$RUNNER_TEMP/nudge-macos.zip" "$BINARY"
-                  xcrun notarytool submit "$RUNNER_TEMP/nudge-macos.zip" \
-                          --keychain-profile "notarytool-password" \
-                          --wait
-
-            - name: Cleanup keychain
-              if: needs.prepare.outputs.publish == 'true' && runner.os == 'macOS' && always()
-              run: security delete-keychain "$RUNNER_TEMP/build.keychain" || true
 
             - name: Package binary
               id: package

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -97,7 +97,7 @@ actionlint
 
 The GitHub `Release` workflow runs as a dry-run matrix on pull requests,
 merge-queue checks, and pushes to `main`. Tag builds use the same matrix and
-cache keys, then sign/notarize macOS binaries and create the draft release.
+cache keys, then create the draft release.
 Supported release targets are macOS, Linux, and Windows x64. Targets whose ONNX
 Runtime artifacts are unavailable or do not link in the release cross-toolchain
 build with `--no-default-features`, which keeps BM25 learned-note search and

--- a/packages/nudge/tests/it/install_script.rs
+++ b/packages/nudge/tests/it/install_script.rs
@@ -54,13 +54,7 @@ fn shell_installer_keeps_musl_release_artifacts_available() {
 
 #[test]
 fn release_workflow_builds_ort_limited_targets_without_embeddings() {
-    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("packages dir")
-        .parent()
-        .expect("repo root");
-    let workflow_path = repo_root.join(".github/workflows/release.yml");
-    let workflow = fs::read_to_string(&workflow_path).expect("read release workflow");
+    let workflow = read_release_workflow();
 
     pretty_assert_eq!(
         target_embeddings(&workflow, "x86_64-apple-darwin"),
@@ -105,13 +99,7 @@ fn release_workflow_builds_ort_limited_targets_without_embeddings() {
 
 #[test]
 fn release_workflow_checks_out_repo_before_generating_release_notes() {
-    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("packages dir")
-        .parent()
-        .expect("repo root");
-    let workflow_path = repo_root.join(".github/workflows/release.yml");
-    let workflow = fs::read_to_string(&workflow_path).expect("read release workflow");
+    let workflow = read_release_workflow();
     let release_job = release_job(&workflow).expect("release job");
 
     let checkout = release_job
@@ -129,6 +117,19 @@ fn release_workflow_checks_out_repo_before_generating_release_notes() {
         release_job[checkout..generated_notes].contains("fetch-depth: 0"),
         "generated notes should have full git history available"
     );
+}
+
+fn read_release_workflow() -> String {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("packages dir")
+        .parent()
+        .expect("repo root");
+    let workflow_path = repo_root.join(".github/workflows/release.yml");
+
+    fs::read_to_string(&workflow_path)
+        .expect("read release workflow")
+        .replace("\r\n", "\n")
 }
 
 fn release_job(workflow: &str) -> Option<&str> {


### PR DESCRIPTION
## Why this change

The release workflow should build and publish the existing macOS artifacts without the Apple certificate and notarization credential pipeline.

## What changed

- Removed certificate import, code signing, notarization submission, keychain cleanup, and Apple secret references from the release workflow.
- Kept both macOS targets in the existing build, package, and upload matrix.
- Updated the release documentation and made workflow tests portable across CRLF checkouts.

## Testing

- `cargo +nightly fmt --all --check` passed.
- `cargo clippy --all-targets --all-features -- -D warnings` passed.
- `cargo build --all-targets` passed.
- `cargo test --all-features -- --test-threads=1` passed: 268 unit and integration tests plus 1 doctest.
- `cargo build -p nudge --release` passed.
- `cargo build -p nudge --no-default-features --release` passed.
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release.yml` passed.
- `cargo run -q -p nudge -- validate` passed.
- `cargo run -q -p nudge -- check .github/workflows/release.yml docs/developer-guide.md packages/nudge/tests/it/install_script.rs` passed.

Co-authored-by: Codex <noreply@openai.com>